### PR TITLE
Allow custom tag as env variable

### DIFF
--- a/hooks/command
+++ b/hooks/command
@@ -39,12 +39,6 @@ function docker_compose_config_file() {
   echo "${BUILDKITE_PLUGIN_DOCKER_COMPOSE_CONFIG:-docker-compose.yml}"
 }
 
-# Returns the configured docker compose config exetension file name
-# https://docs.docker.com/compose/extends/
-function docker_compose_config_extend_file() {
-  echo "${BUILDKITE_PLUGIN_DOCKER_COMPOSE_EXCONFIG:-}"
-}
-
 # Returns the name of the docker compose project for this build
 function docker_compose_project_name() {
   # No dashes or underscores because docker-compose will remove them anyways
@@ -63,9 +57,10 @@ function run_docker_compose() {
   # Append docker compose file
   command+=(-f "$(docker_compose_config_file)")
 
-  # Append docker compose file
-  if [[ ! -z "${BUILDKITE_PLUGIN_DOCKER_COMPOSE_EXCONFIG:-}" ]]; then
-    command+=(-f "$(docker_compose_config_extend_file)")
+  # Append the configured docker compose config exetension file name
+  # https://docs.docker.com/compose/extends/
+  if [[ ! -z "$BUILDKITE_PLUGIN_DOCKER_COMPOSE_EXCONFIG" ]]; then
+    command+=(-f "$BUILDKITE_PLUGIN_DOCKER_COMPOSE_EXCONFIG")
   fi
 
   # Append project name

--- a/hooks/command
+++ b/hooks/command
@@ -39,6 +39,12 @@ function docker_compose_config_file() {
   echo "${BUILDKITE_PLUGIN_DOCKER_COMPOSE_CONFIG:-docker-compose.yml}"
 }
 
+# Returns the configured docker compose config exetension file name
+# https://docs.docker.com/compose/extends/
+function docker_compose_config_extend_file() {
+  echo "${-f BUILDKITE_PLUGIN_DOCKER_COMPOSE_EXCONFIG:-}"
+}
+
 # Returns the name of the docker compose project for this build
 function docker_compose_project_name() {
   # No dashes or underscores because docker-compose will remove them anyways
@@ -56,6 +62,9 @@ function run_docker_compose() {
 
   # Append docker compose file
   command+=(-f "$(docker_compose_config_file)")
+
+  # Append docker compose file
+  command+=("$(docker_compose_config_extend_file)")
 
   # Append project name
   command+=(-p "$(docker_compose_project_name)")

--- a/hooks/command
+++ b/hooks/command
@@ -59,8 +59,8 @@ function run_docker_compose() {
 
   # Append the configured docker compose config exetension file name
   # https://docs.docker.com/compose/extends/
-  if [[ ! -z "$BUILDKITE_PLUGIN_DOCKER_COMPOSE_EXCONFIG" ]]; then
-    command+=(-f "$BUILDKITE_PLUGIN_DOCKER_COMPOSE_EXCONFIG")
+  if [[ ! -z "${BUILDKITE_PLUGIN_DOCKER_COMPOSE_EXCONFIG:-}" ]]; then
+    command+=(-f "${BUILDKITE_PLUGIN_DOCKER_COMPOSE_EXCONFIG:-}")
   fi
 
   # Append project name

--- a/hooks/command
+++ b/hooks/command
@@ -67,6 +67,31 @@ function build_meta_data_image_tag_key() {
   echo "docker-compose-plugin-built-image-tag-$1"
 }
 
+# Returns a friendly image file name like "myproject-app-build-49" than can be
+# used as the docker image tag or tar.gz filename
+image_file_name() {
+  # The project slug env variable includes the org (e.g. "org/project"), so we
+  # have to strip the org from the front (e.g. "project")
+  local project_name=$(echo "$BUILDKITE_PROJECT_SLUG" | sed 's/^\([^\/]*\/\)//g')
+  # look for custom image tag string (i.e. "latest")
+  if [[ ! -z "${BUILDKITE_PLUGIN_DOCKER_COMPOSE_IMAGE_TAG:-}" ]]; then
+    echo "$BUILDKITE_PLUGIN_DOCKER_COMPOSE_IMAGE_TAG"
+  else
+    echo "$project_name-$COMPOSE_SERVICE_NAME-build-$BUILDKITE_BUILD_NUMBER"
+  fi
+}
+
+function push_image_to_docker_repository() {
+  DOCKER_IMAGE_REPOSITORY="${BUILDKITE_PLUGIN_DOCKER_COMPOSE_IMAGE_REPOSITORY:-}"
+  local tag="$DOCKER_IMAGE_REPOSITORY:$(image_file_name)"
+
+  plugin_prompt_and_must_run docker tag "$COMPOSE_SERVICE_DOCKER_IMAGE_NAME" "$tag"
+  plugin_prompt_and_must_run docker push "$tag"
+  plugin_prompt_and_must_run docker rmi "$tag"
+
+  plugin_prompt_and_must_run buildkite-agent meta-data set "$(build_meta_data_image_tag_key "$COMPOSE_SERVICE_NAME")" "$tag"
+}
+
 ## BUILD OR RUN
 
 DIR="$(cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd)"

--- a/hooks/command
+++ b/hooks/command
@@ -42,7 +42,7 @@ function docker_compose_config_file() {
 # Returns the configured docker compose config exetension file name
 # https://docs.docker.com/compose/extends/
 function docker_compose_config_extend_file() {
-  echo "${-f BUILDKITE_PLUGIN_DOCKER_COMPOSE_EXCONFIG:-}"
+  echo "${BUILDKITE_PLUGIN_DOCKER_COMPOSE_EXCONFIG:-}"
 }
 
 # Returns the name of the docker compose project for this build
@@ -64,7 +64,9 @@ function run_docker_compose() {
   command+=(-f "$(docker_compose_config_file)")
 
   # Append docker compose file
-  command+=("$(docker_compose_config_extend_file)")
+  if [[ ! -z "${BUILDKITE_PLUGIN_DOCKER_COMPOSE_EXCONFIG:-}" ]]; then
+    command+=(-f "$(docker_compose_config_extend_file)")
+  fi
 
   # Append project name
   command+=(-p "$(docker_compose_project_name)")

--- a/hooks/commands/build.sh
+++ b/hooks/commands/build.sh
@@ -10,8 +10,12 @@ image_file_name() {
   # The project slug env variable includes the org (e.g. "org/project"), so we
   # have to strip the org from the front (e.g. "project")
   local project_name=$(echo "$BUILDKITE_PROJECT_SLUG" | sed 's/^\([^\/]*\/\)//g')
-
-  echo "$project_name-$COMPOSE_SERVICE_NAME-build-$BUILDKITE_BUILD_NUMBER"
+  # look for custom image tag string (i.e. "latest")
+  if [[ ! -z "${BUILDKITE_PLUGIN_DOCKER_COMPOSE_IMAGE_TAG:-}" ]]; then
+    echo "$BUILDKITE_PLUGIN_DOCKER_COMPOSE_IMAGE_TAG"
+  else
+    echo "$project_name-$COMPOSE_SERVICE_NAME-build-$BUILDKITE_BUILD_NUMBER"
+  fi
 }
 
 push_image_to_docker_repository() {

--- a/hooks/commands/build.sh
+++ b/hooks/commands/build.sh
@@ -4,30 +4,6 @@ COMPOSE_SERVICE_NAME="$BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD"
 COMPOSE_SERVICE_DOCKER_IMAGE_NAME="$(docker_compose_container_name "$COMPOSE_SERVICE_NAME")"
 DOCKER_IMAGE_REPOSITORY="${BUILDKITE_PLUGIN_DOCKER_COMPOSE_IMAGE_REPOSITORY:-}"
 
-# Returns a friendly image file name like "myproject-app-build-49" than can be
-# used as the docker image tag or tar.gz filename
-image_file_name() {
-  # The project slug env variable includes the org (e.g. "org/project"), so we
-  # have to strip the org from the front (e.g. "project")
-  local project_name=$(echo "$BUILDKITE_PROJECT_SLUG" | sed 's/^\([^\/]*\/\)//g')
-  # look for custom image tag string (i.e. "latest")
-  if [[ ! -z "${BUILDKITE_PLUGIN_DOCKER_COMPOSE_IMAGE_TAG:-}" ]]; then
-    echo "$BUILDKITE_PLUGIN_DOCKER_COMPOSE_IMAGE_TAG"
-  else
-    echo "$project_name-$COMPOSE_SERVICE_NAME-build-$BUILDKITE_BUILD_NUMBER"
-  fi
-}
-
-push_image_to_docker_repository() {
-  local tag="$DOCKER_IMAGE_REPOSITORY:$(image_file_name)"
-
-  plugin_prompt_and_must_run docker tag "$COMPOSE_SERVICE_DOCKER_IMAGE_NAME" "$tag"
-  plugin_prompt_and_must_run docker push "$tag"
-  plugin_prompt_and_must_run docker rmi "$tag"
-
-  plugin_prompt_and_must_run buildkite-agent meta-data set "$(build_meta_data_image_tag_key "$COMPOSE_SERVICE_NAME")" "$tag"
-}
-
 echo "+++ :docker: Building Docker Compose images for service $COMPOSE_SERVICE_NAME"
 
 run_docker_compose build "$COMPOSE_SERVICE_NAME"

--- a/hooks/commands/run.sh
+++ b/hooks/commands/run.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 
 COMPOSE_SERVICE_NAME="$BUILDKITE_PLUGIN_DOCKER_COMPOSE_RUN"
+COMPOSE_SERVICE_DOCKER_IMAGE_NAME="$(docker_compose_container_name "$COMPOSE_SERVICE_NAME")"
+DOCKER_IMAGE_REPOSITORY="${BUILDKITE_PLUGIN_DOCKER_COMPOSE_IMAGE_REPOSITORY:-}"
 
 check_required_args() {
   if [[ -z "${BUILDKITE_COMMAND:-}" ]]; then
@@ -72,3 +74,9 @@ echo "+++ :docker: Running command in Docker Compose service: $COMPOSE_SERVICE_N
 # does not work whereas the follow down:
 #   docker-compose run "app" go test
 run_docker_compose run "$COMPOSE_SERVICE_NAME" $BUILDKITE_COMMAND
+
+if [[ ! -z "$DOCKER_IMAGE_REPOSITORY" ]]; then
+  echo "~~~ :docker: Pushing image $COMPOSE_SERVICE_DOCKER_IMAGE_NAME to $DOCKER_IMAGE_REPOSITORY"
+
+  push_image_to_docker_repository
+fi


### PR DESCRIPTION
For our AWS deployment our infrastructure looks for a :latest tag on ECR images - just a quick alteration to allow a tag to be specified as an env variable in pipeline.yml (BUILDKITE_PLUGIN_DOCKER_COMPOSE_IMAGE_TAG).