### PR TITLE
Support cache-from in run

### DIFF
--- a/lib/shared.bash
+++ b/lib/shared.bash
@@ -190,3 +190,19 @@ function retry {
 
   echo "$status"
 }
+
+function set_cached_from_for_service() {
+  local service_name="$1"
+  local service_image="$2"
+
+  printf -v "cache_from__${service_name}" %s "$service_image"
+}
+
+function get_cached_from_for_service() {
+  local service_name="$1"
+  local cache_key="cache_from__${service_name}"
+
+  if [[ -n "${!cache_key-}" ]] ; then
+    echo "${!cache_key}"
+  fi
+}

--- a/lib/shared.bash
+++ b/lib/shared.bash
@@ -110,7 +110,10 @@ function build_image_override_file_with_version() {
   shift
   while test ${#} -gt 0 ; do
     printf "  %s:\\n" "$1"
-    printf "    image: %s\\n" "$2"
+
+    if [[ -n "$2" ]] ; then
+      printf "    image: %s\\n" "$2"
+    fi
 
     if [[ -n "$3" ]] ; then
       if [[ -z "$version" || "$version" == 2* || "$version" == 3 || "$version" == 3.0* || "$version" == 3.1* ]]; then

--- a/tests/run.bats
+++ b/tests/run.bats
@@ -368,3 +368,33 @@ export BUILDKITE_JOB_ID=1111
   unstub docker-compose
   unstub buildkite-agent
 }
+
+@test "Run with a service that with a prebuilt cache_from" {
+  export BUILDKITE_JOB_ID=1111
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CONFIG=tests/composefiles/docker-compose.v3.2.yml
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RUN=myservice
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CACHE_FROM=base_service
+  export BUILDKITE_PIPELINE_SLUG=test
+  export BUILDKITE_BUILD_NUMBER=1
+  export BUILDKITE_COMMAND=pwd
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CHECK_LINKED_CONTAINERS=false
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLEANUP=false
+
+  stub docker-compose \
+    "-f ${BUILDKITE_PLUGIN_DOCKER_COMPOSE_CONFIG} -p buildkite1111 -f docker-compose.buildkite-1-override.yml pull base_service : echo pulled base_service" \
+    "-f ${BUILDKITE_PLUGIN_DOCKER_COMPOSE_CONFIG} -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 myservice pwd : echo ran myservice"
+
+  stub buildkite-agent \
+    "meta-data get docker-compose-plugin-built-image-tag-myservice-${BUILDKITE_PLUGIN_DOCKER_COMPOSE_CONFIG} : exit 1" \
+    "meta-data get docker-compose-plugin-built-image-tag-base_service-${BUILDKITE_PLUGIN_DOCKER_COMPOSE_CONFIG} : echo myimage1"
+
+  run $PWD/hooks/command
+
+  assert_success
+  assert_output --partial "pulled base_service"
+  assert_output --partial "ran myservice"
+  assert_output --partial "cache_from:"
+  unstub docker-compose
+  unstub buildkite-agent
+}
+


### PR DESCRIPTION
This allows for the `cache-from` directive to be used in run commands. This means you can prebuilt a shared base image and then use it as the cache ancestry for subsequent run commands that would otherwise rebuild images from scratch, for instance:

### pipeline.yml
```yaml
steps:
  - name: ':docker: :package:'
    plugins:
      'docker-compose#aa08b09':
        build: base_service
        image-repository: my.registry/llamas
  - wait
  - name: 'task 1'
    command: echo hello world
    plugins:
      'docker-compose#aa08b09':
        run: service1
        cache_from: base_service
  - name: 'task 2'
    command: echo hello world
    plugins:
      'docker-compose#aa08b09':
        run: service2
        cache_from: base_service
```

### docker-compose.yml
```
version: '3.4'
services:
  base_service:
    build: .

  service1:
    build: .

  service2:
    build: .
```

Related to #122 and #127.