### PR TITLE
Extract run functions into a shared library that can be tested

### DIFF
--- a/.buildkite/pipeline.sh
+++ b/.buildkite/pipeline.sh
@@ -53,6 +53,12 @@ steps:
         run: helloworld
         config: tests/composefiles/docker-compose.v2.1.yml
 
+  - wait
+  - label: run with default command
+    plugins:
+      ${BUILDKITE_REPO}#${commit}:
+        run: helloworld
+        config: tests/composefiles/docker-compose.v2.1.yml
 
   - wait
   - label: build, where an image name is specified

--- a/hooks/command
+++ b/hooks/command
@@ -8,6 +8,7 @@ DIR="$(cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd)"
 if [[ ! -z "$(plugin_read_config BUILD)" ]]; then
   . "$DIR/commands/build.sh"
 elif [[ ! -z "$(plugin_read_config RUN)" ]]; then
+  . "$DIR/../lib/run.bash"
   . "$DIR/commands/run.sh"
 else
   echo "+++ Docker Compose plugin error"

--- a/hooks/commands/build.sh
+++ b/hooks/commands/build.sh
@@ -5,15 +5,14 @@ build_image_repository="$(plugin_read_config IMAGE_REPOSITORY)"
 build_image_name_default="${BUILDKITE_PIPELINE_SLUG}-${build_service_name}-build-${BUILDKITE_BUILD_NUMBER}"
 build_image_name="$(plugin_read_config IMAGE_NAME "$build_image_name_default")"
 override_file="docker-compose.buildkite-${build_service_name}-override.yml"
-config_version="$(docker_compose_config_version)"
 
 if [[ ! -z "$build_image_repository" ]]; then
   build_image_name="${build_image_repository}:${build_image_name}"
 fi
 
 echo "~~~ :docker: Creating a modified Docker Compose config"
-build_image_override_file "$config_version" "$build_service_name" "$build_image_name" \
-  | tee "$override_file"
+build_image_override_file "$build_service_name" "$build_image_name" \
+  > "$override_file"
 
 echo "+++ :docker: Building Docker Compose images for service $build_service_name"
 run_docker_compose -f "$override_file" build "$build_service_name"

--- a/hooks/commands/build.sh
+++ b/hooks/commands/build.sh
@@ -12,7 +12,7 @@ fi
 
 echo "~~~ :docker: Creating a modified Docker Compose config"
 build_image_override_file "$build_service_name" "$build_image_name" \
-  > "$override_file"
+  | tee "$override_file"
 
 echo "+++ :docker: Building Docker Compose images for service $build_service_name"
 run_docker_compose -f "$override_file" build "$build_service_name"

--- a/hooks/commands/run.sh
+++ b/hooks/commands/run.sh
@@ -3,46 +3,7 @@
 run_service_name="$(plugin_read_config RUN)"
 override_file="docker-compose.buildkite-${run_service_name}-override.yml"
 
-compose_force_cleanup() {
-  echo "~~~ :docker: Cleaning up Docker containers"
-
-  # Send them a friendly kill
-  run_docker_compose kill || true
-
-  # `compose down` doesn't support force removing images
-  if [[ "$(plugin_read_config LEAVE_VOLUMES 'false')" == "false" ]]; then
-    run_docker_compose rm --force -v || true
-  else
-    run_docker_compose rm --force || true
-  fi
-
-  # Stop and remove all the linked services and network
-  if [[ "$(plugin_read_config LEAVE_VOLUMES 'false')" == "false" ]]; then
-    run_docker_compose down --volumes || true
-  else
-    run_docker_compose down || true
-  fi
-}
-
 trap compose_force_cleanup EXIT
-
-try_image_restore_from_docker_repository() {
-  local version
-  local image
-
-  image=$(plugin_get_build_image_metadata "$run_service_name")
-
-  if [[ -n "$image" ]] ; then
-    echo "~~~ :docker: Pulling docker image $image"
-    plugin_prompt_and_must_run docker pull "$image"
-
-    version=$(docker_compose_config_version)
-
-    echo "~~~ :docker: Creating a modified Docker Compose config ($version)"
-    build_image_override_file "$version" "$run_service_name" "$image" \
-      | tee "$override_file"
-  fi
-}
 
 try_image_restore_from_docker_repository
 
