### PR TITLE
Fix broken prebuild, closes #50

### DIFF
--- a/.buildkite/pipeline.sh
+++ b/.buildkite/pipeline.sh
@@ -76,4 +76,21 @@ steps:
         run: helloworldimage
         config: tests/composefiles/docker-compose.v2.1.yml
 
+  - wait
+  - label: build with image-repository
+    command: /hello
+    plugins:
+      ${BUILDKITE_REPO}#${commit}:
+        build: helloworld
+        image-repository: buildkiteci/docker-compose-buildkite-plugin
+        config: tests/composefiles/docker-compose.v2.1.yml
+
+  - wait
+  - label: run after build with pre-built image
+    command: /hello
+    plugins:
+      ${BUILDKITE_REPO}#${commit}:
+        run: helloworld
+        config: tests/composefiles/docker-compose.v2.1.yml
+
 YAML

--- a/hooks/command
+++ b/hooks/command
@@ -4,6 +4,7 @@ set -ueo pipefail
 DIR="$(cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd)"
 
 . "$DIR/../lib/shared.bash"
+. "$DIR/../lib/metadata.bash"
 
 if [[ -n "$(plugin_read_list BUILD)" ]]; then
   . "$DIR/commands/build.sh"

--- a/hooks/commands/build.sh
+++ b/hooks/commands/build.sh
@@ -31,9 +31,11 @@ if [[ -n "$image_repository" ]]; then
 
   i=0
   while [[ ${#build_images[@]} -gt 0 ]] ; do
-    plugin_set_build_image_metadata "${build_images[@]:0:2}"
-    plugin_set_build_image_metadata "$i" "${build_images[@]:1:2}"
+    plugin_set_metadata "built-image-tag-${build_images[0]}" "${build_images[1]}"
+    plugin_set_metadata "built-image-tag-${i}" "${build_images[0]}"
     build_images=("${build_images[@]:2}")
     i=$((i+1))
   done
+
+  plugin_set_metadata "built-image-count" "$i"
 fi

--- a/hooks/commands/run.sh
+++ b/hooks/commands/run.sh
@@ -17,9 +17,10 @@ fi
 test -f "$override_file" && rm "$override_file"
 
 built_images=( $(get_prebuilt_images_from_metadata) )
+echo "~~~ :docker: Found ${#built_images[@]} pre-built services"
 
 if [[ ${#built_images[@]} -gt 0 ]] ; then
-  echo "~~~ :docker: Creating a modified docker-compose config for pre-built images"
+  echo "~~~ :docker: Creating a modified docker-compose config for pre-built images" >&2;
   build_image_override_file "${built_images[@]}" | tee "$override_file"
   built_services=( $(get_services_from_map "${built_images[@]}") )
 
@@ -27,7 +28,7 @@ if [[ ${#built_images[@]} -gt 0 ]] ; then
   run_docker_compose -f "$override_file" pull "${built_services[@]}"
 fi
 
-echo "+++ :docker: Running command in Docker Compose service: $service_name"
+echo "+++ :docker: Running command in Docker Compose service: $service_name" >&2;
 set +e
 
 # $BUILDKITE_COMMAND needs to be unquoted because:

--- a/hooks/commands/run.sh
+++ b/hooks/commands/run.sh
@@ -17,7 +17,8 @@ fi
 test -f "$override_file" && rm "$override_file"
 
 built_images=( $(get_prebuilt_images_from_metadata) )
-echo "~~~ :docker: Found ${#built_images[@]} pre-built services"
+
+echo "~~~ :docker: Found $((${#built_images[@]}/2)) pre-built services"
 
 if [[ ${#built_images[@]} -gt 0 ]] ; then
   echo "~~~ :docker: Creating a modified docker-compose config for pre-built images" >&2;

--- a/lib/metadata.bash
+++ b/lib/metadata.bash
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+readonly META_IMAGE_COUNT=built-image-count
+readonly META_IMAGE_TAG_IDX=built-image-tag-
+readonly META_IMAGE_TAG=built-image-tag-
+
+# Read agent metadata for the plugin
+function plugin_get_metadata() {
+  local key="docker-compose-plugin-$1"
+  plugin_prompt buildkite-agent meta-data get "$key"
+  buildkite-agent meta-data get "$key"
+}
+
+# Write agent metadata for the plugin
+function plugin_set_metadata() {
+  local key="docker-compose-plugin-$1"
+  local value="$2"
+  plugin_prompt_and_must_run buildkite-agent meta-data set "$key" "$value"
+}
+
+# Gets a list of service / image pairs, each pair on a newline, delimited by space
+function get_prebuilt_images_from_metadata() {
+  local service
+  local image
+  local count
+  count=$(plugin_get_metadata "$META_IMAGE_COUNT")
+
+  [[ $count -gt 0 ]] || return 0
+
+  for i in $(seq 0 $((count-1))) ; do
+    service="$(plugin_get_metadata "${META_IMAGE_TAG_IDX}${i}")"
+    image="$(plugin_get_metadata "${META_IMAGE_TAG}${service}")"
+    echo "$service $image"
+    i=$((i+1))
+  done
+}
+
+# Helper for use with get_prebuilt_images_from_metadata
+function get_services_from_map() {
+  for ((n=1;n<$#;n++)) ; do
+    if (( $((n % 2)) == 1 )) ; then
+      echo ${!n}
+    fi
+  done
+}

--- a/lib/run.bash
+++ b/lib/run.bash
@@ -19,28 +19,6 @@ compose_cleanup() {
   fi
 }
 
-get_prebuilt_images_from_metadata() {
-  local value
-  for i in {0..10} ; do
-    if ! value="$(plugin_get_build_image_metadata "$i")" ; then
-      return $?
-    fi
-    if [[ -z "$value" ]] ; then
-      break
-    fi
-    echo "$value"
-    i=$((i+1))
-  done
-}
-
-get_services_from_map() {
-  for ((n=1;n<$#;n++)) ; do
-    if (( $((n % 2)) == 1 )) ; then
-      echo ${!n}
-    fi
-  done
-}
-
 list_linked_containers() {
   for container_id in $(HIDE_PROMPT=1 run_docker_compose ps -q); do
     docker inspect --format='{{.Name}}' "$container_id"

--- a/lib/shared.bash
+++ b/lib/shared.bash
@@ -27,22 +27,6 @@ function plugin_read_config() {
   echo "${!var:-$default}"
 }
 
-# Read agent metadata for pre-built images
-function plugin_get_build_image_metadata() {
-  local service="$1"
-  local key="docker-compose-plugin-built-image-tag-${service}"
-  plugin_prompt buildkite-agent meta-data get "$key"
-  buildkite-agent meta-data get "$key"
-}
-
-# Write agent metadata for pre-built images
-function plugin_set_build_image_metadata() {
-  local service="$1"
-  local value="$2"
-  plugin_prompt_and_must_run buildkite-agent meta-data set \
-    "docker-compose-plugin-built-image-tag-${service}" "$value"
-}
-
 # Reads either a value or a list from plugin config
 function plugin_read_list() {
   local prefix="BUILDKITE_PLUGIN_DOCKER_COMPOSE_$1"

--- a/tests/build.bats
+++ b/tests/build.bats
@@ -35,16 +35,18 @@ load '../lib/shared'
     "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml push myservice : echo pushed myservice" \
 
   stub buildkite-agent \
-    "meta-data set docker-compose-plugin-built-image-tag-myservice my.repository/llamas:test-myservice-build-1 : echo set legacy metadata" \
-    "meta-data set docker-compose-plugin-built-image-tag-0 my.repository/llamas:test-myservice-build-1 : echo set metadata 0"
+    "meta-data set docker-compose-plugin-built-image-tag-myservice my.repository/llamas:test-myservice-build-1 : echo set image metadata 0" \
+    "meta-data set docker-compose-plugin-built-image-tag-0 myservice : echo set key metadata 0 " \
+    "meta-data set docker-compose-plugin-built-image-count 1 : echo set image count"
 
   run $PWD/hooks/command
 
   assert_success
   assert_output --partial "built myservice"
   assert_output --partial "pushed myservice"
-  assert_output --partial "set legacy metadata"
-  assert_output --partial "set metadata 0"
+  assert_output --partial "set image metadata 0"
+  assert_output --partial "set key metadata 0"
+  assert_output --partial "set image count"
   unstub docker-compose
   unstub buildkite-agent
 }
@@ -62,20 +64,22 @@ load '../lib/shared'
     "-f docker-compose.yml -p buildkite1112 -f docker-compose.buildkite-1-override.yml push myservice1 myservice2 : echo pushed all services" \
 
   stub buildkite-agent \
-    "meta-data set docker-compose-plugin-built-image-tag-myservice1 my.repository/llamas:test-myservice1-build-1 : echo set legacy metadata 1" \
-    "meta-data set docker-compose-plugin-built-image-tag-0 my.repository/llamas:test-myservice1-build-1 : echo set metadata 0" \
-    "meta-data set docker-compose-plugin-built-image-tag-myservice2 my.repository/llamas:test-myservice2-build-1 : echo set legacy metadata 2" \
-    "meta-data set docker-compose-plugin-built-image-tag-1 my.repository/llamas:test-myservice2-build-1 : echo set metadata 1"
+    "meta-data set docker-compose-plugin-built-image-tag-myservice1 my.repository/llamas:test-myservice1-build-1 : echo set image metadata 0" \
+    "meta-data set docker-compose-plugin-built-image-tag-0 myservice1 : echo set key metadata 0" \
+    "meta-data set docker-compose-plugin-built-image-tag-myservice2 my.repository/llamas:test-myservice2-build-1 : echo set image metadata 1" \
+    "meta-data set docker-compose-plugin-built-image-tag-1 myservice2 : echo set key metadata 1" \
+    "meta-data set docker-compose-plugin-built-image-count 2 : echo set image count"
 
   run $PWD/hooks/command
 
   assert_success
   assert_output --partial "built all services"
   assert_output --partial "pushed all services"
-  assert_output --partial "set legacy metadata 1"
-  assert_output --partial "set legacy metadata 2"
-  assert_output --partial "set metadata 0"
-  assert_output --partial "set metadata 1"
+  assert_output --partial "set image metadata 0"
+  assert_output --partial "set key metadata 0"
+  assert_output --partial "set image metadata 1"
+  assert_output --partial "set key metadata 1"
+  assert_output --partial "set image count"
   unstub docker-compose
   unstub buildkite-agent
 }

--- a/tests/prebuilt-image-metadata.bats
+++ b/tests/prebuilt-image-metadata.bats
@@ -1,0 +1,46 @@
+
+#!/usr/bin/env bats
+
+load '/usr/local/lib/bats/load.bash'
+load '../lib/shared'
+load '../lib/metadata'
+
+@test "Get prebuilt images from agent metadata (two images)" {
+  stub buildkite-agent \
+    "meta-data get docker-compose-plugin-built-image-count : echo 2" \
+    "meta-data get docker-compose-plugin-built-image-tag-0 : echo service1" \
+    "meta-data get docker-compose-plugin-built-image-tag-service1 : echo image" \
+    "meta-data get docker-compose-plugin-built-image-tag-1 : echo service2" \
+    "meta-data get docker-compose-plugin-built-image-tag-service2 : echo image "
+
+  run get_prebuilt_images_from_metadata
+
+  assert_success
+  assert_output --partial "service1 image"
+  assert_output --partial "service2 image"
+  unstub buildkite-agent
+}
+
+@test "Get prebuilt images from agent metadata (no images)" {
+  stub buildkite-agent \
+    "meta-data get docker-compose-plugin-built-image-count : echo 0"
+
+  run get_prebuilt_images_from_metadata
+
+  assert_success
+  unstub buildkite-agent
+}
+
+@test "Get services from an image map" {
+  image_map=(
+    "myservice1" "myimage1"
+    "myservice2" "myimage2"
+  )
+  run get_services_from_map "${image_map[@]}"
+
+  assert_success
+  assert_equal "${#lines[@]}" "2"
+  assert_equal "${lines[0]}" "myservice1"
+  assert_equal "${lines[1]}" "myservice2"
+}
+

--- a/tests/run.bats
+++ b/tests/run.bats
@@ -8,33 +8,6 @@ load '../lib/run'
 # export BUILDKITE_AGENT_STUB_DEBUG=/dev/tty
 # export BATS_MOCK_TMPDIR=$PWD
 
-@test "Get services from an image map" {
-  image_map=(
-    "myservice1" "myimage1"
-    "myservice2" "myimage2"
-  )
-  run get_services_from_map "${image_map[@]}"
-
-  assert_success
-  assert_equal "${#lines[@]}" "2"
-  assert_equal "${lines[0]}" "myservice1"
-  assert_equal "${lines[1]}" "myservice2"
-}
-
-@test "Get prebuilt images from agent metadata" {
-  stub buildkite-agent \
-    "meta-data get docker-compose-plugin-built-image-tag-0 : echo service1 image" \
-    "meta-data get docker-compose-plugin-built-image-tag-1 : echo service2 image" \
-    "meta-data get docker-compose-plugin-built-image-tag-2 : echo "
-
-  run get_prebuilt_images_from_metadata
-
-  assert_success
-  assert_output --partial "service1 image"
-  assert_output --partial "service2 image"
-  unstub buildkite-agent
-}
-
 @test "Run without a prebuilt image" {
   export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RUN=myservice
@@ -48,7 +21,7 @@ load '../lib/run'
     "-f docker-compose.yml -p buildkite1111 run myservice pwd : echo ran myservice"
 
   stub buildkite-agent \
-    "meta-data get docker-compose-plugin-built-image-tag-0 : echo "
+    "meta-data get docker-compose-plugin-built-image-count : echo 0"
 
   run $PWD/hooks/command
 
@@ -72,8 +45,9 @@ load '../lib/run'
     "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run myservice pwd : echo ran myservice"
 
   stub buildkite-agent \
-    "meta-data get docker-compose-plugin-built-image-tag-0 : echo myservice myimage" \
-    "meta-data get docker-compose-plugin-built-image-tag-1 : echo "
+    "meta-data get docker-compose-plugin-built-image-count : echo 1" \
+    "meta-data get docker-compose-plugin-built-image-tag-0 : echo myservice" \
+    "meta-data get docker-compose-plugin-built-image-tag-myservice : echo myimage"
 
   run $PWD/hooks/command
 
@@ -97,9 +71,11 @@ load '../lib/run'
     "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run myservice1 pwd : echo ran myservice"
 
   stub buildkite-agent \
-    "meta-data get docker-compose-plugin-built-image-tag-0 : echo myservice1 myimage" \
-    "meta-data get docker-compose-plugin-built-image-tag-1 : echo myservice2 myimage " \
-    "meta-data get docker-compose-plugin-built-image-tag-2 : echo " \
+    "meta-data get docker-compose-plugin-built-image-count : echo 2" \
+    "meta-data get docker-compose-plugin-built-image-tag-0 : echo myservice1" \
+    "meta-data get docker-compose-plugin-built-image-tag-myservice1 : echo myimage" \
+    "meta-data get docker-compose-plugin-built-image-tag-1 : echo myservice2" \
+    "meta-data get docker-compose-plugin-built-image-tag-myservice2 : echo myimage"
 
   run $PWD/hooks/command
 


### PR DESCRIPTION
The first attempt at this iterated over tag-idx and looked for space delimited service/image pairs. This was clunky and relied on failure modes from the agent. This broke in practice. This new approach takes advantage of the older tag-service format and simply adds a count and
a numerically indexed service name.