### PR TITLE
Scope build meta-data keys by config file

### DIFF
--- a/hooks/commands/build.sh
+++ b/hooks/commands/build.sh
@@ -62,7 +62,7 @@ if [[ -n "$image_repository" ]]; then
   run_docker_compose -f "$override_file" push "${services[@]}"
 
   while [[ ${#build_images[@]} -gt 0 ]] ; do
-    plugin_set_metadata "built-image-tag-${build_images[0]}" "${build_images[1]}"
+    set_prebuilt_image "${build_images[0]}" "${build_images[1]}"
     build_images=("${build_images[@]:3}")
   done
 fi

--- a/lib/metadata.bash
+++ b/lib/metadata.bash
@@ -19,8 +19,20 @@ function plugin_set_metadata() {
   plugin_prompt_and_must_run buildkite-agent meta-data set "$key" "$value"
 }
 
-# Gets a prebuilt iamge for a service name
+function prebuilt_image_meta_data_key() {
+  local service="$1"
+  echo "${META_IMAGE_TAG}${service}"
+}
+
+# Sets a prebuilt image for a service name
+function set_prebuilt_image() {
+  local service="$1"
+  local image="$2"
+  plugin_set_metadata "$(prebuilt_image_meta_data_key "$service")" "$image"
+}
+
+# Gets a prebuilt image for a service name
 function get_prebuilt_image() {
   local service="$1"
-  plugin_get_metadata "${META_IMAGE_TAG}${service}"
+  plugin_get_metadata "$(prebuilt_image_meta_data_key "$service")"
 }

--- a/lib/metadata.bash
+++ b/lib/metadata.bash
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-readonly META_IMAGE_TAG=built-image-tag-
-
 # Read agent metadata for the plugin
 function plugin_get_metadata() {
   local key="docker-compose-plugin-$1"
@@ -19,9 +17,23 @@ function plugin_set_metadata() {
   plugin_prompt_and_must_run buildkite-agent meta-data set "$key" "$value"
 }
 
+# The service name, and the docker-compose config files, are the uniqueness key
+# for the pre-built image meta-data tag
 function prebuilt_image_meta_data_key() {
   local service="$1"
-  echo "${META_IMAGE_TAG}${service}"
+  local config_key=""
+
+  for file in $(docker_compose_config_files) ; do
+    config_key+="-$file"
+  done
+
+  # If they just use the default config, we use the old-style (non-suffixed)
+  # style key
+  if [[ "$config_key" == "-docker-compose.yml" ]]; then
+    echo "built-image-tag-$service"
+  else
+    echo "built-image-tag-$service$config_key"
+  fi
 }
 
 # Sets a prebuilt image for a service name

--- a/tests/metadata.bats
+++ b/tests/metadata.bats
@@ -1,0 +1,31 @@
+#!/usr/bin/env bats
+
+load '/usr/local/lib/bats/load.bash'
+load '../lib/shared'
+load '../lib/metadata'
+
+@test "Image service tag with default config" {
+  run prebuilt_image_meta_data_key "service"
+
+  assert_success
+  assert_output "built-image-tag-service"
+}
+
+@test "Image service tag with single non-default config" {
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CONFIG=tests/composefiles/docker-compose.v2.0.yml
+
+  run prebuilt_image_meta_data_key "service"
+
+  assert_success
+  assert_output "built-image-tag-service-tests/composefiles/docker-compose.v2.0.yml"
+}
+
+@test "Image service tag with multiple non-default config" {
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CONFIG_0=tests/composefiles/docker-compose.v2.0.yml
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CONFIG_1=tests/composefiles/docker-compose.v2.1.yml
+
+  run prebuilt_image_meta_data_key "service"
+
+  assert_success
+  assert_output "built-image-tag-service-tests/composefiles/docker-compose.v2.0.yml-tests/composefiles/docker-compose.v2.1.yml"
+}


### PR DESCRIPTION
This updates the meta-data key used for storing pre-built images to include the docker-compose config file name. This allows you to pre-build and run the same named service from two completely different docker-compose.yml files, without any fear of clashing.

For example:

```yml
steps:
  - name: ":docker: dev"
    plugins:
      docker-compose#x:
        build: app
        image-repository: org/app-dev

  - label: ":docker: staging"
    plugins:
      docker-compose#x:
        config: docker-compose.staging.yml
        build: app
        image-repository: org/app-staging

  - wait

  - name: ":hammer: dev"
    command: yarn test
    plugins:
      docker-compose#x:
        run: app

  - name: ":hammer: staging"
    command: yarn test-staging
    plugins:
      docker-compose#x:
        config: docker-compose.staging.yml
        run: app
```

The above two will now set and get the following meta-data keys:

```
docker-compose-plugin-built-image-tag-app
docker-compose-plugin-built-image-tag-app-docker-compose.staging.yml
```

If you specify multiple configs with the array syntax they're joined with a dash. For example, the following:

```yml
steps:
  - name: ":docker: dev"
    plugins:
      docker-compose#x:
        config:
          - docker-compose.one.yml
          - docker-compose.two.yml
        build: app
        image-repository: org/app-dev
```

Sets the following meta-data key:

```
docker-compose-plugin-built-image-tag-app-docker-compose.one.yml-docker-compose.two.yml
```

I don't think this should have any backwards compatibility problems, unless people were depending on the meta-data key, but as that's not configurable I'd consider it private.

- [x] Tests
- [x] Code

Fixes #111