### PR TITLE
Add support for push command

### DIFF
--- a/.buildkite/pipeline.sh
+++ b/.buildkite/pipeline.sh
@@ -79,7 +79,6 @@ steps:
 
   - wait
   - label: build with custom image-name
-    command: /hello
     plugins:
       ${BUILDKITE_REPO}#${commit}:
         build: helloworld
@@ -93,6 +92,13 @@ steps:
     plugins:
       ${BUILDKITE_REPO}#${commit}:
         run: helloworld
+        config: tests/composefiles/docker-compose.v2.1.yml
+
+  - wait
+  - label: push after build with custom image-name
+    plugins:
+      ${BUILDKITE_REPO}#${commit}:
+        push: helloworld
         config: tests/composefiles/docker-compose.v2.1.yml
 
 YAML

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,8 @@ RUN mkdir -p /usr/local/lib/bats/bats-mock \
     && printf 'source "%s"\n' "/usr/local/lib/bats/bats-mock/stub.bash" >> /usr/local/lib/bats/load.bash \
     && rm -rf /tmp/bats-mock.tgz
 
+RUN apk --no-cache add ncurses
+
 WORKDIR /app
 ENTRYPOINT ["/usr/local/bin/bats"]
 CMD ["tests/"]

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2015 Buildkite
+Copyright (c) 2017 Buildkite
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -169,8 +169,6 @@ The name of the service the command should be run within. If the docker-compose 
 
 A list of services to push in the format `service:image:tag`. If an image has been pre-built with the build step, that image will be re-tagged, otherwise docker-compose's built in push operation will be used. 
 
