### PR TITLE
Add a no-cache build option

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,9 +227,9 @@ The repository for pushing and pulling pre-built images, same as the repository 
 
 The default is `""`  which only builds images on the local Docker host doing the build.
 
-Note: this option only needs to be specified on the build step, and will be automatically picked up by following steps.
-
 This option can also be configured on the agent machine using the environment variable `BUILDKITE_PLUGIN_DOCKER_COMPOSE_IMAGE_REPOSITORY`.
+
+Note: this option can only be specified on a `build` step.
 
 ### `image-name` (optional)
 
@@ -241,14 +241,9 @@ Note: this option can only be specified on a `build` step.
 
 ### `env` or `environment` (optional)
 
-A list of either KEY or KEY=VALUE that are passed through
-as environment variables to the container.
+A list of either KEY or KEY=VALUE that are passed through as environment variables to the container.
 
-### `verbose` (optional)
-
-Sets `docker-compose` to run with `--verbose`
-
-The default is `false`.
+Note: this option can only be specified on a `run` step.
 
 ### `pull-retries` (optional)
 
@@ -264,7 +259,23 @@ This option can also be configured on the agent machine using the environment va
 
 ### `cache-from` (optional)
 
-A list of images to pull caches from in the format `service:index.docker.io/org/repo/image:tag`. Requires docker-compose file version `3.2+`. Currently only one image per service is supported. If there's no image present for a service local docker cache will be used.
+A list of images to pull caches from in the format `service:index.docker.io/org/repo/image:tag` before building. Requires docker-compose file version `3.2+`. Currently only one image per service is supported. If there's no image present for a service local docker cache will be used.
+
+Note: this option can only be specified on a `build` step.
+
+### `no-cache` (optional)
+
+Sets the build step to run with `--no-cache`, causing Docker Compose to not use any caches when building the image.
+
+The default is `false`.
+
+Note: this option can only be specified on a `build` step.
+
+### `verbose` (optional)
+
+Sets `docker-compose` to run with `--verbose`
+
+The default is `false`.
 
 ## Developing
 

--- a/README.md
+++ b/README.md
@@ -263,6 +263,14 @@ A list of images to pull caches from in the format `service:index.docker.io/org/
 
 Note: this option can only be specified on a `build` step.
 
+### `leave-volumes` (optional)
+
+Prevent the removal of volumes after the command has been run.
+
+The default is `false`.
+
+Note: this option can only be specified on a `run` step.
+
 ### `no-cache` (optional)
 
 Sets the build step to run with `--no-cache`, causing Docker Compose to not use any caches when building the image.

--- a/README.md
+++ b/README.md
@@ -290,7 +290,7 @@ The default is `false`.
 To run the tests:
 
 ```bash
-docker-compose run tests
+docker-compose run --rm tests
 ```
 
 ## License

--- a/hooks/commands/build.sh
+++ b/hooks/commands/build.sh
@@ -43,8 +43,14 @@ fi
 
 services=( $(plugin_read_list BUILD) )
 
+build_args=(--pull)
+
+if [[ "$(plugin_read_config NO_CACHE "false")" == "true" ]] ; then
+  build_args+=(--no-cache)
+fi
+
 echo "+++ :docker: Building services ${services[*]}"
-run_docker_compose -f "$override_file" build --pull "${services[@]}"
+run_docker_compose -f "$override_file" build "${build_args[@]}" "${services[@]}"
 
 if [[ -n "$image_repository" ]]; then
   echo "~~~ :docker: Pushing built images to $image_repository"

--- a/tests/build.bats
+++ b/tests/build.bats
@@ -23,6 +23,23 @@ load '../lib/shared'
   assert_output --partial "built myservice"
 }
 
+@test "Build with no-cache" {
+  export BUILDKITE_JOB_ID=1111
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD=myservice
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_NO_CACHE=true
+  export BUILDKITE_PIPELINE_SLUG=test
+  export BUILDKITE_BUILD_NUMBER=1
+
+  stub docker-compose \
+    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml build --pull --no-cache myservice : echo built myservice"
+
+  run $PWD/hooks/command
+
+  assert_success
+  assert_output --partial "built myservice"
+  unstub docker-compose
+}
+
 @test "Build with a repository" {
   export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD=myservice


### PR DESCRIPTION
This adds a `no-cache: true` option to the build stage. It also cleans up some of the readme, and documents the `leave-volumes` option.