### PR TITLE
Support env parameter to docker-compose

### DIFF
--- a/.buildkite/pipeline.sh
+++ b/.buildkite/pipeline.sh
@@ -31,10 +31,14 @@ steps:
 
   - wait
   - label: run, with environment
+    command: "sh -c \"[ $$LLAMAS = always ] && [ $$TESTING = alpacas ]\""
     plugins:
       ${BUILDKITE_REPO}#${commit}:
         run: alpinewithenv
         config: tests/composefiles/docker-compose.v2.1.yml
+        environment:
+          - TESTING=alpacas
+
 
   - wait
   - label: build

--- a/.buildkite/pipeline.sh
+++ b/.buildkite/pipeline.sh
@@ -30,6 +30,13 @@ steps:
         config: tests/composefiles/docker-compose.v2.1.yml
 
   - wait
+  - label: run, with environment
+    plugins:
+      ${BUILDKITE_REPO}#${commit}:
+        run: alpinewithenv
+        config: tests/composefiles/docker-compose.v2.1.yml
+
+  - wait
   - label: build
     command: /hello
     plugins:

--- a/.buildkite/pipeline.sh
+++ b/.buildkite/pipeline.sh
@@ -31,8 +31,7 @@ steps:
 
   - wait
   - label: run, with environment
-    command:|
-      sh -c '[ $$LLAMAS = always ] && [ $$TESTING = alpacas ]'
+    command: "[ $$LLAMAS = always ] && [ $$TESTING = alpacas ]"
     plugins:
       ${BUILDKITE_REPO}#${commit}:
         run: alpinewithenv

--- a/.buildkite/pipeline.sh
+++ b/.buildkite/pipeline.sh
@@ -31,7 +31,8 @@ steps:
 
   - wait
   - label: run, with environment
-    command: "sh -c \"[ $$LLAMAS = always ] && [ $$TESTING = alpacas ]\""
+    command:|
+      sh -c '[ $$LLAMAS = always ] && [ $$TESTING = alpacas ]'
     plugins:
       ${BUILDKITE_REPO}#${commit}:
         run: alpinewithenv

--- a/.buildkite/pipeline.sh
+++ b/.buildkite/pipeline.sh
@@ -31,13 +31,12 @@ steps:
 
   - wait
   - label: run, with environment
-    command: "[ $$LLAMAS = always ] && [ $$TESTING = alpacas ]"
     plugins:
       ${BUILDKITE_REPO}#${commit}:
         run: alpinewithenv
         config: tests/composefiles/docker-compose.v2.1.yml
         environment:
-          - TESTING=alpacas
+          - ALPACAS=sometimes
 
 
   - wait

--- a/README.md
+++ b/README.md
@@ -211,6 +211,11 @@ A number of times to retry failed docker push. Defaults to 0.
 
 This option can also be configured on the agent machine using the environment variable `BUILDKITE_PLUGIN_DOCKER_COMPOSE_PUSH_RETRIES`.
 
+
+### `environment` (optional)
+
+Extra environment variables to pass to docker-compose, in an array of KEY=VALUE params.
+
 ## Developing
 
 To run the tests:

--- a/README.md
+++ b/README.md
@@ -21,7 +21,8 @@ steps:
         run: app
 ```
 
-You can also specify a custom Docker Compose config file if you need:
+You can also specify a custom Docker Compose config file and what environment to pass
+through if you need:
 
 ```yml
 steps:
@@ -30,6 +31,8 @@ steps:
       docker-compose#v1.5.2:
         run: app
         config: docker-compose.tests.yml
+        env:
+          - BUILDKITE_BUILD_NUMBER
 ```
 
 or multiple config files:
@@ -66,6 +69,31 @@ Assuming your application’s directory inside the container was `/app`, you wou
 volumes:
   - "./dist:/app/dist"
 ```
