### PR TITLE
basic cache_from support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN mkdir -p /usr/local/lib/bats/bats-mock \
     && printf 'source "%s"\n' "/usr/local/lib/bats/bats-mock/stub.bash" >> /usr/local/lib/bats/load.bash \
     && rm -rf /tmp/bats-mock.tgz
 
-RUN apk --no-cache add ncurses
+RUN apk --no-cache add ncurses bc
 
 WORKDIR /app
 ENTRYPOINT ["/usr/local/bin/bats"]

--- a/hooks/commands/build.sh
+++ b/hooks/commands/build.sh
@@ -22,6 +22,16 @@ fi
 
 services=( $(plugin_read_list BUILD) )
 
+
+for line in $(plugin_read_list CACHE_FROM) ; do
+  IFS=':' read -a tokens <<< "$line"
+  service_name=${tokens[0]}
+  service_image=$(IFS=':'; echo "${tokens[*]:1}")
+
+  echo "+++ :docker: Pulling cache image for $service_name"
+  plugin_prompt_and_run docker pull "$service_image"
+done
+
 echo "+++ :docker: Building services ${services[*]}"
 run_docker_compose -f "$override_file" build --pull "${services[@]}"
 

--- a/hooks/commands/build.sh
+++ b/hooks/commands/build.sh
@@ -2,6 +2,7 @@
 set -ueo pipefail
 
 image_repository="$(plugin_read_config IMAGE_REPOSITORY)"
+pull_retries="$(plugin_read_config PULL_RETRIES "0")"
 override_file="docker-compose.buildkite-${BUILDKITE_BUILD_NUMBER}-override.yml"
 build_images=()
 declare -A cache_from
@@ -10,12 +11,14 @@ for line in $(plugin_read_list CACHE_FROM) ; do
   IFS=':' read -a tokens <<< "$line"
   service_name=${tokens[0]}
   service_image=$(IFS=':'; echo "${tokens[*]:1}")
-  cache_from[$service_name]=$(IFS=':'; echo "$service_image")
 
-  echo "+++ :docker: Pulling cache image for $service_name"
-  plugin_prompt_and_run docker pull "$service_image"
+  echo "~~~ :docker: Pulling cache image for $service_name"
+  if retry "$pull_retries" plugin_prompt_and_run docker pull "$service_image" ; then
+    cache_from[$service_name]=$service_image
+  else
+    echo "!!! :docker: Pull failed. $service_image will not be used as a cache for $service_name"
+  fi
 done
-# using_cache_from=${cache_from[@]+"${#cache_from[@]}"}
 
 for service_name in $(plugin_read_list BUILD) ; do
   image_name=$(build_image_name "${service_name}")
@@ -27,7 +30,7 @@ for service_name in $(plugin_read_list BUILD) ; do
   build_images+=("$service_name" "$image_name")
 
   if in_array $service_name ${!cache_from[@]} ; then
-    build_images+=("${cache_from[$1]}")
+    build_images+=("${cache_from[$service_name]}")
   else
     build_images+=("")
   fi

--- a/hooks/commands/run.sh
+++ b/hooks/commands/run.sh
@@ -26,7 +26,7 @@ test -f "$override_file" && rm "$override_file"
 
 if prebuilt_image=$(get_prebuilt_image "$service_name") ; then
   echo "~~~ :docker: Found a pre-built image for $service_name"
-  build_image_override_file "${service_name}" "${prebuilt_image}" | tee "$override_file"
+  build_image_override_file "${service_name}" "${prebuilt_image}" "" | tee "$override_file"
 
   echo "~~~ :docker: Pulling pre-built services $service_name"
   retry "$pull_retries" run_docker_compose -f "$override_file" pull "$service_name"

