### PR TITLE
Add run-image-alias functionality

### DIFF
--- a/.buildkite/pipeline.sh
+++ b/.buildkite/pipeline.sh
@@ -119,18 +119,17 @@ steps:
         config: tests/composefiles/docker-compose.v2.1.yml
 
   - wait
-  - label: build with alias-from
+  - label: build with run-image-alias
     plugins:
       ${BUILDKITE_REPO}#${commit}:
         build: base_service
         config: tests/composefiles/docker-compose.v3.2.shared-base-service.yml
 
   - wait
-  - label: run with alias-from
+  - label: run with run-image-alias
     plugins:
       ${BUILDKITE_REPO}#${commit}:
         run: service1
-        alias-from:
-          - base_image
+        run-image-alias: base_image
         config: tests/composefiles/docker-compose.v3.2.shared-base-service.yml
 YAML

--- a/.buildkite/pipeline.sh
+++ b/.buildkite/pipeline.sh
@@ -118,4 +118,19 @@ steps:
         push: helloworld
         config: tests/composefiles/docker-compose.v2.1.yml
 
+  - wait
+  - label: build with alias-from
+    plugins:
+      ${BUILDKITE_REPO}#${commit}:
+        build: base_service
+        config: tests/composefiles/docker-compose.v3.2.shared-base-service.yml
+
+  - wait
+  - label: run with alias-from
+    plugins:
+      ${BUILDKITE_REPO}#${commit}:
+        run: service1
+        alias-from:
+          - base_image
+        config: tests/composefiles/docker-compose.v3.2.shared-base-service.yml
 YAML

--- a/README.md
+++ b/README.md
@@ -290,15 +290,17 @@ A number of times to retry failed docker push. Defaults to 0.
 
 This option can also be configured on the agent machine using the environment variable `BUILDKITE_PLUGIN_DOCKER_COMPOSE_PUSH_RETRIES`.
 
-### `alias-from` (optional, run only)
-
-Pulls down specified images, and aliases them as the image-name.
-
 ### `cache-from` (optional)
 
 A list of images to pull caches from in the format `service:index.docker.io/org/repo/image:tag` before building. Requires docker-compose file version `3.2+`. Currently only one image per service is supported. If there's no image present for a service local docker cache will be used.
 
 Note: this option can only be specified on a `build` step.
+
+### `run-image-alias` (optional, run only)
+
+Pulls the image for the specified service, and aliases the service as the image-name. This can be used for builds that run multiple services using a single specified image.
+
+Note: this option can only be specified on a `run` step.
 
 ### `leave-volumes` (optional, run only)
 

--- a/README.md
+++ b/README.md
@@ -290,6 +290,10 @@ A number of times to retry failed docker push. Defaults to 0.
 
 This option can also be configured on the agent machine using the environment variable `BUILDKITE_PLUGIN_DOCKER_COMPOSE_PUSH_RETRIES`.
 
+### `alias-from` (optional, run only)
+
+Pulls down specified images, and aliases them as the image-name.
+
 ### `cache-from` (optional)
 
 A list of images to pull caches from in the format `service:index.docker.io/org/repo/image:tag` before building. Requires docker-compose file version `3.2+`. Currently only one image per service is supported. If there's no image present for a service local docker cache will be used.

--- a/hooks/commands/run.sh
+++ b/hooks/commands/run.sh
@@ -67,11 +67,11 @@ for service_name in "${prebuilt_candidates[@]}" ; do
 done
 
 # Add "alias-from" service names to override file.
-while read -r name ; do
+while read -r service_name ; do
   if [[ -n "$service_name" ]] ; then
     if prebuilt_image=$(get_prebuilt_image "$service_name") ; then
-      echo "~~~ :docker: Aliasing pre-built image for $service_name"
-      prebuilt_service_overrides+=("$service_name" "$prebuilt_image" "")
+      echo "~~~ :docker: Aliasing pre-built image for $run_service"
+      prebuilt_service_overrides+=("$run_service" "$prebuilt_image" "")
     fi
   fi
 done <<< "$(plugin_read_list ALIAS_FROM)"

--- a/hooks/commands/run.sh
+++ b/hooks/commands/run.sh
@@ -38,16 +38,6 @@ while read -r name ; do
   fi
 done <<< "$(plugin_read_list PULL)"
 
-# Pull images specified from run-image-alias
-if [[ -z "${run_image_alias:-}" ]] ; then
-  if prebuilt_image=$(get_prebuilt_image "$run_image_alias") ; then
-    echo "~~~ :docker: Aliasing pre-built image for $run_service against $run_image_alias"
-    pull_services+=("$run_image_alias")
-    prebuilt_candidates+=("$run_image_alias")
-    prebuilt_service_overrides+=("$run_service" "$prebuilt_image" "")
-  fi
-fi
-
 # A list of tuples of [service image cache_from] for build_image_override_file
 prebuilt_service_overrides=()
 prebuilt_services=()
@@ -65,6 +55,17 @@ for service_name in "${prebuilt_candidates[@]}" ; do
    fi
   fi
 done
