### PR TITLE
Fix bug where version wasn't parsed on macOS

### DIFF
--- a/lib/shared.bash
+++ b/lib/shared.bash
@@ -66,29 +66,21 @@ function docker_compose_config_files() {
   done
 }
 
-# Returns the first docker compose config file name
-function docker_compose_config_file() {
-  if ! config_files=( $(docker_compose_config_files) ) ; then
-    echo "docker-compose.yml"
-  fi
-
-  echo "${config_files[0]}"
-}
-
 # Returns all docker compose custom environment in the form -e "ENV=VAR"
 function docker_compose_env_params() {
   env_vars=( $( plugin_read_list ENV ) $( plugin_read_list ENVIRONMENT ) )
 
-  [[ -z "${env_vars[*]:-}" ]] && return 
+  [[ -z "${env_vars[*]:-}" ]] && return
 
   for value in "${env_vars[@]}" ; do
     echo -n "-e $value "
   done
 }
 
-# Returns the version of the first docker compose config file
+# Returns the version from the output of docker_compose_config
 function docker_compose_config_version() {
-  sed -n "s/\\s*version:\\s*['\"]\(.*\)['\"]/\1/p" < "$(docker_compose_config_file)"
+  local config=($(docker_compose_config_files))
+  awk '/\s*version:/ { print $2; }' < "${config[0]}" | sed "s/[\"']//g"
 }
 
 # Build an docker-compose file that overrides the image for a set of

--- a/tests/docker-compose-config.bats
+++ b/tests/docker-compose-config.bats
@@ -10,13 +10,6 @@ load '../lib/shared'
   assert_output "docker-compose.yml"
 }
 
-@test "Read the first docker-compose config when none exists" {
-  run docker_compose_config_file
-
-  assert_success
-  assert_output "docker-compose.yml"
-}
-
 @test "Read docker-compose config when there are several" {
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CONFIG_0="llamas1.yml"
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CONFIG_1="llamas2.yml"
@@ -29,16 +22,6 @@ load '../lib/shared'
   assert_equal "${lines[2]}" "llamas3.yml"
 }
 
-@test "Read the first docker-compose config when there are several" {
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CONFIG_0="llamas1.yml"
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CONFIG_1="llamas2.yml"
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CONFIG_2="llamas3.yml"
-  run docker_compose_config_file
-
-  assert_success
-  assert_output "llamas1.yml"
-}
-
 @test "Read colon delimited config files" {
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CONFIG="llamas1.yml:llamas2.yml"
   run docker_compose_config_files
@@ -48,22 +31,14 @@ load '../lib/shared'
   assert_equal "${lines[1]}" "llamas2.yml"
 }
 
-@test "Read the first docker-compose config when there are colon delimited config files" {
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CONFIG="llamas1.yml:llamas2.yml"
-  run docker_compose_config_file
-
-  assert_success
-  assert_output "llamas1.yml"
-}
-
-@test "Read version from docker-compose file with whitespace around the version" {
+@test "Read version from docker-compose v2.0 file with whitespace around the version" {
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CONFIG="tests/composefiles/docker-compose.v2.0.with-version-whitespace.yml"
   run docker_compose_config_version
   assert_success
   assert_output "2"
 }
 
-@test "Read version from docker-compose v2 file" {
+@test "Read version from docker-compose v2.0 file" {
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CONFIG="tests/composefiles/docker-compose.v2.0.yml"
   run docker_compose_config_version
   assert_success


### PR DESCRIPTION
It seems like our mechanism for parsing version numbers didn't work on macOS. 

/cc @toolmantim 