### PR TITLE
Less eval, attempt 2

### DIFF
--- a/hooks/command
+++ b/hooks/command
@@ -52,7 +52,7 @@ function docker_compose_container_name() {
 
 # Runs the docker-compose command, scoped to the project, with the given arguments
 function run_docker_compose() {
-  command=(docker-compose)
+  local command=(docker-compose)
 
   # Append docker compose file
   command+=(-f "$(docker_compose_config_file)")

--- a/hooks/command
+++ b/hooks/command
@@ -12,7 +12,7 @@ export $(env | grep "BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILDKITE_PLUGIN_" | sed "s
 ## SET UP SHARED FUNCTIONS
 
 # Show a prompt for a command
-function buildkite-prompt {
+function plugin_prompt {
   # Output "$" prefix in a pleasant grey...
   echo -ne "\033[90m$\033[0m"
 
@@ -24,13 +24,13 @@ function buildkite-prompt {
 }
 
 # Shows the command being run, and runs it
-function buildkite-prompt-and-run {
-  buildkite-prompt "$@"
+function plugin_prompt_and_run {
+  plugin_prompt "$@"
   "$@"
 }
 
 # Shows the command about to be run, and exits if it fails
-function buildkite-run {
+function plugin_prompt_and_must_run {
   buildkite-prompt-and-run "$@" || exit $?
 }
 
@@ -60,7 +60,7 @@ function run_docker_compose() {
   # Append project name
   command+=(-p "$(docker_compose_project_name)")
 
-  buildkite-run "${command[@]}" "$@"
+  plugin_prompt_and_run "${command[@]}" "$@"
 }
 
 function build_meta_data_image_tag_key() {

--- a/hooks/command
+++ b/hooks/command
@@ -6,43 +6,64 @@ set -ueo pipefail
 # environment variables into the desired BUILDKITE_PLUGIN_DOCKER_COMPOSE_
 # variables. This can be removed once we update the bootstrap for this new
 # plugin naming convention.
-eval $(env | grep "_BUILDKITE_PLUGIN_GIT_" | sed "s/_BUILDKITE_PLUGIN_GIT_/_/g" | sed 's/^/export /')
-eval $(env | grep "BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILDKITE_PLUGIN_" | sed "s/BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILDKITE_PLUGIN_/BUILDKITE_PLUGIN_DOCKER_COMPOSE_/g" | sed 's/^/export /')
+export $(env | grep "_BUILDKITE_PLUGIN_GIT_" | sed "s/_BUILDKITE_PLUGIN_GIT_/_/")
+export $(env | grep "BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILDKITE_PLUGIN_" | sed "s/BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILDKITE_PLUGIN_/BUILDKITE_PLUGIN_DOCKER_COMPOSE_/g")
 
 ## SET UP SHARED FUNCTIONS
 
-# Shows the command about to be run, and exits if it fails
-buildkite-run() {
-  echo -e "\033[90m$\033[0m $1"
-  eval "$1"
-  EVAL_EXIT_STATUS=$?
+# Show a prompt for a command
+function buildkite-prompt {
+  # Output "$" prefix in a pleasant grey...
+  echo -ne "\033[90m$\033[0m"
 
-  if [[ $EVAL_EXIT_STATUS -ne 0 ]]; then
-    exit $EVAL_EXIT_STATUS
-  fi
+  # ...each positional parameter with spaces and correct escaping for copy/pasting...
+  printf " %q" "$@"
+
+  # ...and a trailing newline.
+  echo
+}
+
+# Shows the command being run, and runs it
+function buildkite-prompt-and-run {
+  buildkite-prompt "$@"
+  "$@"
+}
+
+# Shows the command about to be run, and exits if it fails
+function buildkite-run {
+  buildkite-prompt-and-run "$@" || exit $?
+}
+
+# Returns the configured docker compose config file name
+function docker_compose_config_file() {
+  echo "${BUILDKITE_PLUGIN_DOCKER_COMPOSE_CONFIG:-docker-compose.yml}"
 }
 
 # Returns the name of the docker compose project for this build
-docker_compose_project_name() {
+function docker_compose_project_name() {
   # No dashes or underscores because docker-compose will remove them anyways
   echo "buildkite${BUILDKITE_JOB_ID//-}"
 }
 
 # Returns the name of the docker compose container that corresponds to the given service
-docker_compose_container_name() {
+function docker_compose_container_name() {
   echo "$(docker_compose_project_name)_$1"
 }
 
-docker_compose_config_file() {
-  echo "${BUILDKITE_PLUGIN_DOCKER_COMPOSE_CONFIG:-docker-compose.yml}"
-}
-
 # Runs the docker-compose command, scoped to the project, with the given arguments
-run_docker_compose() {
-  buildkite-run "docker-compose -f $(docker_compose_config_file) -p $(docker_compose_project_name) $1"
+function run_docker_compose() {
+  command=(docker-compose)
+
+  # Append docker compose file
+  command+=(-f "$(docker_compose_config_file)")
+
+  # Append project name
+  command+=(-p "$(docker_compose_project_name)")
+
+  buildkite-run "${command[@]}" "$@"
 }
 
-build_meta_data_image_tag_key() {
+function build_meta_data_image_tag_key() {
   echo "docker-compose-plugin-built-image-tag-$1"
 }
 

--- a/hooks/commands/build.sh
+++ b/hooks/commands/build.sh
@@ -17,20 +17,21 @@ image_file_name() {
 push_image_to_docker_repository() {
   local tag="$DOCKER_IMAGE_REPOSITORY:$(image_file_name)"
 
-  buildkite-run "docker tag $COMPOSE_SERVICE_DOCKER_IMAGE_NAME $tag"
-  buildkite-run "docker push $tag"
-  buildkite-run "docker rmi $tag"
+  buildkite-run docker tag "$COMPOSE_SERVICE_DOCKER_IMAGE_NAME" "$tag"
+  buildkite-run docker push "$tag"
+  buildkite-run docker rmi "$tag"
 
-  buildkite-run "buildkite-agent meta-data set \"$(build_meta_data_image_tag_key "$COMPOSE_SERVICE_NAME")\" \"$tag\""
+  buildkite-run buildkite-agent meta-data set "$(build_meta_data_image_tag_key "$COMPOSE_SERVICE_NAME")" "$tag"
 }
 
 echo "+++ :docker: Building Docker Compose images for service $COMPOSE_SERVICE_NAME"
 
-run_docker_compose "build $COMPOSE_SERVICE_NAME"
+run_docker_compose "build" "$COMPOSE_SERVICE_NAME"
 
 echo "~~~ :docker: Listing docker images"
 
-buildkite-run "docker images | grep buildkite"
+buildkite-prompt docker images
+docker images | grep buildkite
 
 if [[ ! -z "$DOCKER_IMAGE_REPOSITORY" ]]; then
   echo "~~~ :docker: Pushing image $COMPOSE_SERVICE_DOCKER_IMAGE_NAME to $DOCKER_IMAGE_REPOSITORY"

--- a/hooks/commands/build.sh
+++ b/hooks/commands/build.sh
@@ -17,20 +17,20 @@ image_file_name() {
 push_image_to_docker_repository() {
   local tag="$DOCKER_IMAGE_REPOSITORY:$(image_file_name)"
 
-  buildkite-run docker tag "$COMPOSE_SERVICE_DOCKER_IMAGE_NAME" "$tag"
-  buildkite-run docker push "$tag"
-  buildkite-run docker rmi "$tag"
+  plugin_prompt_and_must_run docker tag "$COMPOSE_SERVICE_DOCKER_IMAGE_NAME" "$tag"
+  plugin_prompt_and_must_run docker push "$tag"
+  plugin_prompt_and_must_run docker rmi "$tag"
 
-  buildkite-run buildkite-agent meta-data set "$(build_meta_data_image_tag_key "$COMPOSE_SERVICE_NAME")" "$tag"
+  plugin_prompt_and_must_run buildkite-agent meta-data set "$(build_meta_data_image_tag_key "$COMPOSE_SERVICE_NAME")" "$tag"
 }
 
 echo "+++ :docker: Building Docker Compose images for service $COMPOSE_SERVICE_NAME"
 
-run_docker_compose "build" "$COMPOSE_SERVICE_NAME"
+run_docker_compose build "$COMPOSE_SERVICE_NAME"
 
 echo "~~~ :docker: Listing docker images"
 
-buildkite-prompt docker images
+plugin_prompt docker images
 docker images | grep buildkite
 
 if [[ ! -z "$DOCKER_IMAGE_REPOSITORY" ]]; then

--- a/hooks/commands/run.sh
+++ b/hooks/commands/run.sh
@@ -14,49 +14,52 @@ check_required_args
 compose_force_cleanup() {
   echo "~~~ :docker: Cleaning up Docker containers"
 
-  if [[ "${BUILDKITE_PLUGIN_DOCKER_COMPOSE_LEAVE_VOLUMES:-false}" == "true" ]]; then
-    local remove_volume_flag=""
-  else
-    local remove_volume_flag="-v"
-  fi
-
   # Send them a friendly kill
-  run_docker_compose "kill" || true
+  run_docker_compose kill || true
 
   local docker_compose_version=$(run_docker_compose --version)
 
   if [[ "$docker_compose_version" == *1.4* || "$docker_compose_version" == *1.5* || "$docker_compose_version" == *1.6* ]]; then
     # There's no --all flag to remove adhoc containers
-    run_docker_compose "rm --force $remove_volume_flag" || true
+    if [[ "${BUILDKITE_PLUGIN_DOCKER_COMPOSE_LEAVE_VOLUMES:-false}" == "true" ]]; then
+      run_docker_compose rm --force -v || true
+    else
+      run_docker_compose rm --force || true
+    fi
 
     # So now we remove the adhoc container
     # This isn't cleaned up by compose, so we have to do it ourselves
     local adhoc_run_container_name="${COMPOSE_SERVICE_NAME}_run_1"
-    buildkite-run "docker rm -f $remove_volume_flag $(docker_compose_container_name \""$adhoc_run_container_name"\") || true"
+    plugin_prompt_and_run docker rm -f "$remove_volume_flag" "$(docker_compose_container_name "$adhoc_run_container_name")" || true
   else
     # `compose down` doesn't support force removing images, so we use `rm --force`
-    run_docker_compose "rm --force --all $remove_volume_flag" || true
+    if [[ "${BUILDKITE_PLUGIN_DOCKER_COMPOSE_LEAVE_VOLUMES:-false}" == "true" ]]; then
+      run_docker_compose rm --force --all -v || true
+    else
+      run_docker_compose rm --force --all || true
+    fi
 
     # Stop and remove all the linked services and network
-    run_docker_compose "down" || true
+    run_docker_compose down || true
   fi
 }
 
 trap compose_force_cleanup EXIT
 
 try_image_restore_from_docker_repository() {
-  local tag=$(buildkite-agent meta-data get "$(build_meta_data_image_tag_key "$COMPOSE_SERVICE_NAME")" 2>/dev/null)
+  plugin_prompt buildkite-agent meta-data get "$(build_meta_data_image_tag_key "$COMPOSE_SERVICE_NAME")"
+  local tag="$(buildkite-agent meta-data get "$(build_meta_data_image_tag_key "$COMPOSE_SERVICE_NAME")" 2>/dev/null)"
 
   if [[ ! -z "$tag" ]]; then
     echo "~~~ :docker: Pulling docker image $tag"
 
-    buildkite-run "docker pull \"$tag\""
+    plugin_prompt_and_must_run docker pull "$tag"
 
     echo "~~~ :docker: Creating a modified Docker Compose config"
 
     # TODO: Fix this el-dodgo method
     local escaped_tag_for_sed=$(echo "$tag" | sed -e 's/[\/&]/\\&/g')
-    buildkite-run "sed -i.orig \"s/build: \./image: $escaped_tag_for_sed/\" \"$(docker_compose_config_file)\""
+    plugin_prompt_and_must_run sed -i.orig "s/build: \./image: $escaped_tag_for_sed/" "$(docker_compose_config_file)"
   fi
 }
 
@@ -68,4 +71,4 @@ echo "+++ :docker: Running command in Docker Compose service: $COMPOSE_SERVICE_N
 #   docker-compose run "app" "go test"
 # does not work whereas the follow down:
 #   docker-compose run "app" go test
-run_docker_compose "run \"$COMPOSE_SERVICE_NAME\" $BUILDKITE_COMMAND"
+run_docker_compose run "$COMPOSE_SERVICE_NAME" $BUILDKITE_COMMAND


### PR DESCRIPTION
This is a retry of #2. I somehow totally missed unescaping the commands being run in the run.sh file — I suspect I fat fingered a git commit somewhere.

I've tested this a little more extensively including differrent versions of docker compose, run and build phases, with/without leaving volumes, and with buildkite commands with varying numbers of arguments.

The `$BUILDKITE_COMMAND` being unescaped is a little strange, but there's probably not much we can do...

Also:

```
$ docker-compose -f docker-compose.yml -p buildkite123abc rm --force --all -v
WARNING: --all flag is obsolete. This is now the default behavior of `docker-compose rm`
Going to remove buildkite123abc_app_run_1, buildkite123abc_redis_1, buildkite123abc_db_1
```