### PR TITLE
Don't infinitely retry if no retry config set

### DIFF
--- a/lib/shared.bash
+++ b/lib/shared.bash
@@ -148,7 +148,9 @@ function retry {
   until "$@"; do
     status=$?
     echo "Exited with $status"
-    if (( attempts == retries )); then
+    if (( retries == "0" )); then
+      return $status
+    elif (( attempts == retries )); then
       echo "Failed $attempts retries"
       return $status
     else


### PR DESCRIPTION
In #58 retry support was added, but if you don't set the value of `pull-retries` or `push-retries`, they end up with a default value of `"0"` and the retry logic just counts down to negative infinity.

This fixes it by handling the "0" case.

Fixes #70