### PR TITLE
Override image name in build

### DIFF
--- a/hooks/commands/build.sh
+++ b/hooks/commands/build.sh
@@ -4,7 +4,6 @@ COMPOSE_SERVICE_NAME="$BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD"
 COMPOSE_SERVICE_DOCKER_IMAGE_NAME="$(docker_compose_container_name "$COMPOSE_SERVICE_NAME")"
 DOCKER_IMAGE_REPOSITORY="${BUILDKITE_PLUGIN_DOCKER_COMPOSE_IMAGE_REPOSITORY:-}"
 COMPOSE_SERVICE_OVERRIDE_FILE="docker-compose.buildkite-$COMPOSE_SERVICE_NAME-override.yml"
-BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD_TAG="$DOCKER_IMAGE_REPOSITORY:$(image_file_name)"
 
 # Returns a friendly image file name like "myproject-app-build-49" than can be
 # used as the docker image tag or tar.gz filename
@@ -23,7 +22,7 @@ push_image_to_docker_repository() {
   plugin_prompt_and_must_run buildkite-agent meta-data set "$(build_meta_data_image_tag_key "$COMPOSE_SERVICE_NAME")" "$tag"
 }
 
-
+BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD_TAG="$DOCKER_IMAGE_REPOSITORY:$(image_file_name)"
 
 echo "~~~ :docker: Creating a modified Docker Compose config"
 

--- a/hooks/commands/build.sh
+++ b/hooks/commands/build.sh
@@ -3,6 +3,8 @@
 COMPOSE_SERVICE_NAME="$BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD"
 COMPOSE_SERVICE_DOCKER_IMAGE_NAME="$(docker_compose_container_name "$COMPOSE_SERVICE_NAME")"
 DOCKER_IMAGE_REPOSITORY="${BUILDKITE_PLUGIN_DOCKER_COMPOSE_IMAGE_REPOSITORY:-}"
+COMPOSE_SERVICE_OVERRIDE_FILE="docker-compose.buildkite-$COMPOSE_SERVICE_NAME-override.yml"
+BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD_TAG="$DOCKER_IMAGE_REPOSITORY:$(image_file_name)"
 
 # Returns a friendly image file name like "myproject-app-build-49" than can be
 # used as the docker image tag or tar.gz filename
@@ -15,23 +17,28 @@ image_file_name() {
 }
 
 push_image_to_docker_repository() {
-  local tag="$DOCKER_IMAGE_REPOSITORY:$(image_file_name)"
-
-  plugin_prompt_and_must_run docker tag "$COMPOSE_SERVICE_DOCKER_IMAGE_NAME" "$tag"
-  plugin_prompt_and_must_run docker push "$tag"
-  plugin_prompt_and_must_run docker rmi "$tag"
+  plugin_prompt_and_must_run docker push "$BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD_TAG"
+  plugin_prompt_and_must_run docker rmi "$BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD_TAG"
 
   plugin_prompt_and_must_run buildkite-agent meta-data set "$(build_meta_data_image_tag_key "$COMPOSE_SERVICE_NAME")" "$tag"
 }
 
+
+
+echo "~~~ :docker: Creating a modified Docker Compose config"
+
+# Override the config so that the service uses the restored image instead of building
+cat > $COMPOSE_SERVICE_OVERRIDE_FILE <<EOF
+version: '2'
+services:
+  $COMPOSE_SERVICE_NAME:
+    image: $BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD_TAG
+EOF
+cat $COMPOSE_SERVICE_OVERRIDE_FILE
+
 echo "+++ :docker: Building Docker Compose images for service $COMPOSE_SERVICE_NAME"
 
-run_docker_compose build "$COMPOSE_SERVICE_NAME"
-
-echo "~~~ :docker: Listing docker images"
-
-plugin_prompt docker images
-docker images | grep buildkite
+run_docker_compose build -f "$COMPOSE_SERVICE_OVERRIDE_FILE" "$COMPOSE_SERVICE_NAME"
 
 if [[ ! -z "$DOCKER_IMAGE_REPOSITORY" ]]; then
   echo "~~~ :docker: Pushing image $COMPOSE_SERVICE_DOCKER_IMAGE_NAME to $DOCKER_IMAGE_REPOSITORY"

--- a/hooks/commands/build.sh
+++ b/hooks/commands/build.sh
@@ -37,7 +37,7 @@ cat $COMPOSE_SERVICE_OVERRIDE_FILE
 
 echo "+++ :docker: Building Docker Compose images for service $COMPOSE_SERVICE_NAME"
 
-run_docker_compose build -f "$COMPOSE_SERVICE_OVERRIDE_FILE" "$COMPOSE_SERVICE_NAME"
+run_docker_compose -f "$COMPOSE_SERVICE_OVERRIDE_FILE" build "$COMPOSE_SERVICE_NAME"
 
 if [[ ! -z "$DOCKER_IMAGE_REPOSITORY" ]]; then
   echo "~~~ :docker: Pushing image $COMPOSE_SERVICE_DOCKER_IMAGE_NAME to $DOCKER_IMAGE_REPOSITORY"

--- a/hooks/commands/build.sh
+++ b/hooks/commands/build.sh
@@ -16,8 +16,10 @@ image_file_name() {
 }
 
 push_image_to_docker_repository() {
-  plugin_prompt_and_must_run docker push "$BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD_TAG"
-  plugin_prompt_and_must_run docker rmi "$BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD_TAG"
+  local tag="$BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD_TAG"
+
+  plugin_prompt_and_must_run docker push "$tag"
+  plugin_prompt_and_must_run docker rmi "$tag"
 
   plugin_prompt_and_must_run buildkite-agent meta-data set "$(build_meta_data_image_tag_key "$COMPOSE_SERVICE_NAME")" "$tag"
 }


### PR DESCRIPTION
Following on from https://github.com/buildkite-plugins/docker-compose-buildkite-plugin/pull/13, this uses an override file for the `build` step with the generated `image` name, which docker-compose then uses as the tag name. 

This makes it easier to figuring out which images have been built, and also supports docker-compose files with existing image stanza's (see https://github.com/buildkite-plugins/docker-compose-buildkite-plugin/issues/12). 