+
+## Environment
+
+By default, docker-compose makes whatever environment variables it gets available for 
+interpolation of docker-compose.yml, but it doesn't pass them in to your containers. 
+
+You can use the [environent key in docker-compose.yml](https://docs.docker.com/compose/environment-variables/) to either set specific environment vars or "pass through" environment
+variables from outside docker-compose.
+
+If you want to add extra environment above what is declared in your `docker-compose.yml`, 
+this plugin offers a `environment` block of it's own:
+
+```yml
+steps:
+  - command: generate-dist.sh
+    plugins:
+      docker-compose#v1.4.0:
+        run: app
+        env:
+          - BUILDKITE_BUILD_NUMBER
+          - BUILDKITE_PULL_REQUEST
+          - MY_CUSTOM_ENV=llamas
+```
+
+Note how the values in the list can either be just a key (so the value is sourced from the environment) or a KEY=VALUE pair.
 
 ## Pre-building the image
 
@@ -193,6 +221,11 @@ The default is `${BUILDKITE_PIPELINE_SLUG}-${BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUI
 
 Note: this option can only be specified on a `build` step.
 
+### `env` or `environment` (optional)
+
+A list of either KEY or KEY=VALUE that are passed through
+as environment variables to the container.
+
 ### `verbose` (optional)
 
 Sets `docker-compose` to run with `--verbose`
@@ -210,11 +243,6 @@ This option can also be configured on the agent machine using the environment va
 A number of times to retry failed docker push. Defaults to 0.
 
 This option can also be configured on the agent machine using the environment variable `BUILDKITE_PLUGIN_DOCKER_COMPOSE_PUSH_RETRIES`.
-
-
-### `environment` (optional)
-
-Extra environment variables to pass to docker-compose, in an array of KEY=VALUE params.
 
 ## Developing
 

--- a/hooks/commands/run.sh
+++ b/hooks/commands/run.sh
@@ -40,11 +40,13 @@ set +e
 # does not work whereas the following does:
 #   docker-compose run "app" go test
 
+run_params="$(docker_compose_env_params)"
+
 if [[ -f "$override_file" ]]; then
-  run_docker_compose -f "$override_file" run "$service_name" $BUILDKITE_COMMAND
+  run_docker_compose -f "$override_file" run $run_params "$service_name" $BUILDKITE_COMMAND
 else
   run_docker_compose build --pull "$service_name"
-  run_docker_compose run "$service_name" $BUILDKITE_COMMAND
+  run_docker_compose run $run_params "$service_name" $BUILDKITE_COMMAND
 fi
 
 exitcode=$?

--- a/lib/shared.bash
+++ b/lib/shared.bash
@@ -77,7 +77,7 @@ function docker_compose_config_file() {
 
 # Returns all docker compose custom environment in the form -e "ENV=VAR"
 function docker_compose_env_params() {
-  env_vars=( $( plugin_read_list ENV ) )
+  env_vars=( $( plugin_read_list ENV ) $( plugin_read_list ENVIRONMENT ) )
 
   [[ -z "${env_vars[*]:-}" ]] && return 
 

--- a/lib/shared.bash
+++ b/lib/shared.bash
@@ -75,6 +75,17 @@ function docker_compose_config_file() {
   echo "${config_files[0]}"
 }
 
+# Returns all docker compose custom environment in the form -e "ENV=VAR"
+function docker_compose_env_params() {
+  env_vars=( $( plugin_read_list ENV ) )
+
+  [[ -z "${env_vars[*]:-}" ]] && return 
+
+  for value in "${env_vars[@]}" ; do
+    echo -n "-e $value "
+  done
+}
+
 # Returns the version of the first docker compose config file
 function docker_compose_config_version() {
   sed -n "s/\\s*version:\\s*['\"]\(.*\)['\"]/\1/p" < "$(docker_compose_config_file)"

--- a/tests/composefiles/docker-compose.v2.1.yml
+++ b/tests/composefiles/docker-compose.v2.1.yml
@@ -13,8 +13,8 @@ services:
   alpinewithenv:
     image: alpine:3.3
     environment:
-      - BLAH=${VARIABLE:-default}
-    command: "sh -c 'echo BLAH=$$BLAH'"
+      - LLAMAS=${VARIABLE:-always}
+    command: "sh -c \"[ $$LLAMAS = always ]\""
 
   alpinewithfailinglink:
     image: alpine:3.3

--- a/tests/composefiles/docker-compose.v2.1.yml
+++ b/tests/composefiles/docker-compose.v2.1.yml
@@ -15,7 +15,7 @@ services:
     environment:
       - LLAMAS=${MISSING_VARIABLE:-always}
     volumes:
-      - tests/scripts/test_env.sh:/bin/test_env.sh
+      - ./tests/scripts/test_env.sh:/bin/test_env.sh
     command: /bin/test_env.sh
 
   alpinewithfailinglink:

--- a/tests/composefiles/docker-compose.v2.1.yml
+++ b/tests/composefiles/docker-compose.v2.1.yml
@@ -15,8 +15,8 @@ services:
     environment:
       - LLAMAS=${MISSING_VARIABLE:-always}
     volumes:
-      - ./tests/scripts/test_env.sh:/bin/test_env.sh
-    command: /bin/test_env.sh
+      - ../../tests/scripts:/scripts:ro
+    command: /scripts/test_env.sh
 
   alpinewithfailinglink:
     image: alpine:3.3

--- a/tests/composefiles/docker-compose.v2.1.yml
+++ b/tests/composefiles/docker-compose.v2.1.yml
@@ -13,8 +13,10 @@ services:
   alpinewithenv:
     image: alpine:3.3
     environment:
-      - LLAMAS=${VARIABLE:-always}
-    command: "sh -c \"[ $$LLAMAS = always ]\""
+      - LLAMAS=${MISSING_VARIABLE:-always}
+    volumes:
+      - tests/scripts/test_env.sh:/bin/test_env.sh
+    command: /bin/test_env.sh
 
   alpinewithfailinglink:
     image: alpine:3.3

--- a/tests/composefiles/docker-compose.v2.1.yml
+++ b/tests/composefiles/docker-compose.v2.1.yml
@@ -14,7 +14,7 @@ services:
     image: alpine:3.3
     environment:
       - BLAH=${VARIABLE:-default}
-    command: "sh -c 'echo BLAH=\$BLAH'"
+    command: "sh -c 'echo BLAH=$$BLAH'"
 
   alpinewithfailinglink:
     image: alpine:3.3

--- a/tests/composefiles/docker-compose.v2.1.yml
+++ b/tests/composefiles/docker-compose.v2.1.yml
@@ -10,6 +10,12 @@ services:
     image: myhelloworld
     build: .
 
+  alpinewithenv:
+    image: alpine:3.3
+    environment:
+      - BLAH=${VARIABLE:-default}
+    command: "sh -c 'echo BLAH=\$BLAH'"
+
   alpinewithfailinglink:
     image: alpine:3.3
     command: echo hello from alpine

--- a/tests/run.bats
+++ b/tests/run.bats
@@ -33,6 +33,31 @@ load '../lib/run'
   unstub buildkite-agent
 }
 
+@test "Run without a prebuilt image with custom env" {
+  export BUILDKITE_JOB_ID=1111
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RUN=myservice
+  export BUILDKITE_PIPELINE_SLUG=test
+  export BUILDKITE_BUILD_NUMBER=1
+  export BUILDKITE_COMMAND=pwd
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CHECK_LINKED_CONTAINERS=false
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLEANUP=false
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_ENV_0=MYENV=0
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_ENV_1=MYENV=1
+
+  stub docker-compose \
+    "-f docker-compose.yml -p buildkite1111 run -e MYENV=0 -e MYENV=1 myservice pwd : echo ran myservice"
+
+  stub buildkite-agent \
+    "meta-data get docker-compose-plugin-built-image-tag-myservice : exit 1"
+
+  run $PWD/hooks/command
+
+  assert_success
+  assert_output --partial "ran myservice"
+  unstub docker-compose
+  unstub buildkite-agent
+}
+
 @test "Run with a prebuilt image" {
   export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RUN=myservice

--- a/tests/run.bats
+++ b/tests/run.bats
@@ -43,9 +43,11 @@ load '../lib/run'
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLEANUP=false
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_ENV_0=MYENV=0
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_ENV_1=MYENV=1
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_ENVIRONMENT_0=MYENV=2
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_ENVIRONMENT_1=MYENV=3
 
   stub docker-compose \
-    "-f docker-compose.yml -p buildkite1111 run -e MYENV=0 -e MYENV=1 myservice pwd : echo ran myservice"
+    "-f docker-compose.yml -p buildkite1111 run -e MYENV=0 -e MYENV=1 -e MYENV=2 -e MYENV=3 myservice pwd : echo ran myservice"
 
   stub buildkite-agent \
     "meta-data get docker-compose-plugin-built-image-tag-myservice : exit 1"

--- a/tests/run.bats
+++ b/tests/run.bats
@@ -42,12 +42,13 @@ load '../lib/run'
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CHECK_LINKED_CONTAINERS=false
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLEANUP=false
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_ENV_0=MYENV=0
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_ENV_1=MYENV=1
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_ENV_1=MYENV
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_ENVIRONMENT_0=MYENV=2
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_ENVIRONMENT_1=MYENV=3
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_ENVIRONMENT_1=MYENV
 
   stub docker-compose \
-    "-f docker-compose.yml -p buildkite1111 run -e MYENV=0 -e MYENV=1 -e MYENV=2 -e MYENV=3 myservice pwd : echo ran myservice"
+    "-f docker-compose.yml -p buildkite1111 build --pull myservice : echo built myservice" \
+    "-f docker-compose.yml -p buildkite1111 run -e MYENV=0 -e MYENV -e MYENV=2 -e MYENV myservice pwd : echo ran myservice"
 
   stub buildkite-agent \
     "meta-data get docker-compose-plugin-built-image-tag-myservice : exit 1"

--- a/tests/scripts/test_env.sh
+++ b/tests/scripts/test_env.sh
@@ -4,9 +4,13 @@ set -eu
 if ! [ "$LLAMAS" = always ] ; then
   echo "Expected \$LLAMAS=always, got $LLAMAS"
   exit 1
+else
+  echo "LLAMAS=always 👌🏻"
 fi
 
 if ! [ "$ALPACAS" = sometimes ] ; then
   echo "Expected \$ALPACAS=sometimes, got $ALPACAS"
   exit 1
+else
+  echo "ALPACAS=sometimes 👌🏻"
 fi

--- a/tests/scripts/test_env.sh
+++ b/tests/scripts/test_env.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+set -eu
+
+if ! [ "$LLAMAS" = always ] ; then
+  echo "Expected \$LLAMAS=always, got $LLAMAS"
+  exit 1
+fi
+
+if ! [ "$ALPACAS" = sometimes ] ; then
+  echo "Expected \$ALPACAS=sometimes, got $ALPACAS"
+  exit 1
+fi


### PR DESCRIPTION
This adds support for an `env` block that is passed in to `docker-compse run`, for instance:

```yaml
steps:
  - command: test.sh
    plugins:
      docker-compose#v1.5.2:
        run: app
        env:
          - MYENV=1
          - MYENV=2
        config:
          - docker-compose.yml
          - docker-compose.test.yml
```