### PR TITLE
Allow specifying the --no-deps flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,6 +279,12 @@ If set to false, doesn't allocate a TTY. This is useful in some situations where
 
 The default is `true`.
 
+### `dependencies` (optional, run only)
+
+If set to false, doesn't start linked services.
+
+The default is `true`.
+
 ### `verbose` (optional)
 
 Sets `docker-compose` to run with `--verbose`

--- a/hooks/commands/run.sh
+++ b/hooks/commands/run.sh
@@ -91,6 +91,11 @@ if [[ "$(plugin_read_config TTY "true")" == "false" ]] ; then
   run_params+=(-T)
 fi
 
+# Optionally disable dependencies
+if [[ "$(plugin_read_config DEPENDENCIES "true")" == "false" ]] ; then
+  run_params+=(--no-deps)
+fi
+
 run_params+=("$run_service")
 
 if [[ ! -f "$override_file" ]]; then

--- a/tests/run.bats
+++ b/tests/run.bats
@@ -236,6 +236,31 @@ export BUILDKITE_JOB_ID=1111
   unstub buildkite-agent
 }
 
+@test "Run without dependencies" {
+  export BUILDKITE_JOB_ID=1111
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RUN=myservice
+  export BUILDKITE_PIPELINE_SLUG=test
+  export BUILDKITE_BUILD_NUMBER=1
+  export BUILDKITE_COMMAND=pwd
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CHECK_LINKED_CONTAINERS=false
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLEANUP=false
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_DEPENDENCIES=false
+
+  stub docker-compose \
+    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml pull myservice : echo pulled myservice" \
+    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 --no-deps myservice pwd : echo ran myservice without dependencies"
+
+  stub buildkite-agent \
+    "meta-data get docker-compose-plugin-built-image-tag-myservice : echo myimage"
+
+  run $PWD/hooks/command
+
+  assert_success
+  assert_output --partial "ran myservice without dependencies"
+  unstub docker-compose
+  unstub buildkite-agent
+}
+
 @test "Run with multiple config files" {
   export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RUN=myservice


### PR DESCRIPTION
I'm currently trying to migrate my buildkite pipeline to use the new plugin system but I've run into a little snag. I have some steps that require a bunch of dependent services but some steps that do not. I tried using the docker plugin for the steps that don't need the services but the docker plugin makes some assumptions that don't work in my case^. Given I have a docker compose file anyway and I'm using it for the other steps, it would be convenient for me to use the docker-compose plugin for everything but specify the `--no-deps` flag somehow. I'm not fussed _how_ that option gets set but given I made this change to confirm this solved my problem, I figured I'd make a PR rather than just an issue.

^ For completeness, the docker plugin always specifies the `--workdir` commandline flag, overriding the default I set in my `Dockerfile` and mounts the pwd at that directory which I also don't want. My source code is already inside the image that I prebuilt in a previous step. Theoretically changes could be made on the docker plugin to solve my problem as well but this seems cleaner.