--- a/lib/shared.bash
+++ b/lib/shared.bash
@@ -100,9 +100,17 @@ function build_image_override_file_with_version() {
     IFS=':' read -a tokens <<< "$line"
     cache_from[${tokens[0]}]=$(IFS=':'; echo "${tokens[*]:1}")
   done
+  local using_cache_from=${cache_from[@]+"${#cache_from[@]}"}
 
   if [[ -z "$version" ]]; then
     echo "The 'build' option can only be used with Compose file versions 2.0 and above."
+    echo "For more information on Docker Compose configuration file versions, see:"
+    echo "https://docs.docker.com/compose/compose-file/compose-versioning/#versioning"
+    exit 1
+  fi
+
+  if [[ -n "$using_cache_from" && $(bc <<< "$version < 3.2") -gt 0 ]] ; then
+    echo "The 'cache_from' option can only be used with Compose file versions 3.2 and above."
     echo "For more information on Docker Compose configuration file versions, see:"
     echo "https://docs.docker.com/compose/compose-file/compose-versioning/#versioning"
     exit 1

--- a/tests/build.bats
+++ b/tests/build.bats
@@ -91,12 +91,12 @@ load '../lib/shared'
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CONFIG="tests/composefiles/docker-compose.v3.2.yml"
   export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD_0=helloworld
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CACHE_FROM_0=myservice:my.repository/myservice:latest
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CACHE_FROM_0=helloworld:my.repository/myservice_cache:latest
   export BUILDKITE_PIPELINE_SLUG=test
   export BUILDKITE_BUILD_NUMBER=1
 
   stub docker \
-    "pull my.repository/myservice:latest : echo pulled cache image"
+    "pull my.repository/myservice_cache:latest : echo pulled cache image"
 
   stub docker-compose \
     "-f tests/composefiles/docker-compose.v3.2.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml build --pull helloworld : echo built helloworld"
@@ -105,6 +105,58 @@ load '../lib/shared'
 
   assert_success
   assert_output --partial "pulled cache image"
+  assert_output --partial "- my.repository/myservice_cache:latest"
+  assert_output --partial "built helloworld"
+  unstub docker
+  unstub docker-compose
+}
+
+@test "Build with a cache-from image when pulling of the cache-from image failed" {
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CONFIG="tests/composefiles/docker-compose.v3.2.yml"
+  export BUILDKITE_JOB_ID=1111
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD_0=helloworld
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CACHE_FROM_0=helloworld:my.repository/myservice_cache:latest
+  export BUILDKITE_PIPELINE_SLUG=test
+  export BUILDKITE_BUILD_NUMBER=1
+
+  stub docker \
+    "pull my.repository/myservice_cache:latest : exit 1"
+
+  stub docker-compose \
+    "-f tests/composefiles/docker-compose.v3.2.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml build --pull helloworld : echo built helloworld"
+
+  run $PWD/hooks/command
+
+  assert_success
+  assert_output --partial "my.repository/myservice_cache:latest will not be used as a cache for helloworld"
+  refute_output --partial "- my.repository/myservice_cache:latest"
+  assert_output --partial "built helloworld"
+  unstub docker
+  unstub docker-compose
+}
+
+@test "Build with a cache-from image retry on failing pull" {
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CONFIG="tests/composefiles/docker-compose.v3.2.yml"
+  export BUILDKITE_JOB_ID=1111
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD_0=helloworld
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CACHE_FROM_0=helloworld:my.repository/myservice_cache:latest
+  export BUILDKITE_PIPELINE_SLUG=test
+  export BUILDKITE_BUILD_NUMBER=1
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_PULL_RETRIES=3
+
+  stub docker \
+    "pull my.repository/myservice_cache:latest : exit 1" \
+    "pull my.repository/myservice_cache:latest : exit 1" \
+    "pull my.repository/myservice_cache:latest : echo pulled cache image"
+
+  stub docker-compose \
+    "-f tests/composefiles/docker-compose.v3.2.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml build --pull helloworld : echo built helloworld"
+
+  run $PWD/hooks/command
+
+  assert_success
+  assert_output --partial "pulled cache image"
+  assert_output --partial "- my.repository/myservice_cache:latest"
   assert_output --partial "built helloworld"
   unstub docker
   unstub docker-compose

--- a/tests/build.bats
+++ b/tests/build.bats
@@ -88,8 +88,9 @@ load '../lib/shared'
 }
 
 @test "Build with a cache-from image" {
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CONFIG="tests/composefiles/docker-compose.v3.2.yml"
   export BUILDKITE_JOB_ID=1111
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD=myservice
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD_0=helloworld
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CACHE_FROM_0=myservice:my.repository/myservice:latest
   export BUILDKITE_PIPELINE_SLUG=test
   export BUILDKITE_BUILD_NUMBER=1
@@ -98,13 +99,13 @@ load '../lib/shared'
     "pull my.repository/myservice:latest : echo pulled cache image"
 
   stub docker-compose \
-      "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml build --pull myservice : echo built myservice"
+    "-f tests/composefiles/docker-compose.v3.2.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml build --pull helloworld : echo built helloworld"
 
   run $PWD/hooks/command
 
   assert_success
   assert_output --partial "pulled cache image"
-  assert_output --partial "built myservice"
+  assert_output --partial "built helloworld"
   unstub docker
   unstub docker-compose
 }

