### PR TITLE
Custom tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ steps:
     plugins:
       docker-compose:
         build: app
-        image-repository: index.docker.io/org/repo
+        image-repository: org/repo
     
   - wait
 
@@ -94,13 +94,33 @@ Default: `docker-compose.yml`
 
 ## `image-repository` (optional)
 
-The repository for pushing and pulling pre-built images, same as the repository location you would use for a `docker push`, for example `"index.docker.io/org/repo"`. Each image is tagged to the specific build so you can safely share the same image repository for any number of projects and builds.
+The repository for pushing and pulling pre-built images, same as the repository location you would use for a `docker push`, for example `"org/repo"`. Each image is tagged to the specific build so you can safely share the same image repository for any number of projects and builds.
 
 The default is `""`  which only builds images on the local Docker host doing the build.
 
 Note: this option only needs to be specified on the build step, and will be automatically picked up by following steps.
 
 This option can also be configured on the agent machine using the environment variable `BUILDKITE_PLUGIN_DOCKER_COMPOSE_IMAGE_REPOSITORY`.
+
+## `tags` (optional)
+
+By default we'll push the image to your `image-repository` tagged with the automatically generated docker compose container name. You can specify your own tags instead:
+
+```
+steps:
+  - name: ":docker:"
+    plugins:
+      docker-compose:
+        build: app
+        image-repository: org/repo
+        tags:
+          - latest
+          - ${BUILDKITE_COMMIT:0:7}
+          - $BUILDKITE_BRANCH
+          - $BUILDKITE_JOB_ID
+```
+
+Note: if you are running multiple agents on a single machine sharing a Docker daemon then it is possible that multiple jobs with the same tags might collide. Docker can't tag and push images as an atomic operation.
 
 ## Roadmap
 

--- a/hooks/command
+++ b/hooks/command
@@ -67,6 +67,10 @@ function build_meta_data_image_tag_key() {
   echo "docker-compose-plugin-built-image-tag-$1"
 }
 
+function short_sha(){
+  git rev-parse --short "$BUILDKITE_COMMIT"
+}
+
 ## BUILD OR RUN
 
 DIR="$(cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd)"

--- a/hooks/command
+++ b/hooks/command
@@ -67,10 +67,6 @@ function build_meta_data_image_tag_key() {
   echo "docker-compose-plugin-built-image-tag-$1"
 }
 
-function short_sha(){
-  git rev-parse --short "$BUILDKITE_COMMIT"
-}
-
 ## BUILD OR RUN
 
 DIR="$(cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd)"

--- a/hooks/commands/build.sh
+++ b/hooks/commands/build.sh
@@ -15,15 +15,26 @@ image_file_name() {
 }
 
 push_image_to_docker_repository() {
-  local tag="$DOCKER_IMAGE_REPOSITORY:$(image_file_name)"
-  local sha_tag="$DOCKER_IMAGE_REPOSITORY:$(short_sha)"
+  # XXX: Consuming array configuration is pretty gnarly
+  declare -a tags
+  if [[ -n "$BUILDKITE_PLUGIN_DOCKER_COMPOSE_TAGS_0" ]]; then
+    local i=0
+    local name="BUILDKITE_PLUGIN_DOCKER_COMPOSE_TAGS_${i}"
+    while [[ -n "${!name:-}" ]]; do
+      tags+=("${!name}")
+      i=$[$i+1]
+      name="BUILDKITE_PLUGIN_DOCKER_COMPOSE_TAGS_${i}"
+    done
+  else
+    tags+=("$(image_file_name)")
+  fi
 
-  plugin_prompt_and_must_run docker tag "$COMPOSE_SERVICE_DOCKER_IMAGE_NAME" "$tag"
-  plugin_prompt_and_must_run docker tag "$COMPOSE_SERVICE_DOCKER_IMAGE_NAME" "$sha_tag"
-  plugin_prompt_and_must_run docker push "$tag"
-  plugin_prompt_and_must_run docker push "$sha_tag"
-  plugin_prompt_and_must_run docker rmi "$tag"
-  plugin_prompt_and_must_run docker rmi "$sha_tag"
+  local tag
+  for tag in "${tags[@]}"; do
+    plugin_prompt_and_must_run docker tag "$COMPOSE_SERVICE_DOCKER_IMAGE_NAME" "$DOCKER_IMAGE_REPOSITORY:$tag"
+    plugin_prompt_and_must_run docker push "$DOCKER_IMAGE_REPOSITORY:$tag"
+    plugin_prompt_and_must_run docker rmi "$DOCKER_IMAGE_REPOSITORY:$tag"
+  done
 
   plugin_prompt_and_must_run buildkite-agent meta-data set "$(build_meta_data_image_tag_key "$COMPOSE_SERVICE_NAME")" "$tag"
 }

