### PR TITLE
Expands the previous header groups on error

### DIFF
--- a/commands/run.sh
+++ b/commands/run.sh
@@ -10,6 +10,11 @@ override_file="docker-compose.buildkite-${BUILDKITE_BUILD_NUMBER}-override.yml"
 pull_retries="$(plugin_read_config PULL_RETRIES "0")"
 
 cleanup() {
+  # shellcheck disable=SC2181
+  if [[ $? -ne 0 ]] ; then
+    echo "^^^ +++"
+  fi
+
   echo "~~~ :docker: Cleaning up after docker-compose" >&2
   compose_cleanup
 }


### PR DESCRIPTION
Currently if a step like "Building" or "Pulling" fails, the error is buried because our header expansion gear favours the final cleanup step.

This ensures that on errors the previous group gets expanded before the cleanup step. 