### PR TITLE
Fix a regression caused by e03f6a1

### DIFF
--- a/hooks/commands/build.sh
+++ b/hooks/commands/build.sh
@@ -24,9 +24,8 @@ push_image_to_docker_repository() {
   plugin_prompt_and_must_run buildkite-agent meta-data set "$(build_meta_data_image_tag_key "$COMPOSE_SERVICE_NAME")" "$tag"
 }
 
-# Either use the build tag as an image name or a tag
-if [[ -z "$COMPOSE_SERVICE_DOCKER_IMAGE_NAME" ]] ; then
-  BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD_TAG="$(image_file_name)"
+if [[ -z "$DOCKER_IMAGE_REPOSITORY" ]] ; then
+  BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD_TAG="$COMPOSE_SERVICE_NAME:$(image_file_name)"
 else
   BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD_TAG="$COMPOSE_SERVICE_DOCKER_IMAGE_NAME:$(image_file_name)"
 fi


### PR DESCRIPTION
Resulted in build steps trying to push images like `docker push buildkite11fa7e735a9f48d08ed9c3723e2c60a7_accounts:blah-blah-accounts-build-26`