--- a/hooks/commands/build.sh
+++ b/hooks/commands/build.sh
@@ -19,11 +19,11 @@ push_image_to_docker_repository() {
   declare -a tags
   if [[ -n "${BUILDKITE_PLUGIN_DOCKER_COMPOSE_TAGS_0:-}" ]]; then
     local i=0
-    local name="BUILDKITE_PLUGIN_DOCKER_COMPOSE_TAGS_${i}"
-    while [[ -n "${!name:-}" ]]; do
-      tags+=("${!name}")
+    local parameter="BUILDKITE_PLUGIN_DOCKER_COMPOSE_TAGS_${i}"
+    while [[ -n "${!parameter:-}" ]]; do
+      tags+=("${!parameter}")
       i=$[$i+1]
-      name="BUILDKITE_PLUGIN_DOCKER_COMPOSE_TAGS_${i}"
+      parameter="BUILDKITE_PLUGIN_DOCKER_COMPOSE_TAGS_${i}"
     done
   else
     tags+=("$(image_file_name)")

--- a/hooks/commands/build.sh
+++ b/hooks/commands/build.sh
@@ -17,7 +17,7 @@ image_file_name() {
 push_image_to_docker_repository() {
   # XXX: Consuming array configuration is pretty gnarly
   declare -a tags
-  if [[ -n "$BUILDKITE_PLUGIN_DOCKER_COMPOSE_TAGS_0" ]]; then
+  if [[ -n "${BUILDKITE_PLUGIN_DOCKER_COMPOSE_TAGS_0:-}" ]]; then
     local i=0
     local name="BUILDKITE_PLUGIN_DOCKER_COMPOSE_TAGS_${i}"
     while [[ -n "${!name:-}" ]]; do

--- a/hooks/commands/build.sh
+++ b/hooks/commands/build.sh
@@ -16,10 +16,14 @@ image_file_name() {
 
 push_image_to_docker_repository() {
   local tag="$DOCKER_IMAGE_REPOSITORY:$(image_file_name)"
+  local sha_tag="$DOCKER_IMAGE_REPOSITORY:$(short_sha)"
 
   plugin_prompt_and_must_run docker tag "$COMPOSE_SERVICE_DOCKER_IMAGE_NAME" "$tag"
+  plugin_prompt_and_must_run docker tag "$COMPOSE_SERVICE_DOCKER_IMAGE_NAME" "$sha_tag"
   plugin_prompt_and_must_run docker push "$tag"
+  plugin_prompt_and_must_run docker push "$sha_tag"
   plugin_prompt_and_must_run docker rmi "$tag"
+  plugin_prompt_and_must_run docker rmi "$sha_tag"
 
   plugin_prompt_and_must_run buildkite-agent meta-data set "$(build_meta_data_image_tag_key "$COMPOSE_SERVICE_NAME")" "$tag"
 }


### PR DESCRIPTION
Rebound of #7 to add custom tags in a generally configurable way!
- [ ] Make sure split build/run pipelines have a known tag to download -- maybe the original tag still needs to be always pushed
