### PR TITLE
Add a short sha tag to pushed images

### DIFF
--- a/hooks/command
+++ b/hooks/command
@@ -67,6 +67,10 @@ function build_meta_data_image_tag_key() {
   echo "docker-compose-plugin-built-image-tag-$1"
 }
 
+function short_sha(){
+  git rev-parse --short "$BUILDKITE_COMMIT"
+}
+
 ## BUILD OR RUN
 
 DIR="$(cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd)"

--- a/hooks/commands/build.sh
+++ b/hooks/commands/build.sh
@@ -16,10 +16,14 @@ image_file_name() {
 
 push_image_to_docker_repository() {
   local tag="$DOCKER_IMAGE_REPOSITORY:$(image_file_name)"
+  local sha_tag="$DOCKER_IMAGE_REPOSITORY:$(short_sha)"
 
   plugin_prompt_and_must_run docker tag "$COMPOSE_SERVICE_DOCKER_IMAGE_NAME" "$tag"
+  plugin_prompt_and_must_run docker tag "$COMPOSE_SERVICE_DOCKER_IMAGE_NAME" "$sha_tag"
   plugin_prompt_and_must_run docker push "$tag"
+  plugin_prompt_and_must_run docker push "$sha_tag"
   plugin_prompt_and_must_run docker rmi "$tag"
+  plugin_prompt_and_must_run docker rmi "$sha_tag"
 
   plugin_prompt_and_must_run buildkite-agent meta-data set "$(build_meta_data_image_tag_key "$COMPOSE_SERVICE_NAME")" "$tag"
 }


### PR DESCRIPTION
This is a proof-of-concept PR.

I love this plugin!!  This plugin made it a breeze to split up our tests and dropped our previous pipeline times from 10+ min down to under 5 for the worst case, and down to 2m30s in the best case!

However, the tags it produces, are, well...ugly.  They're completely cromulent on the backend, but we use those tag names in a deploy tool, and well, who wants to deploy `my-application-app-build-100`?  We're already used to the git short sha's, so I think it'd be nice to have an option to push that tag to the repo.

This commit adds the short sha (`git rev-parse --short $BUILDKITE_COMMIT`) as a tag that's pushed to the repo.

I'm not emotionally invested in this exact code change, so as long as we've got some way to indicate either "add the short sha as a tag" or "use this as a tag for this build", my request would be met.

Again, thanks for this great plugin!
