### PR TITLE
Less alarming messages

### DIFF
--- a/commands/run.sh
+++ b/commands/run.sh
@@ -105,6 +105,7 @@ run_params+=("$run_service")
 
 if [[ ! -f "$override_file" ]]; then
   echo "~~~ :docker: Building Docker Compose Service: $run_service" >&2
+  echo "⚠️ No pre-built image found from a previous 'build' step for this service and config file. Building image..."
   run_docker_compose build --pull "$run_service"
 fi
 

--- a/lib/metadata.bash
+++ b/lib/metadata.bash
@@ -4,10 +4,7 @@
 function plugin_get_metadata() {
   local key="docker-compose-plugin-$1"
   plugin_prompt buildkite-agent meta-data get "$key"
-  buildkite-agent meta-data get "$key" || (
-    echo "~~~ Failed to get metadata $key (exit $?)" >&2
-    return 1
-  )
+  buildkite-agent meta-data get "$key"
 }
 
 # Write agent metadata for the plugin


### PR DESCRIPTION
Calling out a header with "Failed" is leading some customers astray:

<img width="1113" alt="screen shot 2018-05-18 at 11 28 13 am" src="https://user-images.githubusercontent.com/14028/40211568-b7ac4362-5a8e-11e8-89c4-d290871bc73a.png">

Expanding this header isn't useful:

<img width="1117" alt="screen shot 2018-05-18 at 11 28 25 am" src="https://user-images.githubusercontent.com/14028/40211574-bfbd52b2-5a8e-11e8-9ce4-14a09bf318ec.png">

The buildkite-agent meta-data commands are already quite chatty and should have sufficient output for debugging, without being alarmist about missing meta-data:

<img width="1115" alt="screen shot 2018-05-18 at 11 27 49 am" src="https://user-images.githubusercontent.com/14028/40211575-c4728958-5a8e-11e8-9039-07f047b8d1a8.png">

I've removed the header. Thoughts?