+
+# Pull images specified from run-image-alias
+if [[ -z "${run_image_alias:-}" ]] ; then
+  echo "~~~ :docker: Found runtime image alias for $run_image_alias"
+  if prebuilt_image=$(get_prebuilt_image "$run_image_alias") ; then
+    echo "~~~ :docker: Aliasing pre-built image for $run_service against $run_image_alias"
+    pull_services+=("$run_image_alias")
+    prebuilt_candidates+=("$run_image_alias")
+    prebuilt_service_overrides+=("$run_service" "$prebuilt_image" "")
+  fi
+fi
 
 # If there are any prebuilts, we need to generate an override docker-compose file
 if [[ ${#prebuilt_services[@]} -gt 0 ]] ; then

--- a/hooks/commands/run.sh
+++ b/hooks/commands/run.sh
@@ -57,7 +57,8 @@ for service_name in "${prebuilt_candidates[@]}" ; do
 done
 
 # Pull images specified from run-image-alias
-if [[ -z "${run_image_alias:-}" ]] ; then
+echo "~~~ :docker: (DEBUG) run_image_alias is $run_image_alias"
+if [[ -z "$run_image_alias" ]] ; then
   echo "~~~ :docker: Found runtime image alias for $run_image_alias"
   if prebuilt_image=$(get_prebuilt_image "$run_image_alias") ; then
     echo "~~~ :docker: Aliasing pre-built image for $run_service against $run_image_alias"

--- a/hooks/commands/run.sh
+++ b/hooks/commands/run.sh
@@ -64,6 +64,7 @@ if [[ -n "$run_image_alias" ]] ; then
     pull_services+=("$run_image_alias")
     prebuilt_candidates+=("$run_image_alias")
     prebuilt_services+=("$run_service")
+    prebuilt_service_overrides+=("$run_image_alias" "$prebuilt_image" "")
     prebuilt_service_overrides+=("$run_service" "$prebuilt_image" "")
   fi
 fi

--- a/hooks/commands/run.sh
+++ b/hooks/commands/run.sh
@@ -57,8 +57,7 @@ for service_name in "${prebuilt_candidates[@]}" ; do
 done
 
 # Pull images specified from run-image-alias
-echo "~~~ :docker: (DEBUG) run_image_alias is $run_image_alias"
-if [[ -z "$run_image_alias" ]] ; then
+if [[ -n "$run_image_alias" ]] ; then
   echo "~~~ :docker: Found runtime image alias for $run_image_alias"
   if prebuilt_image=$(get_prebuilt_image "$run_image_alias") ; then
     echo "~~~ :docker: Aliasing pre-built image for $run_service against $run_image_alias"

--- a/hooks/commands/run.sh
+++ b/hooks/commands/run.sh
@@ -38,8 +38,8 @@ while read -r name ; do
   fi
 done <<< "$(plugin_read_list PULL)"
 
-# Pull images specified from RUN_IMAGE_ALIAS
-if [[ -n "$run_image_alias" ]] ; then
+# Pull images specified from run-image-alias
+if [[ -z "${run_image_alias:-}" ]] ; then
   if prebuilt_image=$(get_prebuilt_image "$run_image_alias") ; then
     echo "~~~ :docker: Aliasing pre-built image for $run_service against $run_image_alias"
     pull_services+=("$run_image_alias")

--- a/hooks/commands/run.sh
+++ b/hooks/commands/run.sh
@@ -63,6 +63,7 @@ if [[ -z "${run_image_alias:-}" ]] ; then
     echo "~~~ :docker: Aliasing pre-built image for $run_service against $run_image_alias"
     pull_services+=("$run_image_alias")
     prebuilt_candidates+=("$run_image_alias")
+    prebuilt_services+=("$run_service")
     prebuilt_service_overrides+=("$run_service" "$prebuilt_image" "")
   fi
 fi

--- a/tests/composefiles/docker-compose.v3.2.shared-base-service.yml
+++ b/tests/composefiles/docker-compose.v3.2.shared-base-service.yml
@@ -6,10 +6,12 @@ services:
 
   service1:
     image: myimage:latest
+    command: echo service1
     depends_on:
       - base_service
 
   service2:
     image: myimage:latest
+    command: echo service2
     depends_on:
       - base_service

--- a/tests/composefiles/docker-compose.v3.2.shared-base-service.yml
+++ b/tests/composefiles/docker-compose.v3.2.shared-base-service.yml
@@ -1,0 +1,15 @@
+version: '3.2'
+services:
+  base_service:
+    build: .
+    image: myimage
+
+  service1:
+    image: myimage:latest
+    depends_on:
+      - base_service
+
+  service2:
+    image: myimage:latest
+    depends_on:
+      - base_service


### PR DESCRIPTION
The new configuration, run-image-alias will pull and alias an image for use by pipeline steps. This is one possible way that we could implement #122.

The goal of this new configuration is to generate the override file that looks like this:
```yaml
version: '3.1'
services:
  base_service:
    image: my.repo/image:docker-compose-plugin-${pipeline-slug}-${build-number}
  # Uses the built image for base_image, because we define run-image-alias in the pipeline.
  service1:
    image: my.repo/image:docker-compose-plugin-${pipeline-slug}-${build-number}
```

This probably isn't finished yet as I'm not great with bash, but opening this PR to get comments/thoughts. Maybe it's possible to leverage cache_from instead? Feel free to takeover/modify this PR. 