### PR TITLE
Build services first if they need it before push

### DIFF
--- a/lib/push.bash
+++ b/lib/push.bash
@@ -23,3 +23,8 @@ default_compose_image_for_service() {
 
   printf "%s_%s\n" "$(docker_compose_project_name)" "$service"
 }
+
+docker_image_exists() {
+  local image="$1"
+  plugin_prompt_and_run docker image inspect "${image}" &> /dev/null
+}


### PR DESCRIPTION
The current version exits with an error if the image doesn't exist, but it makes more sense to build it and then push it.