--- a/tests/composefiles/docker-compose.v3.2.yml
+++ b/tests/composefiles/docker-compose.v3.2.yml
@@ -1,0 +1,29 @@
+version: "3.2"
+
+services:
+  helloworld:
+    environment:
+      - BLAH=${VARIABLE:-default}
+    build: .
+
+  helloworldimage:
+    image: myhelloworld
+    build: .
+
+  alpinewithenv:
+    image: alpine:3.3
+    environment:
+      - LLAMAS=${MISSING_VARIABLE:-always}
+    volumes:
+      - ../../tests/scripts:/scripts:ro
+    command: /scripts/test_env.sh
+
+  alpinewithfailinglink:
+    image: alpine:3.3
+    command: echo hello from alpine
+    links:
+      - fail
+
+  fail:
+    image: alpine:3.3
+    command: sh -c "echo failing on purpose, expect exit 1; exit 1"

--- a/tests/image-override-file.bats
+++ b/tests/image-override-file.bats
@@ -21,6 +21,17 @@ services:
 EOF
 )
 
+myservice_override_file3=$(cat <<-EOF
+version: '3.2'
+services:
+  myservice:
+    image: newimage:1.0.0
+    build:
+      cache_from:
+        - my.repository/myservice:latest
+EOF
+)
+
 @test "Build an docker-compose override file" {
   run build_image_override_file_with_version "2.1" "myservice" "newimage:1.0.0"
 
@@ -35,4 +46,13 @@ EOF
 
   assert_success
   assert_output "$myservice_override_file2"
+}
+
+@test "Build a docker-compose file with cache-from" {
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CACHE_FROM_0=myservice:my.repository/myservice:latest
+
+  run build_image_override_file_with_version "3.2" "myservice" "newimage:1.0.0"
+
+  assert_success
+  assert_output "$myservice_override_file3"
 }

--- a/tests/image-override-file.bats
+++ b/tests/image-override-file.bats
@@ -33,7 +33,7 @@ EOF
 )
 
 @test "Build an docker-compose override file" {
-  run build_image_override_file_with_version "2.1" "myservice" "newimage:1.0.0"
+  run build_image_override_file_with_version "2.1" "myservice" "newimage:1.0.0" ""
 
   assert_success
   assert_output "$myservice_override_file1"
@@ -41,26 +41,22 @@ EOF
 
 @test "Build an docker-compose override file with multiple entries" {
   run build_image_override_file_with_version "2.1" \
-    "myservice1" "newimage1:1.0.0" \
-    "myservice2" "newimage2:1.0.0"
+    "myservice1" "newimage1:1.0.0" "" \
+    "myservice2" "newimage2:1.0.0" ""
 
   assert_success
   assert_output "$myservice_override_file2"
 }
 
 @test "Build a docker-compose file with cache-from" {
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CACHE_FROM_0=myservice:my.repository/myservice:latest
-
-  run build_image_override_file_with_version "3.2" "myservice" "newimage:1.0.0"
+  run build_image_override_file_with_version "3.2" "myservice" "newimage:1.0.0" "my.repository/myservice:latest"
 
   assert_success
   assert_output "$myservice_override_file3"
 }
 
 @test "Build a docker-compose file with cache-from and compose-file version < 3.2" {
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CACHE_FROM_0=myservice:my.repository/myservice:latest
-
-  run build_image_override_file_with_version "3" "myservice" "newimage:1.0.0"
+  run build_image_override_file_with_version "3" "myservice" "newimage:1.0.0" "my.repository/myservice:latest"
 
   assert_failure
 }

--- a/tests/image-override-file.bats
+++ b/tests/image-override-file.bats
@@ -56,3 +56,11 @@ EOF
   assert_success
   assert_output "$myservice_override_file3"
 }
+
+@test "Build a docker-compose file with cache-from and compose-file version < 3.2" {
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CACHE_FROM_0=myservice:my.repository/myservice:latest
+
+  run build_image_override_file_with_version "3" "myservice" "newimage:1.0.0"
+
+  assert_failure
+}


### PR DESCRIPTION
### Issue
To save resources we spin down all our runners and builders when not needed. However this busts docker caches for builders and that is bad. Starting from compose file `v3.2` there's a `cache_from` option that allows docker to use caches from any image present locally (image has to be pulled before it can be used as a cache source)

### Usage
```yml
plugins:
  docker-compose:
    build: app
    cache_from:
      - app:your.repo/image:tag
```

### Limitations

This is still kinda work in progress, but that'll do right now since `Bash` is not my native language and I've had enough of it for one day. I'll keep adding more commits to this PR

#### Todo
- [x] fail when trying to use `cache_from` with version < 3.2
- [x] refactor ugly duplicate code that reads cache_from
- [x] ~figure out how to use both remote and local caches simultaneously~ do not set cache_from if the image failed to pull
- [ ] (maybe not in this PR) support using several cache_from images for a single service

I'd be grateful if someone would read through this and point out my mistakes while I'm making them ;) 