### PR TITLE
Detect docker-compose version

### DIFF
--- a/hooks/commands/build.sh
+++ b/hooks/commands/build.sh
@@ -15,12 +15,14 @@ else
   TAG="$BUILDKITE_PLUGIN_DOCKER_COMPOSE_IMAGE_NAME"
 fi
 
+COMPOSE_VERSION=$(grep -Po "version(.+)" docker-compose.yml | grep -Po "\d\.\d")
+
 echo "~~~ :docker: Creating a modified Docker Compose config"
 
 # Override the config so that docker-compose automatically tags the image when built
 
 cat > $COMPOSE_SERVICE_OVERRIDE_FILE <<EOF
-version: '2'
+version: '$COMPOSE_VERSION'
 services:
   $BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD:
     image: $TAG


### PR DESCRIPTION
This PR seeks to address https://github.com/buildkite-plugins/docker-compose-buildkite-plugin/issues/37.

This change allowed me to run a pipeline with docker-compose 2.1 files. 

There are a few areas of improvement:
- [ ] There's probably a cleaner way to get the docker-compose version in a single command.
- [ ] This change assumes there is a `docker-compose.yml` file in the repository. I'm not sure how I can dynamically get the first compose file from the plugin configuration.

I'm happy to address this and any other issue or concern but a bit of guidance would be appreciated. 😄 