### PR TITLE
Quiten container log output

### DIFF
--- a/lib/run.bash
+++ b/lib/run.bash
@@ -35,7 +35,7 @@ check_linked_containers_and_save_logs() {
 
     # Capture logs if the linked container failed OR if the main command failed
     if [[ $container_exit_code -ne 0 ]] || [[ $cmdexit -ne 0 ]] ; then
-      plugin_prompt_and_run docker logs --timestamps --tail 500 "$container_name"
+      plugin_prompt_and_run docker logs --timestamps --tail 5 "$container_name"
       docker logs -t "$container_name" > "${logdir}/${container_name}.log"
     fi
   done


### PR DESCRIPTION
This makes the container log output a little less noisy, and also skips it if it's run outside of a BK job (so it works with [bksr](https://github.com/toolmantim/bksr))