### PR TITLE
Use a configuration file to load the pre-built image

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,8 @@ The default is `""`  which only builds images on the local Docker host doing the
 
 Note: this option only needs to be specified on the build step, and will be automatically picked up by following steps.
 
+Only works with version '2' docker-compose.yml configuration files
+
 This option can also be configured on the agent machine using the environment variable `BUILDKITE_PLUGIN_DOCKER_COMPOSE_IMAGE_REPOSITORY`.
 
 ## Roadmap


### PR DESCRIPTION
Adds support for docker-compose services that have complex (multiline) `build` configurations in their yaml files.

**Context**
A docker-compose.yml allows the `build` configuration to be a string:

```
app:
  build: .
```

or an object

```
app:
  build:
    context: .
    dockerfile: Dockerfile-alternative
    args:
     somearg: foo
```

**Solution**
Instead of using `sed` to replace the `build: .` line with a path to the prebuilt image, the plugin will generate a docker-compose.buildkite-app-override.yml file of the form:

```
version: '2'
services:
  app:
    image: your-docker-registry.io/path-to/prebuilt-image
```

When the `docker-compose run` command is called, it first checks to see if the pre-built image exists before building it.

**Open questions**
- [x] Are there any users of this plugin that use the version 1 syntax for their docker-compose files?
  - If so, we can test for the presence of `version: '2'` in their docker compose file, and revert to the `sed` replacement for v1 users. For simplicity, I opted to leave this out until I hear that it's a requirement.