### PR TITLE
Build a service before run if there is no prebuilt image

### DIFF
--- a/hooks/commands/run.sh
+++ b/hooks/commands/run.sh
@@ -43,6 +43,7 @@ set +e
 if [[ -f "$override_file" ]]; then
   run_docker_compose -f "$override_file" run "$service_name" $BUILDKITE_COMMAND
 else
+  run_docker_compose build "$service_name"
   run_docker_compose run "$service_name" $BUILDKITE_COMMAND
 fi
 

--- a/hooks/commands/run.sh
+++ b/hooks/commands/run.sh
@@ -43,7 +43,7 @@ set +e
 if [[ -f "$override_file" ]]; then
   run_docker_compose -f "$override_file" run "$service_name" $BUILDKITE_COMMAND
 else
-  run_docker_compose build "$service_name"
+  run_docker_compose build --pull "$service_name"
   run_docker_compose run "$service_name" $BUILDKITE_COMMAND
 fi
 

--- a/tests/run.bats
+++ b/tests/run.bats
@@ -18,7 +18,7 @@ load '../lib/run'
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLEANUP=false
 
   stub docker-compose \
-    "-f docker-compose.yml -p buildkite1111 build myservice : echo built myservice" \
+    "-f docker-compose.yml -p buildkite1111 build --pull myservice : echo built myservice" \
     "-f docker-compose.yml -p buildkite1111 run myservice pwd : echo ran myservice"
 
   stub buildkite-agent \

--- a/tests/run.bats
+++ b/tests/run.bats
@@ -18,6 +18,7 @@ load '../lib/run'
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLEANUP=false
 
   stub docker-compose \
+    "-f docker-compose.yml -p buildkite1111 build myservice : echo built myservice" \
     "-f docker-compose.yml -p buildkite1111 run myservice pwd : echo ran myservice"
 
   stub buildkite-agent \
@@ -26,6 +27,7 @@ load '../lib/run'
   run $PWD/hooks/command
 
   assert_success
+  assert_output --partial "built myservice"
   assert_output --partial "ran myservice"
   unstub docker-compose
   unstub buildkite-agent


### PR DESCRIPTION
Currently, without a `build` step, a `run` step doesn't force a build, which can lead to confusing stale image re-use. 

This allows the use of just a `run` step that works as you would expect. 