### PR TITLE
Predictable container names for run

### DIFF
--- a/lib/run.bash
+++ b/lib/run.bash
@@ -19,19 +19,14 @@ compose_cleanup() {
   fi
 }
 
-list_linked_containers() {
-  for container_id in $(HIDE_PROMPT=1 run_docker_compose ps -q); do
-    docker inspect --format='{{.Name}}' "$container_id"
-  done
-}
-
-check_linked_containers() {
+# Checks for failed containers and writes logs for them the the provided dir
+check_linked_containers_and_save_logs() {
   local logdir="$1"
   local cmdexit="$2"
 
   mkdir -p "$logdir"
 
-  for container_name in $(list_linked_containers); do
+  for container_name in $(docker_ps_by_project --format '{{.ID}}'); do
     container_exit_code=$(docker inspect --format='{{.State.ExitCode}}' "$container_name")
 
     if [[ $container_exit_code -ne 0 ]] ; then

--- a/lib/shared.bash
+++ b/lib/shared.bash
@@ -51,6 +51,13 @@ function docker_compose_project_name() {
   echo "buildkite${BUILDKITE_JOB_ID//-}"
 }
 
+# Runs docker ps -a filtered by the current project name
+function docker_ps_by_project() {
+  docker ps -a \
+    --filter "label=com.docker.compose.project=$(docker_compose_project_name)" \
+    "${@}"
+}
+
 # Returns all docker compose config file names split by newlines
 function docker_compose_config_files() {
   local -a config_files=()

--- a/tests/run.bats
+++ b/tests/run.bats
@@ -19,7 +19,7 @@ load '../lib/run'
 
   stub docker-compose \
     "-f docker-compose.yml -p buildkite1111 build --pull myservice : echo built myservice" \
-    "-f docker-compose.yml -p buildkite1111 run myservice echo hello world : echo ran myservice"
+    "-f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 myservice echo hello world : echo ran myservice"
 
   stub buildkite-agent \
     "meta-data get docker-compose-plugin-built-image-tag-myservice : exit 1"
@@ -48,7 +48,7 @@ load '../lib/run'
 
   stub docker-compose \
     "-f docker-compose.yml -p buildkite1111 build --pull myservice : echo built myservice" \
-    "-f docker-compose.yml -p buildkite1111 run -e MYENV=0 -e MYENV -e MYENV=2 -e MYENV myservice pwd : echo ran myservice"
+    "-f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 -e MYENV=0 -e MYENV -e MYENV=2 -e MYENV myservice pwd : echo ran myservice"
 
   stub buildkite-agent \
     "meta-data get docker-compose-plugin-built-image-tag-myservice : exit 1"
@@ -72,7 +72,7 @@ load '../lib/run'
 
   stub docker-compose \
     "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml pull myservice : echo pulled myservice" \
-    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run myservice pwd : echo ran myservice"
+    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 myservice pwd : echo ran myservice"
 
   stub buildkite-agent \
     "meta-data get docker-compose-plugin-built-image-tag-myservice : echo myimage"
@@ -122,7 +122,7 @@ load '../lib/run'
   stub docker-compose \
     "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml pull myservice : exit 2" \
     "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml pull myservice : echo pulled myservice" \
-    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run myservice pwd : echo ran myservice"
+    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 myservice pwd : echo ran myservice"
 
   stub buildkite-agent \
     "meta-data get docker-compose-plugin-built-image-tag-myservice : echo myimage"


### PR DESCRIPTION
So it appears that some time in the past `docker-compose ps` stopped listing containers created by `docker-compose run` in favour of services from `docker-compose up`. I'm struggling to figure out when, ~~but it likely the cause of #78~~. 

This passes a predictable name to `docker-compose run --name xxxxx` so that subsequently we can inspect the container for the given run. Previously it would get a name like `agent_agent_run_1`, where the number was an incrementing run counter per host. 