### PR TITLE
More portable check for empty config

### DIFF
--- a/lib/shared.bash
+++ b/lib/shared.bash
@@ -67,7 +67,8 @@ function docker_compose_config_files() {
     [[ -n "$line" ]] && config_files+=("$line")
   done <<< "$(plugin_read_list CONFIG)"
 
-  if [[ ${#config_files[@]:-} -eq 0 ]]  ; then
+  # Use a default if there are no config files specified
+  if [[ -z "${config_files[*]:-}" ]]  ; then
     echo "docker-compose.yml"
     return
   fi


### PR DESCRIPTION
It seems some bash versions have problems with `${#config_files[@]:-}` as an expansion, which frankly is fair enough as it seems pretty sketchy to me too. 

Closes #113 