@@ -65,33 +26,6 @@ if [[ $exitcode -ne 0 ]] ; then
   echo "^^^ +++"
   echo "+++ :warning: Failed to run command, exited with $exitcode"
 fi
-
-list_linked_containers() {
-  for container_id in $(HIDE_PROMPT=1 run_docker_compose ps -q); do
-    docker inspect --format='{{.Name}}' "$container_id"
-  done
-}
-
-check_linked_containers() {
-  local logdir="$1"
-  local cmdexit="$2"
-
-  mkdir -p "$logdir"
-
-  for container_name in $(list_linked_containers); do
-    container_exit_code=$(docker inspect --format='{{.State.ExitCode}}' "$container_name")
-
-    if [[ $container_exit_code -ne 0 ]] ; then
-      echo "+++ :warning: Linked container $container_name exited with $container_exit_code"
-    fi
-
-    # Capture logs if the linked container failed OR if the main command failed
-    if [[ $container_exit_code -ne 0 ]] || [[ $cmdexit -ne 0 ]] ; then
-      plugin_prompt_and_run docker logs --timestamps --tail 500 "$container_name"
-      docker logs -t "$container_name" > "${logdir}/${container_name}.log"
-    fi
-  done
-}
 
 echo "~~~ Checking linked containers"
 check_linked_containers "docker-compose-logs" "$exitcode"

