### PR TITLE
Correctly capture failures from the Subshell

### DIFF
--- a/hooks/commands/run.sh
+++ b/hooks/commands/run.sh
@@ -57,10 +57,13 @@ fi
 
 run_params+=("$service_name")
 
+# Disable -e outside of the subshell; since the subshell returning a failure
+# would exit the parent shell (here) early.
+set +e
+
 (
   # Reset bash to the default IFS with no glob expanding and no failing on error
   unset IFS
-  set +e
   set -f
 
   # The eval statements below are used to allow $BUILDKITE_COMMAND to be interpolated correctly
@@ -82,6 +85,8 @@ run_params+=("$service_name")
 )
 
 exitcode=$?
+# Restore -e as an option.
+set -e
 
 if [[ $exitcode -ne 0 ]] ; then
   echo "^^^ +++"


### PR DESCRIPTION
Currently the -e option is turned off from inside the subshell - This fails though, as it remains on for the parent shell.

Thus, to capture (and handle) failures, we need to turn the option off in the top level shell correctly, rather than in a child shell, and restore this *after* our block of code has been run.

This manifests itself in the form of failed commands only invoking cleanup, and none of the rest of the code. The check on exit code is completely skipped and, for instance, docker logs from linked containers are never uploaded (which is far from ideal).