### PR TITLE
Multiple docker compose file

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,19 @@ steps:
         config: docker-compose.tests.yml
 ```
 
+or multiple config files:
+
+```yml
+steps:
+  - command: test.sh
+    plugins:
+      docker-compose:
+        run: app
+        config:
+          - docker-compose.yml
+          - docker-compose.test.yml
+```
+
 # Pre-building the image
 
 To speed up run parallel steps you can add a pre-building step to your pipeline, allowing all the `run` steps to skip image building:
@@ -88,7 +101,7 @@ The name of the service the command should be run within. If the docker-compose 
 
 ### `config` (optional)
 
-The file name of the Docker Compose configuration file to use.
+The file name of the Docker Compose configuration file to use. Can also be a list of filenames.
 
 Default: `docker-compose.yml`
 

--- a/hooks/command
+++ b/hooks/command
@@ -55,6 +55,8 @@ function run_docker_compose() {
   local command=(docker-compose)
 
   # Append potentially multiple docker compose file
+  declare file
+  declare -a files
   IFS=":" read -ra files <<< "$(docker_compose_config_file)"
   for file in "${files[@]}"; do
     command+=(-f "$file")

--- a/hooks/command
+++ b/hooks/command
@@ -55,12 +55,27 @@ function run_docker_compose() {
   local command=(docker-compose)
 
   # Append potentially multiple docker compose file
-  declare file
-  declare -a files
-  IFS=":" read -ra files <<< "$(docker_compose_config_file)"
-  for file in "${files[@]}"; do
-    command+=(-f "$file")
-  done
+  if [[ -n "${BUILDKITE_PLUGIN_DOCKER_COMPOSE_CONFIG_0:-}" ]]; then
+    # Plugin config specified an array of config files
+    local i=0
+    local parameter="BUILDKITE_PLUGIN_DOCKER_COMPOSE_CONFIG_${i}"
+    while [[ -n "${!parameter:-}" ]]; do
+      command+=(-f "${!parameter}")
+      i=$[$i+1]
+      parameter="BUILDKITE_PLUGIN_DOCKER_COMPOSE_CONFIG_${i}"
+    done
+  elif [[ -n "${BUILDKITE_PLUGIN_DOCKER_COMPOSE_CONFIG:-}" ]]; then
+    # Plugin config may be colon-separated files
+    declare file
+    declare -a files
+    IFS=":" read -ra files <<< "$(docker_compose_config_file)"
+    for file in "${files[@]}"; do
+      command+=(-f "$file")
+    done
+  else
+    # Use default docker compose location
+    command+=(-f "docker-compose.yml")
+  fi
 
   # Append project name
   command+=(-p "$(docker_compose_project_name)")

--- a/hooks/command
+++ b/hooks/command
@@ -34,11 +34,6 @@ function plugin_prompt_and_must_run {
   plugin_prompt_and_run "$@" || exit $?
 }
 
-# Returns the configured docker compose config file name
-function docker_compose_config_file() {
-  echo "${BUILDKITE_PLUGIN_DOCKER_COMPOSE_CONFIG:-docker-compose.yml}"
-}
-
 # Returns the name of the docker compose project for this build
 function docker_compose_project_name() {
   # No dashes or underscores because docker-compose will remove them anyways
@@ -68,7 +63,7 @@ function run_docker_compose() {
     # Plugin config may be colon-separated files
     declare file
     declare -a files
-    IFS=":" read -ra files <<< "$(docker_compose_config_file)"
+    IFS=":" read -ra files <<< "$BUILDKITE_PLUGIN_DOCKER_COMPOSE_CONFIG"
     for file in "${files[@]}"; do
       command+=(-f "$file")
     done

--- a/hooks/command
+++ b/hooks/command
@@ -54,8 +54,11 @@ function docker_compose_container_name() {
 function run_docker_compose() {
   local command=(docker-compose)
 
-  # Append docker compose file
-  command+=(-f "$(docker_compose_config_file)")
+  # Append potentially multiple docker compose file
+  IFS=":" read -ra files <<< "$(docker_compose_config_file)"
+  for file in "${files[@]}"; do
+    command+=(-f "$file")
+  done
 
   # Append project name
   command+=(-p "$(docker_compose_project_name)")


### PR DESCRIPTION
Based on #2, and a port of buildkite/agent#357, let's enable the use of multiple docker compose files separated by colons.

We should probably also figure out as a next step after this is merged how to use Buildkite plugin config arrays as input, too.