-Be aware that there is a race condition on tagging prebuilt images and pushing them if multiple push steps run in parallel. It's advisable to use a concurrency group in this situation.
-
 ### `config` (optional)
 
 The file name of the Docker Compose configuration file to use. Can also be a list of filenames.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A [Buildkite](https://buildkite.com/) plugin allowing you to create a build syst
 * Containers are built, run and linked on demand using Docker Compose
 * Containers are namespaced to each build job, and cleaned up after use
 * Supports pre-building of images, allowing for fast parallel builds across distributed agents
-* Supports pushing images to a repository
+* Supports pushing tagged images to a repository
 
 ## Example
 
@@ -138,7 +138,7 @@ steps:
         run: tests
 ```
 
-## Pushing Images
+## Pushing Tagged Images
 
 Prebuilt images are automatically pushed with a `build` step, but often you want to finally push your images, perhaps ready for deployment.
 
@@ -148,7 +148,7 @@ steps:
     plugins:
       docker-compose#v1.2.1:
         push: 
-        - app:index.docker.io/org/repo/myapp:
+        - app:index.docker.io/org/repo/myapp
         - app:index.docker.io/org/repo/myapp:latest
 ```
 
@@ -168,6 +168,8 @@ The name of the service the command should be run within. If the docker-compose 
 ### `push`
 
 A list of services to push in the format `service:image:tag`. If an image has been pre-built with the build step, that image will be re-tagged, otherwise docker-compose's built in push operation will be used. 
+
+Be aware that there is a race condition on tagging prebuilt images and pushing them if multiple push steps run in parallel. It's advisable to use a concurrency group in this situation.
 
 ### `config` (optional)
 

--- a/hooks/command
+++ b/hooks/command
@@ -11,6 +11,8 @@ if [[ -n "$(plugin_read_list BUILD)" ]]; then
 elif [[ -n "$(plugin_read_config RUN)" ]]; then
   . "$DIR/../lib/run.bash"
   . "$DIR/commands/run.sh"
+elif [[ -n "$(plugin_read_list PUSH)" ]]; then
+  . "$DIR/commands/push.sh"
 else
   echo "+++ Docker Compose plugin error"
   echo "No build or run options were specified"

--- a/hooks/commands/build.sh
+++ b/hooks/commands/build.sh
@@ -1,12 +1,12 @@
 #!/bin/bash
+set -ueo pipefail
 
 image_repository="$(plugin_read_config IMAGE_REPOSITORY)"
 override_file="docker-compose.buildkite-${BUILDKITE_BUILD_NUMBER}-override.yml"
 build_images=()
 
 for service_name in $(plugin_read_list BUILD) ; do
-  image_name_default="${BUILDKITE_PIPELINE_SLUG}-${service_name}-build-${BUILDKITE_BUILD_NUMBER}"
-  image_name="$(plugin_read_config IMAGE_NAME "$image_name_default")"
+  image_name=$(build_image_name "${service_name}")
 
   if [[ -n "$image_repository" ]]; then
     image_name="${image_repository}:${image_name}"

--- a/hooks/commands/push.sh
+++ b/hooks/commands/push.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+set -ueo pipefail
+
+# First we need to pull down any prebuilt images and tag them as the
+# correct thing for pushing
+override_file="docker-compose.buildkite-${BUILDKITE_BUILD_NUMBER}-override.yml"
+built_images=( $(get_prebuilt_images_from_metadata) )
+built_services=()
+
+echo "~~~ :docker: Found $((${#built_images[@]}/2)) pre-built services" >&2;
+
+if [[ ${#built_images[@]} -gt 0 ]] ; then
+  echo "~~~ :docker: Creating a modified docker-compose config for pre-built images" >&2;
+  build_image_override_file "${built_images[@]}" | tee "$override_file"
+  built_services=( $(get_services_from_map "${built_images[@]}") )
+
+  echo "~~~ :docker: Pulling pre-built services ${built_services[*]}" >&2;
+  run_docker_compose -f "$override_file" pull "${built_services[@]}"
+fi
+
+push_images=()
+push_services=()
+
+# Then we figure out what to push, and where
+for line in $(plugin_read_list PUSH) ; do
+  IFS=':' read -a tokens <<< "$line"
+  service=${tokens[0]}
+  push_services+=(${tokens[0]})
+
+  # two or three tokens is a service:image(:tag) combo
+  if [[ ${#tokens[@]} -gt 1 ]] ; then
+     image="$(IFS=:; echo "${tokens[*]:1}")"
+     prebuilt_image=
+
+    # if the service is prebuilt, tag the prebuilt image to match
+    if prebuilt_image=$(get_prebuilt_image "$service" "${built_images[@]}") ; then
+      docker tag "$prebuilt_image" "$image"
+    fi
+
+    push_images+=("$service" "$(IFS=:; echo "${tokens[*]:1}")")
+  fi
+done
+
+if [[ ${#push_images[@]} -gt 0 ]] ; then
+  echo "~~~ :docker: Creating a modified docker-compose config for pushing" >&2;
+  build_image_override_file "${push_images[@]}" | tee "$override_file"
+fi
+
+echo "~~~ :docker: Pushing services ${push_services[*]}"
+
+if [[ -f "$override_file" ]]; then
+  run_docker_compose -f "$override_file" push "${push_services[@]}"
+else
+  run_docker_compose push "${push_services[@]}"
+fi

--- a/hooks/commands/push.sh
+++ b/hooks/commands/push.sh
@@ -10,6 +10,8 @@ built_services=()
 echo "~~~ :docker: Found $((${#built_images[@]}/2)) pre-built services" >&2;
 
 if [[ ${#built_images[@]} -gt 0 ]] ; then
+  printf "%s => %s\n" "${built_images[@]}"
+
   echo "~~~ :docker: Creating a modified docker-compose config for pre-built images" >&2;
   build_image_override_file "${built_images[@]}" | tee "$override_file"
   built_services=( $(get_services_from_map "${built_images[@]}") )

--- a/hooks/commands/run.sh
+++ b/hooks/commands/run.sh
@@ -21,6 +21,8 @@ built_images=( $(get_prebuilt_images_from_metadata) )
 echo "~~~ :docker: Found $((${#built_images[@]}/2)) pre-built services"
 
 if [[ ${#built_images[@]} -gt 0 ]] ; then
+  printf "%s => %s\n" "${built_images[@]}"
+
   echo "~~~ :docker: Creating a modified docker-compose config for pre-built images" >&2;
   build_image_override_file "${built_images[@]}" | tee "$override_file"
   built_services=( $(get_services_from_map "${built_images[@]}") )

--- a/hooks/commands/run.sh
+++ b/hooks/commands/run.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
-set -eu
+set -ueo pipefail
 
 service_name="$(plugin_read_config RUN)"
 override_file="docker-compose.buildkite-${BUILDKITE_BUILD_NUMBER}-override.yml"
 
 cleanup() {
-  echo "~~~ :docker: Cleaning up after docker-compose"
+  echo "~~~ :docker: Cleaning up after docker-compose" >&2
   compose_cleanup
 }
 

--- a/lib/metadata.bash
+++ b/lib/metadata.bash
@@ -43,3 +43,18 @@ function get_services_from_map() {
     fi
   done
 }
+
+function get_prebuilt_image() {
+  local service="$1"
+  shift
+
+  for ((n=1;n<$#;n++)) ; do
+    if (( $((n % 2)) == 1 )) && [ "${!n}" == "$service" ]; then
+      imagevar=$((n+1))
+      echo ${!imagevar}
+      return 0
+    fi
+  done
+
+  return 1
+}

--- a/lib/shared.bash
+++ b/lib/shared.bash
@@ -51,12 +51,6 @@ function docker_compose_project_name() {
   echo "buildkite${BUILDKITE_JOB_ID//-}"
 }
 
-# Returns the name of the docker compose container that corresponds to the
-# given service
-function docker_compose_container_name() {
-  echo "$(docker_compose_project_name)_$1"
-}
-
 # Returns all docker compose config file names split by newlines
 function docker_compose_config_files() {
   config_files=( $( plugin_read_list CONFIG ) )
@@ -120,4 +114,10 @@ function run_docker_compose() {
   command+=(-p "$(docker_compose_project_name)")
 
   plugin_prompt_and_run "${command[@]}" "$@"
+}
+
+function build_image_name() {
+  local service_name="$1"
+  local default="${BUILDKITE_PIPELINE_SLUG}-${service_name}-build-${BUILDKITE_BUILD_NUMBER}"
+  plugin_read_config IMAGE_NAME "$default"
 }

--- a/tests/prebuilt-image-metadata.bats
+++ b/tests/prebuilt-image-metadata.bats
@@ -44,3 +44,16 @@ load '../lib/metadata'
   assert_equal "${lines[1]}" "myservice2"
 }
 
+
+@test "Get prebuilt image for service from an image map" {
+  image_map=(
+    "myservice1" "myimage1"
+    "myservice2" "myimage2"
+  )
+
+  run get_prebuilt_image "myservice1" "${image_map[@]}"
+  assert_success
+  assert_output "myimage1"
+
+  refute get_prebuilt_image "missingservice" "${image_map[@]}"
+}

--- a/tests/push.bats
+++ b/tests/push.bats
@@ -1,0 +1,90 @@
+#!/usr/bin/env bats
+
+load '/usr/local/lib/bats/load.bash'
+load '../lib/shared'
+
+# export DOCKER_COMPOSE_STUB_DEBUG=/dev/tty
+# export BUILDKITE_AGENT_STUB_DEBUG=/dev/tty
+# export BATS_MOCK_TMPDIR=$PWD
+
+setup() {
+  if [[ -f docker-compose.buildkite-1-override.yml ]]; then
+    rm docker-compose.buildkite-1-override.yml
+  fi
+}
+
+@test "Push a single image" {
+  export BUILDKITE_JOB_ID=1111
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_PUSH=myservice
+  export BUILDKITE_PIPELINE_SLUG=test
+  export BUILDKITE_BUILD_NUMBER=1
+
+  stub buildkite-agent \
+    "meta-data get docker-compose-plugin-built-image-count : echo 0"
+
+  stub docker-compose \
+    "-f docker-compose.yml -p buildkite1111 push myservice : echo pushed myservice"
+
+  run $PWD/hooks/command
+
+  assert_success
+  assert_file_not_exist "docker-compose.buildkite-1-override.yml"
+  assert_output --partial "pushed myservice"
+  unstub docker-compose
+  unstub buildkite-agent
+}
+
+@test "Push two images with a repository and a tag" {
+  export BUILDKITE_JOB_ID=1111
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_PUSH_0=myservice1:my.repository/myservice1
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_PUSH_1=myservice2:my.repository/myservice2:llamas
+  export BUILDKITE_PIPELINE_SLUG=test
+  export BUILDKITE_BUILD_NUMBER=1
+
+  stub docker-compose \
+    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml push myservice1 myservice2 : echo pushed myservices"
+
+  stub buildkite-agent \
+    "meta-data get docker-compose-plugin-built-image-count : echo 0"
+
+  run $PWD/hooks/command
+
+  assert_success
+  assert_output --partial "pushed myservices"
+  assert_file_exist "docker-compose.buildkite-1-override.yml"
+  assert grep -q "image: my.repository/myservice1" docker-compose.buildkite-1-override.yml
+  assert grep -q "image: my.repository/myservice2:llamas" docker-compose.buildkite-1-override.yml
+  unstub docker-compose
+  unstub buildkite-agent
+}
+
+@test "Push a prebuilt image with a repository and a tag" {
+  export BUILDKITE_JOB_ID=1111
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_PUSH=myservice:my.repository/myservice:llamas
+  export BUILDKITE_PIPELINE_SLUG=test
+  export BUILDKITE_BUILD_NUMBER=1
+
+  stub docker \
+    "tag myimage:blahblah my.repository/myservice:llamas : echo tagged image"
+
+  stub docker-compose \
+    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml pull myservice : echo pulled prebuilt image" \
+    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml push myservice : echo pushed myservice"
+
+  stub buildkite-agent \
+    "meta-data get docker-compose-plugin-built-image-count : echo 1" \
+    "meta-data get docker-compose-plugin-built-image-tag-0 : echo myservice" \
+    "meta-data get docker-compose-plugin-built-image-tag-myservice : echo myimage:blahblah"
+
+  run $PWD/hooks/command
+
+  assert_success
+  assert_output --partial "pulled prebuilt image"
+  assert_output --partial "tagged image"
+  assert_output --partial "pushed myservice"
+  assert_file_exist "docker-compose.buildkite-1-override.yml"
+  assert grep -q "image: my.repository/myservice:llamas" docker-compose.buildkite-1-override.yml
+  unstub docker-compose
+  unstub docker
+  unstub buildkite-agent
+}


### PR DESCRIPTION
This allows for a step that pushes your images to an upstream repository.

```yml
steps:
  - name: ":docker: Push to final repository"
    plugins:
      docker-compose#v1.2.1:
        push: 
        - app:index.docker.io/org/repo/myapp
        - app:index.docker.io/org/repo/myapp:latest
```

Interestingly, this was the most complicated of the three commands. The scenario where there are prebuilt images and you are wanting to tag and push those images gets complicated.