### PR TITLE
Support multiple image builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+docker-compose.buildkite-1-override.yml 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,11 @@
 FROM lucor/bats
 
+ENV LIBS_BATS_MOCK_VERSION "1.0.1"
+RUN mkdir -p /usr/local/lib/bats-mock \
+    && curl -sSL https://github.com/jasonkarns/bats-mock/archive/v$LIBS_BATS_MOCK_VERSION.tar.gz -o /tmp/bats-mock.tgz \
+    && tar -zxf /tmp/bats-mock.tgz -C /usr/local/lib/bats/bats-mock --strip 1
+    && printf 'source "%s"\n' "/usr/local/lib/bats-mock" >> /usr/local/lib/bats/load.bash
+
 WORKDIR /app
 ENTRYPOINT ["/usr/local/bin/bats"]
 CMD ["tests/"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,11 @@
 FROM lucor/bats
 
 ENV LIBS_BATS_MOCK_VERSION "1.0.1"
-RUN mkdir -p /usr/local/lib/bats-mock \
+RUN mkdir -p /usr/local/lib/bats/bats-mock \
     && curl -sSL https://github.com/jasonkarns/bats-mock/archive/v$LIBS_BATS_MOCK_VERSION.tar.gz -o /tmp/bats-mock.tgz \
-    && tar -zxf /tmp/bats-mock.tgz -C /usr/local/lib/bats/bats-mock --strip 1
-    && printf 'source "%s"\n' "/usr/local/lib/bats-mock" >> /usr/local/lib/bats/load.bash
+    && tar -zxf /tmp/bats-mock.tgz -C /usr/local/lib/bats/bats-mock --strip 1 \
+    && printf 'source "%s"\n' "/usr/local/lib/bats/bats-mock/stub.bash" >> /usr/local/lib/bats/load.bash \
+    && rm -rf /tmp/bats-mock.tgz
 
 WORKDIR /app
 ENTRYPOINT ["/usr/local/bin/bats"]

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ steps:
 
 # Building multiple images
 
-Sometimes you need to build multiple images:
+Sometimes your compose file has multiple services that need building. The example below will build images for the `app` and `tests` service and then the run step will pull them down and use them for the run as needed.
 
 ```yml
 steps:
@@ -134,9 +134,6 @@ steps:
     parallelism: 25
     plugins:
       docker-compose#v1.1:
-        pull: 
-          - app
-          - tests
         run: tests
 ```
 
@@ -145,6 +142,8 @@ steps:
 ### `build`
 
 The name of a service to build and store, allowing following pipeline steps to run faster as they won't need to build the image. The step’s `command` will be ignored and does not need to be specified.
+
+Either a single service or multiple services can be provided as an array.
 
 ### `run`
 
@@ -173,10 +172,6 @@ The name to use when tagging pre-built images.
 The default is `${BUILDKITE_PIPELINE_SLUG}-${BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD}-build-${BUILDKITE_BUILD_NUMBER}`, for example `my-project-web-build-42`.
 
 Note: this option can only be specified on a `build` step.
-
-## Roadmap
-
-* Support pre-building of multiple Docker Compose services
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -111,6 +111,35 @@ steps:
         run: app
 ```
 
+# Building multiple images
+
+Sometimes you need to build multiple images:
+
+```yml
+steps:
+  - name: ":docker: Build"
+    agents:
+      queue: docker-builder
+    plugins:
+      docker-compose#v1.1:
+        build: 
+          - app
+          - tests
+        image-repository: index.docker.io/org/repo
+
+  - wait
+
+  - name: ":docker: Test %n"
+    command: test.sh
+    parallelism: 25
+    plugins:
+      docker-compose#v1.1:
+        pull: 
+          - app
+          - tests
+        run: tests
+```
+
 ## Options
 
 ### `build`

--- a/hooks/command
+++ b/hooks/command
@@ -5,9 +5,9 @@ DIR="$(cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd)"
 
 . "$DIR/../lib/shared.bash"
 
-if [[ ! -z "$(plugin_read_config BUILD)" ]]; then
+if [[ -n "$(plugin_read_list BUILD)" ]]; then
   . "$DIR/commands/build.sh"
-elif [[ ! -z "$(plugin_read_config RUN)" ]]; then
+elif [[ -n "$(plugin_read_config RUN)" ]]; then
   . "$DIR/../lib/run.bash"
   . "$DIR/commands/run.sh"
 else

--- a/hooks/commands/build.sh
+++ b/hooks/commands/build.sh
@@ -31,6 +31,7 @@ if [[ -n "$image_repository" ]]; then
 
   i=0
   while [[ ${#build_images[@]} -gt 0 ]] ; do
+    plugin_set_build_image_metadata "${build_images[@]:0:2}"
     plugin_set_build_image_metadata "$i" "${build_images[@]:1:2}"
     build_images=("${build_images[@]:2}")
     i=$((i+1))

--- a/hooks/commands/build.sh
+++ b/hooks/commands/build.sh
@@ -1,12 +1,5 @@
 #!/bin/bash
 
-pull_images=( $(plugin_read_list PULL) )
-
-if [[ ${#pull_images[@]} -gt 0 ]] ; then
-  echo "~~~ :docker: Pulling services ${services[*]}"
-  run_docker_compose pull "${services[@]}"
-fi
-
 image_repository="$(plugin_read_config IMAGE_REPOSITORY)"
 override_file="docker-compose.buildkite-${BUILDKITE_BUILD_NUMBER}-override.yml"
 build_images=()
@@ -23,7 +16,7 @@ for service_name in $(plugin_read_list BUILD) ; do
 done
 
 if [[ ${#build_images[@]} -gt 0 ]] ; then
-  echo "~~~ :docker: Creating a modified Docker Compose config"
+  echo "~~~ :docker: Creating a modified docker-compose config"
   build_image_override_file "${build_images[@]}" | tee "$override_file"
 fi
 
@@ -36,8 +29,10 @@ if [[ -n "$image_repository" ]]; then
   echo "~~~ :docker: Pushing built images to $image_repository"
   run_docker_compose -f "$override_file" push "${services[@]}"
 
+  i=0
   while [[ ${#build_images[@]} -gt 0 ]] ; do
-    plugin_set_build_image_metadata "${build_images[@]:0:2}"
+    plugin_set_build_image_metadata "$i" "${build_images[@]:1:2}"
     build_images=("${build_images[@]:2}")
+    i=$((i+1))
   done
 fi

--- a/hooks/commands/build.sh
+++ b/hooks/commands/build.sh
@@ -22,8 +22,8 @@ fi
 
 services=( $(plugin_read_list BUILD) )
 
-echo "+++ :docker: Building services ${services[0]}"
-run_docker_compose -f "$override_file" build "${services[0]}"
+echo "+++ :docker: Building services ${services[*]}"
+run_docker_compose -f "$override_file" build "${services[@]}"
 
 if [[ -n "$image_repository" ]]; then
   echo "~~~ :docker: Pushing built images to $image_repository"

--- a/hooks/commands/build.sh
+++ b/hooks/commands/build.sh
@@ -1,24 +1,36 @@
 #!/bin/bash
 
-build_service_name="$(plugin_read_config BUILD)"
-build_image_repository="$(plugin_read_config IMAGE_REPOSITORY)"
-build_image_name_default="${BUILDKITE_PIPELINE_SLUG}-${build_service_name}-build-${BUILDKITE_BUILD_NUMBER}"
-build_image_name="$(plugin_read_config IMAGE_NAME "$build_image_name_default")"
-override_file="docker-compose.buildkite-${build_service_name}-override.yml"
+image_repository="$(plugin_read_config IMAGE_REPOSITORY)"
+override_file="docker-compose.buildkite-${BUILDKITE_BUILD_NUMBER}-override.yml"
+build_images=()
 
-if [[ ! -z "$build_image_repository" ]]; then
-  build_image_name="${build_image_repository}:${build_image_name}"
+for service_name in $(plugin_read_list BUILD) ; do
+  image_name_default="${BUILDKITE_PIPELINE_SLUG}-${service_name}-build-${BUILDKITE_BUILD_NUMBER}"
+  image_name="$(plugin_read_config IMAGE_NAME "$image_name_default")"
+
+  if [[ -n "$image_repository" ]]; then
+    image_name="${image_repository}:${image_name}"
+  fi
+
+  build_images+=("$service_name" "$image_name")
+done
+
+if [[ ${#build_images[@]} -gt 0 ]] ; then
+  echo "~~~ :docker: Creating a modified Docker Compose config"
+  build_image_override_file "${build_images[@]}" | tee "$override_file"
 fi
 
-echo "~~~ :docker: Creating a modified Docker Compose config"
-build_image_override_file "$build_service_name" "$build_image_name" \
-  | tee "$override_file"
+services=( $(plugin_read_list BUILD) )
 
-echo "+++ :docker: Building Docker Compose images for service $build_service_name"
-run_docker_compose -f "$override_file" build "$build_service_name"
+echo "+++ :docker: Building services ${services[0]}"
+run_docker_compose -f "$override_file" build "${services[0]}"
 
-if [[ ! -z "$build_image_repository" ]]; then
-  echo "~~~ :docker: Pushing image to $build_image_repository"
-  plugin_prompt_and_must_run docker push "$build_image_name"
-  plugin_set_build_image_metadata "$build_service_name" "$build_image_name"
+if [[ -n "$image_repository" ]]; then
+  echo "~~~ :docker: Pushing built images to $image_repository"
+  run_docker_compose -f "$override_file" push "${services[@]}"
+
+  while [[ ${#build_images[@]} -gt 0 ]] ; do
+    plugin_set_build_image_metadata "${build_images[@]:0:2}"
+    build_images=("${build_images[@]:2}")
+  done
 fi

--- a/hooks/commands/build.sh
+++ b/hooks/commands/build.sh
@@ -1,5 +1,12 @@
 #!/bin/bash
 
+pull_images=( $(plugin_read_list PULL) )
+
+if [[ ${#pull_images[@]} -gt 0 ]] ; then
+  echo "~~~ :docker: Pulling services ${services[*]}"
+  run_docker_compose pull "${services[@]}"
+fi
+
 image_repository="$(plugin_read_config IMAGE_REPOSITORY)"
 override_file="docker-compose.buildkite-${BUILDKITE_BUILD_NUMBER}-override.yml"
 build_images=()

--- a/hooks/commands/run.sh
+++ b/hooks/commands/run.sh
@@ -14,6 +14,11 @@ trap cleanup EXIT
 
 test -f "$override_file" && rm "$override_file"
 
+pull_images=( $(plugin_read_list PULL) )
+
+echo "~~~ :docker: Pulling services ${pull_images[*]}"
+run_docker_compose pull "${pull_images[@]}"
+
 build_image=$(get_prebuilt_image_from_metadata "$service_name")
 
 if [[ -n "$build_image" ]] ; then
@@ -21,8 +26,8 @@ if [[ -n "$build_image" ]] ; then
   build_image_override_file "$service_name" "$build_image" \
     | tee "$override_file"
 
-  echo "~~~ :docker: Pulling down latest images"
-  run_docker_compose -f "$override_file" pull "$service_name"
+  echo "~~~ :docker: Pulling pre-built service $service_name"
+  run_docker_compose pull "$service_name"
 fi
 
 echo "+++ :docker: Running command in Docker Compose service: $service_name"

--- a/lib/run.bash
+++ b/lib/run.bash
@@ -1,3 +1,4 @@
+#!/bin/bash
 
 compose_cleanup() {
   # Send them a friendly kill

--- a/lib/run.bash
+++ b/lib/run.bash
@@ -19,9 +19,26 @@ compose_cleanup() {
   fi
 }
 
-get_prebuilt_image_from_metadata() {
-  local service_name="$1"
-  plugin_get_build_image_metadata "$service_name"
+get_prebuilt_images_from_metadata() {
+  local value
+  for i in {0..10} ; do
+    if ! value="$(plugin_get_build_image_metadata "$i")" ; then
+      return $?
+    fi
+    if [[ -z "$value" ]] ; then
+      break
+    fi
+    echo "$value"
+    i=$((i+1))
+  done
+}
+
+get_services_from_map() {
+  for ((n=1;n<$#;n++)) ; do
+    if (( $((n % 2)) == 1 )) ; then
+      echo ${!n}
+    fi
+  done
 }
 
 list_linked_containers() {

--- a/lib/shared.bash
+++ b/lib/shared.bash
@@ -58,8 +58,6 @@ function plugin_read_list() {
     done
   elif [[ -n "${!prefix:-}" ]]; then
     echo "${!prefix}"
-  else
-    return 1
   fi
 }
 

--- a/lib/shared.bash
+++ b/lib/shared.bash
@@ -1,3 +1,4 @@
+#!/bin/bash
 
 # Show a prompt for a command
 function plugin_prompt() {
@@ -76,8 +77,11 @@ function docker_compose_container_name() {
 
 # Returns all docker compose config file names split by newlines
 function docker_compose_config_files() {
-  if ! config_files=( $( plugin_read_list CONFIG ) ) ; then
+  config_files=( $( plugin_read_list CONFIG ) )
+
+  if [[ ${#config_files[@]} -eq 0 ]]  ; then
     echo "docker-compose.yml"
+    return
   fi
 
   # Process any (deprecated) colon delimited config paths

--- a/lib/shared.bash
+++ b/lib/shared.bash
@@ -100,26 +100,27 @@ function docker_compose_config_version() {
   sed -n "s/version: ['\"]\(.*\)['\"]/\1/p" < "$(docker_compose_config_file)"
 }
 
-# Build an docker-compose file that overrides the image for a given service
+# Build an docker-compose file that overrides the image for a set of
+# service and image pairs
 function build_image_override_file() {
-  local service="$1"
-  local image="$2"
-  local version
-
-  version="$(docker_compose_config_version)"
-  build_image_override_file_with_version "$version" "$service" "$image"
+  build_image_override_file_with_version \
+    "$(docker_compose_config_version)" "$@"
 }
 
-# Build an docker-compose file that overrides the image for a given service and version
+# Build an docker-compose file that overrides the image for a specific
+# docker-compose version and set of service and image pairs
 function build_image_override_file_with_version() {
   local version="$1"
-  local service="$2"
-  local image="$3"
 
   printf "version: '%s'\n" "$version"
   printf "services:\n"
-  printf "  %s:\n" "$service"
-  printf "    image: %s\n" "$image"
+
+  shift
+  while test ${#} -gt 0 ; do
+    printf "  %s:\n" "$1"
+    printf "    image: %s\n" "$2"
+    shift 2
+  done
 }
 
 # Runs the docker-compose command, scoped to the project, with the given arguments

--- a/lib/shared.bash
+++ b/lib/shared.bash
@@ -27,15 +27,15 @@ function plugin_read_config() {
   echo "${!var:-$default}"
 }
 
-# Read agent metadata for pre-built images, returns empty string on error
+# Read agent metadata for pre-built images
 function plugin_get_build_image_metadata() {
   local service="$1"
   local key="docker-compose-plugin-built-image-tag-${service}"
   plugin_prompt buildkite-agent meta-data get "$key"
-  buildkite-agent meta-data get "$key" 2>/dev/null || true
+  buildkite-agent meta-data get "$key"
 }
 
-# Write agent metadata for pre-built images, exits on error
+# Write agent metadata for pre-built images
 function plugin_set_build_image_metadata() {
   local service="$1"
   local value="$2"

--- a/tests/build.bats
+++ b/tests/build.bats
@@ -2,13 +2,12 @@
 
 load '/usr/local/lib/bats/load.bash'
 load '../lib/shared'
-load '../lib/run'
 
 # export DOCKER_COMPOSE_STUB_DEBUG=/dev/stdout
 # export BUILDKITE_AGENT_STUB_DEBUG=/dev/stdout
 # export BATS_MOCK_TMPDIR=$PWD
 
-@test "Run a build without a repository" {
+@test "Build without a repository" {
   export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD=myservice
   export BUILDKITE_PIPELINE_SLUG=test
@@ -24,7 +23,7 @@ load '../lib/run'
   assert_output --partial "built myservice"
 }
 
-@test "Run a build with a repository" {
+@test "Build with a repository" {
   export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD=myservice
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_IMAGE_REPOSITORY=my.repository/llamas
@@ -36,19 +35,19 @@ load '../lib/run'
     "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml push myservice : echo pushed myservice" \
 
   stub buildkite-agent \
-    "meta-data set docker-compose-plugin-built-image-tag-myservice my.repository/llamas:test-myservice-build-1 : echo set metadata"
+    "meta-data set docker-compose-plugin-built-image-tag-0 my.repository/llamas:test-myservice-build-1 : echo set metadata 0"
 
   run $PWD/hooks/command
 
-  unstub docker-compose
-  unstub buildkite-agent
   assert_success
   assert_output --partial "built myservice"
   assert_output --partial "pushed myservice"
-  assert_output --partial "set metadata"
+  assert_output --partial "set metadata 0"
+  unstub docker-compose
+  unstub buildkite-agent
 }
 
-@test "Run a build with a repository and multiple services" {
+@test "Build with a repository and multiple services" {
   export BUILDKITE_JOB_ID=1112
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD_0=myservice1
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD_1=myservice2
@@ -61,16 +60,16 @@ load '../lib/run'
     "-f docker-compose.yml -p buildkite1112 -f docker-compose.buildkite-1-override.yml push myservice1 myservice2 : echo pushed all services" \
 
   stub buildkite-agent \
-    "meta-data set docker-compose-plugin-built-image-tag-myservice1 my.repository/llamas:test-myservice1-build-1 : echo set metadata1" \
-    "meta-data set docker-compose-plugin-built-image-tag-myservice2 my.repository/llamas:test-myservice2-build-1 : echo set metadata2"
+    "meta-data set docker-compose-plugin-built-image-tag-0 my.repository/llamas:test-myservice1-build-1 : echo set metadata 0" \
+    "meta-data set docker-compose-plugin-built-image-tag-1 my.repository/llamas:test-myservice2-build-1 : echo set metadata 1"
 
   run $PWD/hooks/command
 
-  unstub docker-compose
-  unstub buildkite-agent
   assert_success
   assert_output --partial "built all services"
   assert_output --partial "pushed all services"
-  assert_output --partial "set metadata1"
-  assert_output --partial "set metadata2"
+  assert_output --partial "set metadata 0"
+  assert_output --partial "set metadata 1"
+  unstub docker-compose
+  unstub buildkite-agent
 }

--- a/tests/build.bats
+++ b/tests/build.bats
@@ -35,6 +35,7 @@ load '../lib/shared'
     "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml push myservice : echo pushed myservice" \
 
   stub buildkite-agent \
+    "meta-data set docker-compose-plugin-built-image-tag-myservice my.repository/llamas:test-myservice-build-1 : echo set legacy metadata" \
     "meta-data set docker-compose-plugin-built-image-tag-0 my.repository/llamas:test-myservice-build-1 : echo set metadata 0"
 
   run $PWD/hooks/command
@@ -42,6 +43,7 @@ load '../lib/shared'
   assert_success
   assert_output --partial "built myservice"
   assert_output --partial "pushed myservice"
+  assert_output --partial "set legacy metadata"
   assert_output --partial "set metadata 0"
   unstub docker-compose
   unstub buildkite-agent
@@ -60,7 +62,9 @@ load '../lib/shared'
     "-f docker-compose.yml -p buildkite1112 -f docker-compose.buildkite-1-override.yml push myservice1 myservice2 : echo pushed all services" \
 
   stub buildkite-agent \
+    "meta-data set docker-compose-plugin-built-image-tag-myservice1 my.repository/llamas:test-myservice1-build-1 : echo set legacy metadata 1" \
     "meta-data set docker-compose-plugin-built-image-tag-0 my.repository/llamas:test-myservice1-build-1 : echo set metadata 0" \
+    "meta-data set docker-compose-plugin-built-image-tag-myservice2 my.repository/llamas:test-myservice2-build-1 : echo set legacy metadata 2" \
     "meta-data set docker-compose-plugin-built-image-tag-1 my.repository/llamas:test-myservice2-build-1 : echo set metadata 1"
 
   run $PWD/hooks/command
@@ -68,6 +72,8 @@ load '../lib/shared'
   assert_success
   assert_output --partial "built all services"
   assert_output --partial "pushed all services"
+  assert_output --partial "set legacy metadata 1"
+  assert_output --partial "set legacy metadata 2"
   assert_output --partial "set metadata 0"
   assert_output --partial "set metadata 1"
   unstub docker-compose

--- a/tests/build.bats
+++ b/tests/build.bats
@@ -1,0 +1,47 @@
+#!/usr/bin/env bats
+
+load '/usr/local/lib/bats/load.bash'
+load '../lib/shared'
+load '../lib/run'
+
+@test "Run a build without a repository" {
+  export BUILDKITE_JOB_ID=1111
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD=myservice
+  export BUILDKITE_PIPELINE_SLUG=test
+  export BUILDKITE_BUILD_NUMBER=1
+
+  export DOCKER_COMPOSE_STUB_DEBUG=/dev/stdout
+
+  stub docker-compose \
+    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml build myservice : echo built myservice"
+
+  run $PWD/hooks/command
+
+  unstub docker-compose
+  assert_success
+  assert_output --partial "built myservice"
+}
+
+@test "Run a build with a repository" {
+  export BUILDKITE_JOB_ID=1111
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD=myservice
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_IMAGE_REPOSITORY=my.repository/llamas
+  export BUILDKITE_PIPELINE_SLUG=test
+  export BUILDKITE_BUILD_NUMBER=1
+
+  stub docker-compose \
+    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml build myservice : echo built myservice" \
+    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml push myservice : echo pushed myservice" \
+
+  stub buildkite-agent \
+    "meta-data set docker-compose-plugin-built-image-tag-myservice my.repository/llamas:test-myservice-build-1 : echo set metadata"
+
+  run $PWD/hooks/command
+
+  unstub docker-compose
+  unstub buildkite-agent
+  assert_success
+  assert_output --partial "built myservice"
+  assert_output --partial "pushed myservice"
+  assert_output --partial "set metadata"
+}

--- a/tests/docker-compose-cleanup.bats
+++ b/tests/docker-compose-cleanup.bats
@@ -1,5 +1,6 @@
 #!/usr/bin/env bats
 
+load '/usr/local/lib/bats/load.bash'
 load '../lib/shared'
 load '../lib/run'
 
@@ -8,10 +9,11 @@ load '../lib/run'
     echo "$@"
   }
   run compose_cleanup
-  [ "$status" -eq 0 ]
-  [ "${lines[0]}" = "kill" ]
-  [ "${lines[1]}" = "rm --force -v" ]
-  [ "${lines[2]}" = "down --volumes" ]
+
+  assert_success
+  assert_equal "${lines[0]}" "kill"
+  assert_equal "${lines[1]}" "rm --force -v"
+  assert_equal "${lines[2]}" "down --volumes"
 }
 
 @test "Possible to skip volume destruction in docker-compose cleanup" {
@@ -20,8 +22,9 @@ load '../lib/run'
     echo "$@"
   }
   run compose_cleanup
-  [ "$status" -eq 0 ]
-  [ "${lines[0]}" = "kill" ]
-  [ "${lines[1]}" = "rm --force" ]
-  [ "${lines[2]}" = "down" ]
+
+  assert_success
+  assert_equal "${lines[0]}" "kill"
+  assert_equal "${lines[1]}" "rm --force"
+  assert_equal "${lines[2]}" "down"
 }

--- a/tests/docker-compose-config.bats
+++ b/tests/docker-compose-config.bats
@@ -1,7 +1,6 @@
 #!/usr/bin/env bats
 
-load '/usr/local/lib/bats-support/load.bash'
-load '/usr/local/lib/bats-assert/load.bash'
+load '/usr/local/lib/bats/load.bash'
 load '../lib/shared'
 
 @test "Read docker-compose config when none exists" {

--- a/tests/docker-compose-config.bats
+++ b/tests/docker-compose-config.bats
@@ -1,17 +1,21 @@
 #!/usr/bin/env bats
 
+load '/usr/local/lib/bats-support/load.bash'
+load '/usr/local/lib/bats-assert/load.bash'
 load '../lib/shared'
 
 @test "Read docker-compose config when none exists" {
   run docker_compose_config_files
-  [ "$status" -eq 0 ]
-  [ "$output" == "docker-compose.yml" ]
+
+  assert_success
+  assert_output "docker-compose.yml"
 }
 
 @test "Read the first docker-compose config when none exists" {
   run docker_compose_config_file
-  [ "$status" -eq 0 ]
-  [ "$output" == "docker-compose.yml" ]
+
+  assert_success
+  assert_output "docker-compose.yml"
 }
 
 @test "Read docker-compose config when there are several" {
@@ -19,10 +23,11 @@ load '../lib/shared'
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CONFIG_1="llamas2.yml"
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CONFIG_2="llamas3.yml"
   run docker_compose_config_files
-  [ "$status" -eq 0 ]
-  [ "${lines[0]}" == "llamas1.yml" ]
-  [ "${lines[1]}" == "llamas2.yml" ]
-  [ "${lines[2]}" == "llamas3.yml" ]
+
+  assert_success
+  assert_equal "${lines[0]}" "llamas1.yml"
+  assert_equal "${lines[1]}" "llamas2.yml"
+  assert_equal "${lines[2]}" "llamas3.yml"
 }
 
 @test "Read the first docker-compose config when there are several" {
@@ -30,37 +35,38 @@ load '../lib/shared'
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CONFIG_1="llamas2.yml"
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CONFIG_2="llamas3.yml"
   run docker_compose_config_file
-  [ "$status" -eq 0 ]
-  [ "$output" == "llamas1.yml" ]
+
+  assert_success
+  assert_output "llamas1.yml"
 }
 
 @test "Read colon delimited config files" {
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CONFIG="llamas1.yml:llamas2.yml"
   run docker_compose_config_files
-  [ "$status" -eq 0 ]
-  [ "${lines[0]}" == "llamas1.yml" ]
-  [ "${lines[1]}" == "llamas2.yml" ]
+
+  assert_success
+  assert_equal "${lines[0]}" "llamas1.yml"
+  assert_equal "${lines[1]}" "llamas2.yml"
 }
 
 @test "Read the first docker-compose config when there are colon delimited config files" {
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CONFIG="llamas1.yml:llamas2.yml"
   run docker_compose_config_file
-  [ "$status" -eq 0 ]
-  [ "${lines[0]}" == "llamas1.yml" ]
+
+  assert_success
+  assert_output "llamas1.yml"
 }
 
 @test "Read version from docker-compose v2 file" {
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CONFIG="tests/composefiles/docker-compose.v2.0.yml"
   run docker_compose_config_version
-  echo $output
-  [ "$status" -eq 0 ]
-  [ "${lines[0]}" == "2" ]
+  assert_success
+  assert_output "2"
 }
 
 @test "Read version from docker-compose v2.1 file" {
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CONFIG="tests/composefiles/docker-compose.v2.1.yml"
   run docker_compose_config_version
-  echo $output
-  [ "$status" -eq 0 ]
-  [ "${lines[0]}" == "2.1" ]
+  assert_success
+  assert_output "2.1"
 }

--- a/tests/image-override-file.bats
+++ b/tests/image-override-file.bats
@@ -3,7 +3,7 @@
 load '/usr/local/lib/bats/load.bash'
 load '../lib/shared'
 
-myservice_override_file=$(cat <<-EOF
+myservice_override_file1=$(cat <<-EOF
 version: '2.1'
 services:
   myservice:
@@ -11,9 +11,28 @@ services:
 EOF
 )
 
+myservice_override_file2=$(cat <<-EOF
+version: '2.1'
+services:
+  myservice1:
+    image: newimage1:1.0.0
+  myservice2:
+    image: newimage2:1.0.0
+EOF
+)
+
 @test "Build an docker-compose override file" {
   run build_image_override_file_with_version "2.1" "myservice" "newimage:1.0.0"
 
   assert_success
-  assert_output "$myservice_override_file"
+  assert_output "$myservice_override_file1"
+}
+
+@test "Build an docker-compose override file with multiple entries" {
+  run build_image_override_file_with_version "2.1" \
+    "myservice1" "newimage1:1.0.0" \
+    "myservice2" "newimage2:1.0.0"
+
+  assert_success
+  assert_output "$myservice_override_file2"
 }

--- a/tests/image-override-file.bats
+++ b/tests/image-override-file.bats
@@ -1,6 +1,8 @@
 #!/usr/bin/env bats
 
 load '../lib/shared'
+load '/usr/local/lib/bats-support/load.bash'
+load '/usr/local/lib/bats-assert/load.bash'
 
 myservice_override_file=$(cat <<-EOF
 version: '2.1'
@@ -12,7 +14,7 @@ EOF
 
 @test "Build an docker-compose override file" {
   run build_image_override_file_with_version "2.1" "myservice" "newimage:1.0.0"
-  echo
-  [ "$status" -eq 0 ]
-  [ "$output" == "$myservice_override_file" ]
+
+  assert_success
+  assert_output "$myservice_override_file"
 }

--- a/tests/image-override-file.bats
+++ b/tests/image-override-file.bats
@@ -1,8 +1,7 @@
 #!/usr/bin/env bats
 
+load '/usr/local/lib/bats/load.bash'
 load '../lib/shared'
-load '/usr/local/lib/bats-support/load.bash'
-load '/usr/local/lib/bats-assert/load.bash'
 
 myservice_override_file=$(cat <<-EOF
 version: '2.1'

--- a/tests/plugin-config.bats
+++ b/tests/plugin-config.bats
@@ -1,8 +1,7 @@
 #!/usr/bin/env bats
 
+load '/usr/local/lib/bats/load.bash'
 load '../lib/shared'
-load '/usr/local/lib/bats-support/load.bash'
-load '/usr/local/lib/bats-assert/load.bash'
 
 @test "Read existing config without default" {
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RUN=llamas

--- a/tests/plugin-config.bats
+++ b/tests/plugin-config.bats
@@ -1,29 +1,35 @@
 #!/usr/bin/env bats
 
 load '../lib/shared'
+load '/usr/local/lib/bats-support/load.bash'
+load '/usr/local/lib/bats-assert/load.bash'
 
 @test "Read existing config without default" {
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RUN=llamas
   run plugin_read_config 'RUN'
-  [ "$status" -eq 0 ]
-  [ "$output" == "llamas" ]
+
+  assert_success
+  assert_output "llamas"
 }
 
 @test "Read existing config with default" {
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RUN=llamas
   run plugin_read_config 'RUN' 'blah'
-  [ "$status" -eq 0 ]
-  [ "$output" == "llamas" ]
+
+  assert_success
+  assert_output "llamas"
 }
 
 @test "Read non-existant config without default" {
   run plugin_read_config 'RUN'
-  [ "$status" -eq 0 ]
-  [ "$output" == "" ]
+
+  assert_success
+  assert_output ""
 }
 
 @test "Read non-existant config with default" {
   run plugin_read_config 'RUN' 'blah'
-  [ "$status" -eq 0 ]
-  [ "$output" == "blah" ]
+
+  assert_success
+  assert_output "blah"
 }

--- a/tests/project-name.bats
+++ b/tests/project-name.bats
@@ -1,8 +1,7 @@
 #!/usr/bin/env bats
 
+load '/usr/local/lib/bats/load.bash'
 load '../lib/shared'
-load '/usr/local/lib/bats-support/load.bash'
-load '/usr/local/lib/bats-assert/load.bash'
 
 @test "Project name comes from BUILDKITE_JOB_ID" {
   export BUILDKITE_JOB_ID=11111-1111-11111-11111

--- a/tests/project-name.bats
+++ b/tests/project-name.bats
@@ -1,10 +1,13 @@
 #!/usr/bin/env bats
 
 load '../lib/shared'
+load '/usr/local/lib/bats-support/load.bash'
+load '/usr/local/lib/bats-assert/load.bash'
 
 @test "Project name comes from BUILDKITE_JOB_ID" {
   export BUILDKITE_JOB_ID=11111-1111-11111-11111
   run docker_compose_project_name
-  [ "$status" -eq 0 ]
-  [ "$output" == "buildkite1111111111111111111" ]
+
+  assert_success
+  assert_output "buildkite1111111111111111111"
 }

--- a/tests/run.bats
+++ b/tests/run.bats
@@ -1,15 +1,17 @@
 #!/usr/bin/env bats
 
+load '/usr/local/lib/bats/load.bash'
 load '../lib/shared'
 load '../lib/run'
 
 @test "Get prebuilt image from agent metadata" {
   export HIDE_PROMPT=1
-  buildkite-agent() {
-    echo "$@"
-  }
+
+  stub buildkite-agent \
+    "meta-data get docker-compose-plugin-built-image-tag-llama : echo blah"
+
   run get_prebuilt_image_from_metadata "llama"
-  echo $output
-  [ "$status" -eq 0 ]
-  [ "$output" = "meta-data get docker-compose-plugin-built-image-tag-llama" ]
+
+  assert_success
+  assert_output "blah"
 }

--- a/tests/run.bats
+++ b/tests/run.bats
@@ -4,14 +4,107 @@ load '/usr/local/lib/bats/load.bash'
 load '../lib/shared'
 load '../lib/run'
 
-@test "Get prebuilt image from agent metadata" {
-  export HIDE_PROMPT=1
+# export DOCKER_COMPOSE_STUB_DEBUG=/dev/tty
+# export BUILDKITE_AGENT_STUB_DEBUG=/dev/tty
+# export BATS_MOCK_TMPDIR=$PWD
 
-  stub buildkite-agent \
-    "meta-data get docker-compose-plugin-built-image-tag-llama : echo blah"
-
-  run get_prebuilt_image_from_metadata "llama"
+@test "Get services from an image map" {
+  image_map=(
+    "myservice1" "myimage1"
+    "myservice2" "myimage2"
+  )
+  run get_services_from_map "${image_map[@]}"
 
   assert_success
-  assert_output "blah"
+  assert_equal "${#lines[@]}" "2"
+  assert_equal "${lines[0]}" "myservice1"
+  assert_equal "${lines[1]}" "myservice2"
+}
+
+@test "Get prebuilt images from agent metadata" {
+  stub buildkite-agent \
+    "meta-data get docker-compose-plugin-built-image-tag-0 : echo service1 image" \
+    "meta-data get docker-compose-plugin-built-image-tag-1 : echo service2 image" \
+    "meta-data get docker-compose-plugin-built-image-tag-2 : echo "
+
+  run get_prebuilt_images_from_metadata
+
+  assert_success
+  assert_output --partial "service1 image"
+  assert_output --partial "service2 image"
+  unstub buildkite-agent
+}
+
+@test "Run without a prebuilt image" {
+  export BUILDKITE_JOB_ID=1111
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RUN=myservice
+  export BUILDKITE_PIPELINE_SLUG=test
+  export BUILDKITE_BUILD_NUMBER=1
+  export BUILDKITE_COMMAND=pwd
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CHECK_LINKED_CONTAINERS=false
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLEANUP=false
+
+  stub docker-compose \
+    "-f docker-compose.yml -p buildkite1111 run myservice pwd : echo ran myservice"
+
+  stub buildkite-agent \
+    "meta-data get docker-compose-plugin-built-image-tag-0 : echo "
+
+  run $PWD/hooks/command
+
+  assert_success
+  assert_output --partial "ran myservice"
+  unstub docker-compose
+  unstub buildkite-agent
+}
+
+@test "Run with a single prebuilt image" {
+  export BUILDKITE_JOB_ID=1111
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RUN=myservice
+  export BUILDKITE_PIPELINE_SLUG=test
+  export BUILDKITE_BUILD_NUMBER=1
+  export BUILDKITE_COMMAND=pwd
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CHECK_LINKED_CONTAINERS=false
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLEANUP=false
+
+  stub docker-compose \
+    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml pull myservice : echo pulled myservice" \
+    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run myservice pwd : echo ran myservice"
+
+  stub buildkite-agent \
+    "meta-data get docker-compose-plugin-built-image-tag-0 : echo myservice myimage" \
+    "meta-data get docker-compose-plugin-built-image-tag-1 : echo "
+
+  run $PWD/hooks/command
+
+  assert_success
+  assert_output --partial "ran myservice"
+  unstub docker-compose
+  unstub buildkite-agent
+}
+
+@test "Run with multiple prebuilt image" {
+  export BUILDKITE_JOB_ID=1111
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RUN=myservice1
+  export BUILDKITE_PIPELINE_SLUG=test
+  export BUILDKITE_BUILD_NUMBER=1
+  export BUILDKITE_COMMAND=pwd
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CHECK_LINKED_CONTAINERS=false
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLEANUP=false
+
+  stub docker-compose \
+    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml pull myservice1 myservice2 : echo pulled services" \
+    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run myservice1 pwd : echo ran myservice"
+
+  stub buildkite-agent \
+    "meta-data get docker-compose-plugin-built-image-tag-0 : echo myservice1 myimage" \
+    "meta-data get docker-compose-plugin-built-image-tag-1 : echo myservice2 myimage " \
+    "meta-data get docker-compose-plugin-built-image-tag-2 : echo " \
+
+  run $PWD/hooks/command
+
+  assert_success
+  assert_output --partial "ran myservice"
+  unstub docker-compose
+  unstub buildkite-agent
 }


### PR DESCRIPTION
This adds support for multiple image builds. The use-case for this is where you have multiple services that need building in one compose file:

```yml
steps:
  - name: ":docker: Build"
    agents:
      queue: docker-builder
    plugins:
      docker-compose:
        build: 
          - app
          - tests
        image-repository: index.docker.io/org/repo

  - wait

  - name: ":docker: Test"
    command: test.sh
    plugins:
      docker-compose:
        run: tests
```

This adds an additional metadata key that is numerically indexed, rather than by service name, so the run step can iterate through them. 

This also adds test coverage for build and run commands.
