### PR TITLE
Improve version whitespace parsing

### DIFF
--- a/lib/shared.bash
+++ b/lib/shared.bash
@@ -77,7 +77,7 @@ function docker_compose_config_file() {
 
 # Returns the version of the first docker compose config file
 function docker_compose_config_version() {
-  sed -n "s/version: ['\"]\(.*\)['\"]/\1/p" < "$(docker_compose_config_file)"
+  sed -n "s/\\s*version:\\s*['\"]\(.*\)['\"]/\1/p" < "$(docker_compose_config_file)"
 }
 
 # Build an docker-compose file that overrides the image for a set of

--- a/lib/shared.bash
+++ b/lib/shared.bash
@@ -92,6 +92,13 @@ function build_image_override_file() {
 function build_image_override_file_with_version() {
   local version="$1"
 
+  if [[ -z "$version" ]]; then
+    echo "The 'build' option can only be used with Compose file versions 2.0 and above."
+    echo "For more information on Docker Compose configuration file versions, see:"
+    echo "https://docs.docker.com/compose/compose-file/compose-versioning/#versioning"
+    exit 1
+  fi
+
   printf "version: '%s'\n" "$version"
   printf "services:\n"
 

--- a/tests/build.bats
+++ b/tests/build.bats
@@ -73,3 +73,16 @@ load '../lib/shared'
   unstub docker-compose
   unstub buildkite-agent
 }
+
+@test "Build with a docker-compose v1.0 configuration file" {
+  export BUILDKITE_JOB_ID=1112
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CONFIG="tests/composefiles/docker-compose.v1.0.yml"
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD_0=helloworld
+  export BUILDKITE_PIPELINE_SLUG=test
+  export BUILDKITE_BUILD_NUMBER=1
+
+  run $PWD/hooks/command
+
+  assert_failure
+  assert_output --partial "Compose file versions 2.0 and above"
+}

--- a/tests/composefiles/docker-compose.v1.0.yml
+++ b/tests/composefiles/docker-compose.v1.0.yml
@@ -1,0 +1,2 @@
+helloworld:
+  build: .

--- a/tests/composefiles/docker-compose.v2.0.with-version-whitespace.yml
+++ b/tests/composefiles/docker-compose.v2.0.with-version-whitespace.yml
@@ -1,0 +1,5 @@
+    version:      '2'
+
+    services:
+      helloworld:
+        build: .

--- a/tests/docker-compose-config.bats
+++ b/tests/docker-compose-config.bats
@@ -56,6 +56,13 @@ load '../lib/shared'
   assert_output "llamas1.yml"
 }
 
+@test "Read version from docker-compose file with whitespace around the version" {
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CONFIG="tests/composefiles/docker-compose.v2.0.with-version-whitespace.yml"
+  run docker_compose_config_version
+  assert_success
+  assert_output "2"
+}
+
 @test "Read version from docker-compose v2 file" {
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CONFIG="tests/composefiles/docker-compose.v2.0.yml"
   run docker_compose_config_version


### PR DESCRIPTION
Fixes the parsing of Compose files containing whitespace, and exits with a friendly error if you try to use version 1.0 configuration files (which aren't supported by the `build` command).

Fixes #67