### PR TITLE
Fix bug with hyphens in service names

### DIFF
--- a/lib/push.bash
+++ b/lib/push.bash
@@ -5,7 +5,7 @@ compose_image_for_service() {
   local image=""
 
   image=$(run_docker_compose config \
-    | grep -E "^(  \\w+:|    image:)" \
+    | grep -E "^(  [_[:alnum:]-]+:|    image:)" \
     | grep -E "(  ${service}:)" -A 1 \
     | grep -oE '  image: (.+)' \
     | awk '{print $2}')

--- a/tests/composefiles/docker-compose.config.with.hyphens.yml
+++ b/tests/composefiles/docker-compose.config.with.hyphens.yml
@@ -1,0 +1,8 @@
+version: '3.2'
+services:
+  app:
+    build: ../..
+    depends_on:
+      - foo-db
+  foo-db:
+    image: postgres:9.4

--- a/tests/docker-compose-images.bats
+++ b/tests/docker-compose-images.bats
@@ -18,6 +18,18 @@ load '../lib/push'
   unstub docker-compose
 }
 
+@test "Image for compose service with a service with hyphens in the name" {
+  export HIDE_PROMPT=1
+  stub docker-compose \
+    "-f docker-compose.yml -p buildkite config : cat $PWD/tests/composefiles/docker-compose.config.with.hyphens.yml"
+
+  run compose_image_for_service "app"
+
+  assert_success
+  assert_output "buildkite_app"
+  unstub docker-compose
+}
+
 @test "Image for compose service without an image in config" {
   export HIDE_PROMPT=1
   stub docker-compose \


### PR DESCRIPTION
We've found that if we have a docker-compose file like so:

```
services:
  app:
    build: ../..
    depends_on:
      - foo-db
  foo-db:
    image: postgres:9.4
```

The push command will tag the app image as `postgres:9.4`, which causes all kinds of bizarre problems.

The issue is the regular expression being used `\w` expands to `[_[:alnum:]]` which won't match a hyphen.

This PR fixes the issue and creates a test for the scenario