### PR TITLE
Run all commands through a shell interpreter

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -49,6 +49,7 @@ steps:
     plugins:
       ${BUILDKITE_REPO}#${BUILDKITE_COMMIT}:
         run: helloworld
+        shell: false
         config: tests/composefiles/docker-compose.v2.0.yml
 
   - wait
@@ -57,6 +58,7 @@ steps:
     plugins:
       ${BUILDKITE_REPO}#${BUILDKITE_COMMIT}:
         run: helloworld
+        shell: false
         config: tests/composefiles/docker-compose.v2.1.yml
 
   - wait
@@ -64,6 +66,7 @@ steps:
     plugins:
       ${BUILDKITE_REPO}#${BUILDKITE_COMMIT}:
         run: helloworld
+        shell: false
         config: tests/composefiles/docker-compose.v2.1.yml
 
   - wait
@@ -80,6 +83,7 @@ steps:
     plugins:
       ${BUILDKITE_REPO}#${BUILDKITE_COMMIT}:
         run: helloworldimage
+        shell: false
         config: tests/composefiles/docker-compose.v2.1.yml
 
   - wait
@@ -97,6 +101,7 @@ steps:
     plugins:
       ${BUILDKITE_REPO}#${BUILDKITE_COMMIT}:
         run: helloworld
+        shell: false
         config: tests/composefiles/docker-compose.v2.1.yml
 
   - wait

--- a/README.md
+++ b/README.md
@@ -351,6 +351,12 @@ Sets `docker-compose` to run with `--verbose`
 
 The default is `false`.
 
+### `shell` (optional, run only)
+
+The shell that is used to invoke commands. This is so that multiple commands can be interpretted. if `false` is specified, the command is invoked directly.
+
+The default is `/bin/sh -e -c`.
+
 ## Developing
 
 To run the tests:

--- a/commands/run.sh
+++ b/commands/run.sh
@@ -144,7 +144,11 @@ set +e
   # helpfully expand prior to passing it to docker-compose)
 
   echo "+++ :docker: Running command in Docker Compose service: $run_service" >&2
-  eval "run_docker_compose \${run_params[@]} $shell '$BUILDKITE_COMMAND'"
+  if [[ $shell == "false" ]] ; then
+    eval "run_docker_compose \${run_params[@]} $BUILDKITE_COMMAND"
+  else
+    eval "run_docker_compose \${run_params[@]} $shell '$BUILDKITE_COMMAND'"
+  fi
 )
 
 exitcode=$?

--- a/commands/run.sh
+++ b/commands/run.sh
@@ -8,6 +8,12 @@ run_service="$(plugin_read_config RUN)"
 container_name="$(docker_compose_project_name)_${run_service}_build_${BUILDKITE_BUILD_NUMBER}"
 override_file="docker-compose.buildkite-${BUILDKITE_BUILD_NUMBER}-override.yml"
 pull_retries="$(plugin_read_config PULL_RETRIES "0")"
+shell="$(plugin_read_config SHELL "/bin/sh -e -c")"
+
+# false means no, shell will invoke directly
+if [[ "$shell" == "false" ]] ; then
+  shell=""
+fi
 
 cleanup() {
   # shellcheck disable=SC2181
@@ -138,7 +144,7 @@ set +e
   # helpfully expand prior to passing it to docker-compose)
 
   echo "+++ :docker: Running command in Docker Compose service: $run_service" >&2
-  eval "run_docker_compose \${run_params[@]} $BUILDKITE_COMMAND"
+  eval "run_docker_compose \${run_params[@]} $shell '$BUILDKITE_COMMAND'"
 )
 
 exitcode=$?

--- a/hooks/command
+++ b/hooks/command
@@ -10,12 +10,18 @@ DIR="$(cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd)"
 
 commands=()
 
+env | grep BUILDKITE_PLUGIN_DOCKER_COMPOSE
+
 [[ -n "$(plugin_read_list BUILD)" ]] && commands+=("BUILD")
 [[ -n "$(plugin_read_list RUN)" ]] && commands+=("RUN")
 [[ -n "$(plugin_read_list PUSH)" ]] && commands+=("PUSH")
 
