### PR TITLE
Output a warning when using push with a configured image

### DIFF
--- a/hooks/commands/push.sh
+++ b/hooks/commands/push.sh
@@ -39,11 +39,17 @@ for line in $(plugin_read_list PUSH) ; do
   if [[ -z "$prebuilt_image" ]] && ! docker_image_exists "${service_image}" ; then
     echo "~~~ :docker: Building ${service_name}" >&2;
     run_docker_compose build "$service_name"
+  elif [[ -n "$prebuilt_image" ]]; then
+    echo "~~~ :docker: Using pre-built image ${prebuilt_image}"
+  else
+    echo "~~~ :warning: Skipping build. Using service image ${service_image} from Docker Compose config"
   fi
 
+  # push: "service-name"
   if [[ ${#tokens[@]} -eq 1 ]] ; then
     echo "~~~ :docker: Pushing images for ${service_name}" >&2;
     retry "$push_retries" run_docker_compose push "${service_name}"
+  # push: "service-name:repo:tag"
   else
     target_image="$(IFS=:; echo "${tokens[*]:1}")"
     echo "~~~ :docker: Pushing image $target_image" >&2;

--- a/tests/push.bats
+++ b/tests/push.bats
@@ -27,6 +27,7 @@ load '../lib/shared'
   run $PWD/hooks/command
 
   assert_success
+  assert_output --partial ":warning: Skipping build"
   assert_output --partial "pushed app"
   unstub docker-compose
   unstub buildkite-agent


### PR DESCRIPTION
If you define an `image` in your docker-compose.yml then this plugin’s `push` command won't automatically rebuild the service image before pushing… it'll push whatever built image is on the Docker daemon matching that name.

This is by design to match how docker-compose works, but is a little surprising for the CI use case and we don't really output anything to help people understand what went wrong.

To make it easier to recognise and debug when it's unexpected, this adds a warning so you know why it didn't build and can fix it if you like (by removing the `image` statement from the docker-compose config):

<img width="823" alt="test" src="https://user-images.githubusercontent.com/153/35083580-f6128c7a-fc73-11e7-8899-c042f1dbf1d8.png">