### PR TITLE
A pull option for run to allow multiple services to be pulled

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,10 @@ The name of the service the command should be run within. If the docker-compose 
 
 A list of services to push in the format `service:image:tag`. If an image has been pre-built with the build step, that image will be re-tagged, otherwise docker-compose's built in push operation will be used.
 
+### `pull` (optional, run only)
+
+Pull down multiple pre-built images. By default only the service that is being run will be pulled down, but this allows multiple images to be specified to handle prebuilt dependent images.
+
 ### `config` (optional)
 
 The file name of the Docker Compose configuration file to use. Can also be a list of filenames.

--- a/lib/metadata.bash
+++ b/lib/metadata.bash
@@ -7,7 +7,7 @@ function plugin_get_metadata() {
   local key="docker-compose-plugin-$1"
   plugin_prompt buildkite-agent meta-data get "$key"
   buildkite-agent meta-data get "$key" || (
-    echo "~~~ Failed to get metdata $key (exit $?)" >&2
+    echo "~~~ Failed to get metadata $key (exit $?)" >&2
     return 1
   )
 }

--- a/lib/shared.bash
+++ b/lib/shared.bash
@@ -92,7 +92,7 @@ function build_image_override_file() {
 }
 
 # Build an docker-compose file that overrides the image for a specific
-# docker-compose version and set of service and image pairs
+# docker-compose version and set of [ service, image, cache_from ] tuples
 function build_image_override_file_with_version() {
   local version="$1"
 

--- a/tests/run.bats
+++ b/tests/run.bats
@@ -18,8 +18,7 @@ load '../lib/run'
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLEANUP=false
 
   stub docker-compose \
-    "-f docker-compose.yml -p buildkite1111 pull myservice : echo pulled myservice" \
-    "-f docker-compose.yml -p buildkite1111 build myservice : echo built myservice" \
+    "-f docker-compose.yml -p buildkite1111 build --pull myservice : echo built myservice" \
     "-f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 myservice echo hello world : echo ran myservice"
 
   stub buildkite-agent \
@@ -44,8 +43,7 @@ load '../lib/run'
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLEANUP=false
 
   stub docker-compose \
-    "-f docker-compose.yml -p buildkite1111 pull myservice : echo pulled myservice" \
-    "-f docker-compose.yml -p buildkite1111 build myservice : echo built myservice" \
+    "-f docker-compose.yml -p buildkite1111 build --pull myservice : echo built myservice" \
     "-f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 myservice $BUILDKITE_COMMAND : echo ran myservice"
 
   stub buildkite-agent \
@@ -74,8 +72,7 @@ load '../lib/run'
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_ENVIRONMENT_1=MYENV
 
   stub docker-compose \
-    "-f docker-compose.yml -p buildkite1111 pull myservice : echo pulled myservice" \
-    "-f docker-compose.yml -p buildkite1111 build myservice : echo built myservice" \
+    "-f docker-compose.yml -p buildkite1111 build --pull myservice : echo built myservice" \
     "-f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 -e MYENV=0 -e MYENV -e MYENV=2 -e MYENV myservice pwd : echo ran myservice"
 
   stub buildkite-agent \
@@ -201,8 +198,7 @@ load '../lib/run'
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CONFIG_2="llamas3.yml"
 
   stub docker-compose \
-    "-f llamas1.yml -f llamas2.yml -f llamas3.yml -p buildkite1111 pull myservice : echo pulling myservice" \
-    "-f llamas1.yml -f llamas2.yml -f llamas3.yml -p buildkite1111 build myservice : echo built myservice" \
+    "-f llamas1.yml -f llamas2.yml -f llamas3.yml -p buildkite1111 build --pull myservice : echo built myservice" \
     "-f llamas1.yml -f llamas2.yml -f llamas3.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 myservice echo hello world : echo ran myservice"
 
   stub buildkite-agent \
@@ -227,8 +223,7 @@ load '../lib/run'
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLEANUP=true
 
   stub docker-compose \
-    "-f docker-compose.yml -p buildkite1111 pull myservice : echo pulling myservice" \
-    "-f docker-compose.yml -p buildkite1111 build myservice : echo built myservice" \
+    "-f docker-compose.yml -p buildkite1111 build --pull myservice : echo built myservice" \
     "-f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 myservice pwd : exit 1" \
     "-f docker-compose.yml -p buildkite1111 kill : echo killing containers" \
     "-f docker-compose.yml -p buildkite1111 rm --force -v : echo removing stopped containers" \
@@ -255,8 +250,7 @@ load '../lib/run'
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLEANUP=false
 
   stub docker-compose \
-    "-f docker-compose.yml -p buildkite1111 pull myservice : echo pulling myservice" \
-    "-f docker-compose.yml -p buildkite1111 build myservice : echo built myservice" \
+    "-f docker-compose.yml -p buildkite1111 build --pull myservice : echo built myservice" \
     "-f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 myservice pwd : exit 2"
 
   stub buildkite-agent \


### PR DESCRIPTION
This adds a top-level `pull` property that is used with run to indicate you want to pull down multiple services. If any of them are prebuilt in a previous step, they will be pulled down.

```yaml
steps:
  - name: ":docker: Build"
    plugins:
      docker-compose#master:
        build: 
          - app
          - app_dependency
        image-repository: index.docker.io/org/repo

  - wait

  - name: ":docker: Test"
    plugins:
      docker-compose#master:
        run: app
        pull: 
          - app_dependency
```

This will probably merit a bump to `2.0.0`.

Closes #96 and #86.