-# Check we've only got one of BUILD, RUN and PUSH
-if [[ ${#commands[@]} -gt 1 ]] ; then
+# Check we've only got one and only one of BUILD, RUN and PUSH
+if [[ -z "${commands[*]:-}" ]] ; then
+  echo "+++ Docker Compose plugin error"
+  echo "Must specify one of build, run or push. None was specified."
+  exit 1
+elif [[ ${#commands[@]} -gt 1 ]] ; then
   echo "+++ Docker Compose plugin error"
   echo "Only one of build, run and push is supported. More than one was used."
   exit 1

--- a/tests/run.bats
+++ b/tests/run.bats
@@ -19,7 +19,7 @@ load '../lib/run'
 
   stub docker-compose \
     "-f docker-compose.yml -p buildkite1111 build --pull myservice : echo built myservice" \
-    "-f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 myservice echo hello world : echo ran myservice"
+    "-f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 myservice /bin/sh -e -c 'echo hello world' : echo ran myservice"
 
   stub buildkite-agent \
     "meta-data get docker-compose-plugin-built-image-tag-myservice : exit 1"
@@ -95,7 +95,7 @@ load '../lib/run'
 
   stub docker-compose \
     "-f docker-compose.yml -p buildkite1111 build --pull myservice : echo built myservice" \
-    "-f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 myservice $BUILDKITE_COMMAND : echo ran myservice"
+    "-f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 myservice /bin/sh -e -c '$BUILDKITE_COMMAND' : echo ran myservice"
 
   stub buildkite-agent \
     "meta-data get docker-compose-plugin-built-image-tag-myservice : exit 1"
@@ -124,7 +124,7 @@ load '../lib/run'
 
   stub docker-compose \
     "-f docker-compose.yml -p buildkite1111 build --pull myservice : echo built myservice" \
-    "-f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 -e MYENV=0 -e MYENV -e MYENV=2 -e MYENV myservice pwd : echo ran myservice"
+    "-f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 -e MYENV=0 -e MYENV -e MYENV=2 -e MYENV myservice /bin/sh -e -c 'pwd' : echo ran myservice"
 
   stub buildkite-agent \
     "meta-data get docker-compose-plugin-built-image-tag-myservice : exit 1"
@@ -148,7 +148,7 @@ load '../lib/run'
 
   stub docker-compose \
     "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml pull myservice : echo pulled myservice" \
-    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 myservice pwd : echo ran myservice"
+    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 myservice /bin/sh -e -c pwd : echo ran myservice"
 
   stub buildkite-agent \
     "meta-data get docker-compose-plugin-built-image-tag-myservice : echo myimage"
@@ -173,7 +173,7 @@ load '../lib/run'
 
   stub docker-compose \
     "-f tests/composefiles/docker-compose.v2.0.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml pull myservice : echo pulled myservice" \
-    "-f tests/composefiles/docker-compose.v2.0.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 myservice pwd : echo ran myservice"
+    "-f tests/composefiles/docker-compose.v2.0.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 myservice /bin/sh -e -c pwd : echo ran myservice"
 
   stub buildkite-agent \
     "meta-data get docker-compose-plugin-built-image-tag-myservice-tests/composefiles/docker-compose.v2.0.yml : echo myimage"
@@ -199,7 +199,7 @@ export BUILDKITE_JOB_ID=1111
 
   stub docker-compose \
     "-f tests/composefiles/docker-compose.v2.0.yml -f tests/composefiles/docker-compose.v2.1.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml pull myservice : echo pulled myservice" \
-    "-f tests/composefiles/docker-compose.v2.0.yml -f tests/composefiles/docker-compose.v2.1.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 myservice pwd : echo ran myservice"
+    "-f tests/composefiles/docker-compose.v2.0.yml -f tests/composefiles/docker-compose.v2.1.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 myservice /bin/sh -e -c pwd : echo ran myservice"
 
   stub buildkite-agent \
     "meta-data get docker-compose-plugin-built-image-tag-myservice-tests/composefiles/docker-compose.v2.0.yml-tests/composefiles/docker-compose.v2.1.yml : echo myimage"
@@ -248,7 +248,7 @@ export BUILDKITE_JOB_ID=1111
   stub docker-compose \
     "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml pull myservice : exit 2" \
     "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml pull myservice : echo pulled myservice" \
-    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 myservice pwd : echo ran myservice"
+    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 myservice /bin/sh -e -c pwd : echo ran myservice"
 
   stub buildkite-agent \
     "meta-data get docker-compose-plugin-built-image-tag-myservice : echo myimage"
@@ -274,7 +274,7 @@ export BUILDKITE_JOB_ID=1111
 
   stub docker-compose \
     "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml pull myservice : echo pulled myservice" \
-    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 -T myservice pwd : echo ran myservice without tty"
+    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 -T myservice /bin/sh -e -c pwd : echo ran myservice without tty"
 
   stub buildkite-agent \
     "meta-data get docker-compose-plugin-built-image-tag-myservice : echo myimage"
@@ -299,7 +299,7 @@ export BUILDKITE_JOB_ID=1111
 
   stub docker-compose \
     "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml pull myservice : echo pulled myservice" \
-    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 --no-deps myservice pwd : echo ran myservice without dependencies"
+    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 --no-deps myservice /bin/sh -e -c pwd : echo ran myservice without dependencies"
 
   stub buildkite-agent \
     "meta-data get docker-compose-plugin-built-image-tag-myservice : echo myimage"
@@ -324,7 +324,7 @@ export BUILDKITE_JOB_ID=1111
 
   stub docker-compose \
     "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml pull myservice : echo pulled myservice" \
-    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 --no-ansi myservice pwd : echo ran myservice without ansi output"
+    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 --no-ansi myservice /bin/sh -e -c pwd : echo ran myservice without ansi output"
 
   stub buildkite-agent \
     "meta-data get docker-compose-plugin-built-image-tag-myservice : echo myimage"
@@ -350,7 +350,7 @@ export BUILDKITE_JOB_ID=1111
 
   stub docker-compose \
     "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml pull myservice : echo pulled myservice" \
-    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 -v ./dist:/app/dist -v ./pkg:/app/pkg myservice pwd : echo ran myservice with volumes"
+    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 -v ./dist:/app/dist -v ./pkg:/app/pkg myservice /bin/sh -e -c pwd : echo ran myservice with volumes"
 
   stub buildkite-agent \
     "meta-data get docker-compose-plugin-built-image-tag-myservice : echo myimage"
@@ -377,7 +377,7 @@ export BUILDKITE_JOB_ID=1111
 
   stub docker-compose \
     "-f llamas1.yml -f llamas2.yml -f llamas3.yml -p buildkite1111 build --pull myservice : echo built myservice" \
-    "-f llamas1.yml -f llamas2.yml -f llamas3.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 myservice echo hello world : echo ran myservice"
+    "-f llamas1.yml -f llamas2.yml -f llamas3.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 myservice /bin/sh -e -c 'echo hello world' : echo ran myservice"
 
   stub buildkite-agent \
     "meta-data get docker-compose-plugin-built-image-tag-myservice-llamas1.yml-llamas2.yml-llamas3.yml : exit 1"
@@ -402,7 +402,7 @@ export BUILDKITE_JOB_ID=1111
 
   stub docker-compose \
     "-f docker-compose.yml -p buildkite1111 build --pull myservice : echo built myservice" \
-    "-f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 myservice pwd : exit 1" \
+    "-f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 myservice /bin/sh -e -c pwd : exit 1" \
     "-f docker-compose.yml -p buildkite1111 kill : echo killing containers" \
     "-f docker-compose.yml -p buildkite1111 rm --force -v : echo removing stopped containers" \
     "-f docker-compose.yml -p buildkite1111 down --volumes : echo removing everything"
@@ -429,7 +429,7 @@ export BUILDKITE_JOB_ID=1111
 
   stub docker-compose \
     "-f docker-compose.yml -p buildkite1111 build --pull myservice : echo built myservice" \
-    "-f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 myservice pwd : exit 2"
+    "-f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 myservice /bin/sh -e -c pwd : exit 2"
 
   stub buildkite-agent \
     "meta-data get docker-compose-plugin-built-image-tag-myservice : exit 1"
@@ -456,7 +456,7 @@ export BUILDKITE_JOB_ID=1111
 
   stub docker-compose \
     "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml pull --parallel myservice1 myservice2 : echo pulled myservice1 and myservice2" \
-    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice1_build_1 myservice1 pwd : echo ran myservice1"
+    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice1_build_1 myservice1 /bin/sh -e -c pwd : echo ran myservice1"
 
   stub buildkite-agent \
     "meta-data get docker-compose-plugin-built-image-tag-myservice1 : echo myimage1" \
@@ -470,3 +470,30 @@ export BUILDKITE_JOB_ID=1111
   unstub docker-compose
   unstub buildkite-agent
 }
+
+@test "Run without a prebuilt image and with no shell" {
+  export BUILDKITE_JOB_ID=1111
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RUN=myservice
+  export BUILDKITE_PIPELINE_SLUG=test
+  export BUILDKITE_BUILD_NUMBER=1
+  export BUILDKITE_COMMAND="pwd"
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_SHELL=false
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CHECK_LINKED_CONTAINERS=false
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLEANUP=false
+
+  stub docker-compose \
+    "-f docker-compose.yml -p buildkite1111 build --pull myservice : echo built myservice" \
+    "-f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 myservice pwd : echo ran myservice"
+
+  stub buildkite-agent \
+    "meta-data get docker-compose-plugin-built-image-tag-myservice : exit 1"
+
+  run $PWD/hooks/command
+
+  assert_success
+  assert_output --partial "built myservice"
+  assert_output --partial "ran myservice"
+  unstub docker-compose
+  unstub buildkite-agent
+}
+


### PR DESCRIPTION
Multiple commands get passed through as new-line delimited commands. Docker needs a single command, so this currently doesn't work. This sets a standard command to execute $BUILDKITE_COMMAND in of `/bin/sh -e -c`, you can provide an alternative via the `shell` parameter. 

The downside is that this are:
* Adds a layer of shell execution to your docker-compose runs
* Requires `/bin/sh` in your container

We could possibly only do this if there is multiple commands, but in some ways that just makes it more magical IMO.