--- a/hooks/commands/run.sh
+++ b/hooks/commands/run.sh
@@ -11,12 +11,12 @@ cleanup() {
 # clean up docker containers on EXIT
 trap cleanup EXIT
 
+test -f "$override_file" && rm "$override_file"
+
 if build_image=$(get_prebuilt_image_from_metadata "$service_name") ; then
   echo "~~~ :docker: Creating a modified Docker Compose config"
   build_image_override_file "$service_name" "$build_image" \
     > "$override_file"
-elif [ -f "$override_file" ] ; then
-  rm "$override_file"
 fi
 
 echo "+++ :docker: Running command in Docker Compose service: $service_name"
@@ -27,11 +27,11 @@ echo "+++ :docker: Running command in Docker Compose service: $service_name"
 #   docker-compose run "app" go test
 
 if [[ -f "$override_file" ]]; then
-  run_docker_compose -f "$override_file" pull "$service_name"
-  run_docker_compose -f "$override_file" run "$service_name" $BUILDKITE_COMMAND
+  run_docker_compose -f "$override_file" pull "$service_name" && \
+    run_docker_compose -f "$override_file" run "$service_name" $BUILDKITE_COMMAND
 else
-  run_docker_compose pull "$service_name"
-  run_docker_compose run "$service_name" $BUILDKITE_COMMAND
+  run_docker_compose pull "$service_name" && \
+    run_docker_compose run "$service_name" $BUILDKITE_COMMAND
 fi
 
 exitcode=$?

--- a/hooks/commands/run.sh
+++ b/hooks/commands/run.sh
@@ -1,13 +1,25 @@
 #!/bin/bash
 
-run_service_name="$(plugin_read_config RUN)"
-override_file="docker-compose.buildkite-${run_service_name}-override.yml"
+service_name="$(plugin_read_config RUN)"
+override_file="docker-compose.buildkite-${service_name}-override.yml"
 
-trap compose_force_cleanup EXIT
+cleanup() {
+  echo "~~~ :docker: Cleaning up after docker-compose"
+  compose_cleanup
+}
 
-try_image_restore_from_docker_repository
+# clean up docker containers on EXIT
+trap cleanup EXIT
 
-echo "+++ :docker: Running command in Docker Compose service: $run_service_name"
+if build_image=$(get_prebuilt_image_from_metadata "$service_name") ; then
+  echo "~~~ :docker: Creating a modified Docker Compose config"
+  build_image_override_file "$service_name" "$build_image" \
+    > "$override_file"
+elif [ -f "$override_file" ] ; then
+  rm "$override_file"
+fi
+
+echo "+++ :docker: Running command in Docker Compose service: $service_name"
 
 # $BUILDKITE_COMMAND needs to be unquoted because:
 #   docker-compose run "app" "go test"
@@ -15,9 +27,11 @@ echo "+++ :docker: Running command in Docker Compose service: $run_service_name"
 #   docker-compose run "app" go test
 
 if [[ -f "$override_file" ]]; then
-  run_docker_compose -f "$override_file" run "$run_service_name" $BUILDKITE_COMMAND
+  run_docker_compose -f "$override_file" pull "$service_name"
+  run_docker_compose -f "$override_file" run "$service_name" $BUILDKITE_COMMAND
 else
-  run_docker_compose run "$run_service_name" $BUILDKITE_COMMAND
+  run_docker_compose pull "$service_name"
+  run_docker_compose run "$service_name" $BUILDKITE_COMMAND
 fi
 
 exitcode=$?

--- a/hooks/commands/run.sh
+++ b/hooks/commands/run.sh
@@ -17,16 +17,11 @@ test -f "$override_file" && rm "$override_file"
 if build_image=$(get_prebuilt_image_from_metadata "$service_name") ; then
   echo "~~~ :docker: Creating a modified Docker Compose config"
   build_image_override_file "$service_name" "$build_image" \
-    > "$override_file"
-fi
+    | tee "$override_file"
 
-echo "~~~ :docker: Pulling down latest images"
-
-if [[ -f "$override_file" ]] ; then
+  echo "~~~ :docker: Pulling down latest images"
   run_docker_compose -f "$override_file" pull "$service_name"
 fi
-
-run_docker_compose pull --ignore-pull-failures
 
 echo "+++ :docker: Running command in Docker Compose service: $service_name"
 set +e

--- a/hooks/commands/run.sh
+++ b/hooks/commands/run.sh
@@ -22,11 +22,11 @@ fi
 
 echo "~~~ :docker: Pulling down latest images"
 
-if [[ -f "$override_file" ]]; then
-  run_docker_compose -f "$override_file" pull --ignore-pull-failures
-else
-  run_docker_compose pull --ignore-pull-failures
+if [[ -n "$build_image" ]] ; then
+  run_docker_compose -f "$override_file" pull "$service_name"
 fi
+
+run_docker_compose pull --ignore-pull-failures
 
 echo "+++ :docker: Running command in Docker Compose service: $service_name"
 set +e

--- a/hooks/commands/run.sh
+++ b/hooks/commands/run.sh
@@ -22,7 +22,7 @@ fi
 
 echo "~~~ :docker: Pulling down latest images"
 
-if [[ -n "$build_image" ]] ; then
+if [[ -f "$override_file" ]] ; then
   run_docker_compose -f "$override_file" pull "$service_name"
 fi
 

--- a/hooks/commands/run.sh
+++ b/hooks/commands/run.sh
@@ -3,15 +3,6 @@
 run_service_name="$(plugin_read_config RUN)"
 override_file="docker-compose.buildkite-${run_service_name}-override.yml"
 
-check_required_args() {
-  if [[ -z "${BUILDKITE_COMMAND:-}" ]]; then
-    echo "No command to run. Did you provide a 'command' for this step?"
-    exit 1
-  fi
-}
-
-check_required_args
-
 compose_force_cleanup() {
   echo "~~~ :docker: Cleaning up Docker containers"
 

--- a/hooks/commands/run.sh
+++ b/hooks/commands/run.sh
@@ -27,10 +27,10 @@ echo "+++ :docker: Running command in Docker Compose service: $service_name"
 #   docker-compose run "app" go test
 
 if [[ -f "$override_file" ]]; then
-  run_docker_compose -f "$override_file" pull "$service_name" && \
+  run_docker_compose -f "$override_file" pull && \
     run_docker_compose -f "$override_file" run "$service_name" $BUILDKITE_COMMAND
 else
-  run_docker_compose pull "$service_name" && \
+  run_docker_compose pull && \
     run_docker_compose run "$service_name" $BUILDKITE_COMMAND
 fi
 

--- a/hooks/commands/run.sh
+++ b/hooks/commands/run.sh
@@ -14,7 +14,9 @@ trap cleanup EXIT
 
 test -f "$override_file" && rm "$override_file"
 
-if build_image=$(get_prebuilt_image_from_metadata "$service_name") ; then
+build_image=$(get_prebuilt_image_from_metadata "$service_name")
+
+if [[ -n "$build_image" ]] ; then
   echo "~~~ :docker: Creating a modified Docker Compose config"
   build_image_override_file "$service_name" "$build_image" \
     | tee "$override_file"

--- a/lib/run.bash
+++ b/lib/run.bash
@@ -1,0 +1,63 @@
+
+compose_force_cleanup() {
+  echo "~~~ :docker: Cleaning up Docker containers"
+
+  # Send them a friendly kill
+  run_docker_compose kill || true
+
+  # `compose down` doesn't support force removing images
+  if [[ "$(plugin_read_config LEAVE_VOLUMES 'false')" == "false" ]]; then
+    run_docker_compose rm --force -v || true
+  else
+    run_docker_compose rm --force || true
+  fi
+
+  # Stop and remove all the linked services and network
+  if [[ "$(plugin_read_config LEAVE_VOLUMES 'false')" == "false" ]]; then
+    run_docker_compose down --volumes || true
+  else
+    run_docker_compose down || true
+  fi
+}
+
+try_image_restore_from_docker_repository() {
+  local version
+
+  if image=$(plugin_get_build_image_metadata "$run_service_name") 2>/dev/null; then
+    echo "~~~ :docker: Pulling docker image $image"
+    plugin_prompt_and_must_run docker pull "$image"
+
+    version=$(docker_compose_config_version)
+
+    echo "~~~ :docker: Creating a modified Docker Compose config ($version)"
+    build_image_override_file "$version" "$run_service_name" "$image" \
+      | tee "$override_file"
+  fi
+}
+
+list_linked_containers() {
+  for container_id in $(HIDE_PROMPT=1 run_docker_compose ps -q); do
+    docker inspect --format='{{.Name}}' "$container_id"
+  done
+}
+
+check_linked_containers() {
+  local logdir="$1"
+  local cmdexit="$2"
+
+  mkdir -p "$logdir"
+
+  for container_name in $(list_linked_containers); do
+    container_exit_code=$(docker inspect --format='{{.State.ExitCode}}' "$container_name")
+
+    if [[ $container_exit_code -ne 0 ]] ; then
+      echo "+++ :warning: Linked container $container_name exited with $container_exit_code"
+    fi
+
+    # Capture logs if the linked container failed OR if the main command failed
+    if [[ $container_exit_code -ne 0 ]] || [[ $cmdexit -ne 0 ]] ; then
+      plugin_prompt_and_run docker logs --timestamps --tail 500 "$container_name"
+      docker logs -t "$container_name" > "${logdir}/${container_name}.log"
+    fi
+  done
+}

--- a/lib/run.bash
+++ b/lib/run.bash
@@ -1,7 +1,5 @@
 
-compose_force_cleanup() {
-  echo "~~~ :docker: Cleaning up Docker containers"
-
+compose_cleanup() {
   # Send them a friendly kill
   run_docker_compose kill || true
 
@@ -20,19 +18,9 @@ compose_force_cleanup() {
   fi
 }
 
-try_image_restore_from_docker_repository() {
-  local version
-
-  if image=$(plugin_get_build_image_metadata "$run_service_name") 2>/dev/null; then
-    echo "~~~ :docker: Pulling docker image $image"
-    plugin_prompt_and_must_run docker pull "$image"
-
-    version=$(docker_compose_config_version)
-
-    echo "~~~ :docker: Creating a modified Docker Compose config ($version)"
-    build_image_override_file "$version" "$run_service_name" "$image" \
-      | tee "$override_file"
-  fi
+get_prebuilt_image_from_metadata() {
+  local service_name="$1"
+  plugin_get_build_image_metadata "$service_name"
 }
 
 list_linked_containers() {

--- a/lib/shared.bash
+++ b/lib/shared.bash
@@ -91,6 +91,16 @@ function docker_compose_config_version() {
 
 # Build an docker-compose file that overrides the image for a given service
 function build_image_override_file() {
+  local service="$1"
+  local image="$2"
+  local version
+
+  version="$(docker_compose_config_version)"
+  build_image_override_file_with_version "$version" "$service" "$image"
+}
+
+# Build an docker-compose file that overrides the image for a given service and version
+function build_image_override_file_with_version() {
   local version="$1"
   local service="$2"
   local image="$3"

--- a/lib/shared.bash
+++ b/lib/shared.bash
@@ -48,12 +48,6 @@ function docker_compose_project_name() {
   echo "buildkite${BUILDKITE_JOB_ID//-}"
 }
 
-# Returns the name of the docker compose container that corresponds to the
-# given service
-function docker_compose_container_name() {
-  echo "$(docker_compose_project_name)_$1"
-}
-
 # Returns the first docker compose config file name
 function docker_compose_config_files() {
   if [[ -n "${BUILDKITE_PLUGIN_DOCKER_COMPOSE_CONFIG_0:-}" ]]; then

--- a/tests/docker-compose-cleanup.bats
+++ b/tests/docker-compose-cleanup.bats
@@ -1,0 +1,27 @@
+#!/usr/bin/env bats
+
+load '../lib/shared'
+load '../lib/run'
+
+@test "Default cleanup of docker-compose" {
+  run_docker_compose() {
+    echo "$@"
+  }
+  run compose_cleanup
+  [ "$status" -eq 0 ]
+  [ "${lines[0]}" = "kill" ]
+  [ "${lines[1]}" = "rm --force -v" ]
+  [ "${lines[2]}" = "down --volumes" ]
+}
+
+@test "Possible to skip volume destruction in docker-compose cleanup" {
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_LEAVE_VOLUMES=1
+  run_docker_compose() {
+    echo "$@"
+  }
+  run compose_cleanup
+  [ "$status" -eq 0 ]
+  [ "${lines[0]}" = "kill" ]
+  [ "${lines[1]}" = "rm --force" ]
+  [ "${lines[2]}" = "down" ]
+}

--- a/tests/image-override-file.bats
+++ b/tests/image-override-file.bats
@@ -11,7 +11,7 @@ EOF
 )
 
 @test "Build an docker-compose override file" {
-  run build_image_override_file "2.1" "myservice" "newimage:1.0.0"
+  run build_image_override_file_with_version "2.1" "myservice" "newimage:1.0.0"
   echo
   [ "$status" -eq 0 ]
   [ "$output" == "$myservice_override_file" ]

--- a/tests/run.bats
+++ b/tests/run.bats
@@ -1,0 +1,15 @@
+#!/usr/bin/env bats
+
+load '../lib/shared'
+load '../lib/run'
+
+@test "Get prebuilt image from agent metadata" {
+  export HIDE_PROMPT=1
+  buildkite-agent() {
+    echo "$@"
+  }
+  run get_prebuilt_image_from_metadata "llama"
+  echo $output
+  [ "$status" -eq 0 ]
+  [ "$output" = "meta-data get docker-compose-plugin-built-image-tag-llama" ]
+}


### PR DESCRIPTION
This moves the inline functions from the run command into a shared library bash file, which makes it easier to test.

~~This also makes a change to how pull works, previously an image would only be pulled if it was brought in from a `image-repository` in a previous build step, but I suspect this is a bug, as it would mean services with a specified `image` wouldn't be updated and might in fact be stale.~~

Decided the above is better suited to a subsequent PR.