### PR TITLE
Add `--workdir` support for run steps.

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,6 +276,13 @@ A list of KEY=VALUE that are passed through as build arguments when image is bei
 
 A list of either KEY or KEY=VALUE that are passed through as environment variables to the container.
 
+### `workdir` (optional, run only)
+
+Specify the container working directory via `docker-compose run --workdir`.
+
+For example, `workdir: "${BUILDKITE_BUILD_CHECKOUT_PATH}"` may be used to run
+within the build directory given appropriately configured volume mounts.
+
 ### `pull-retries` (optional)
 
 A number of times to retry failed docker pull. Defaults to 0.

--- a/README.md
+++ b/README.md
@@ -280,9 +280,6 @@ A list of either KEY or KEY=VALUE that are passed through as environment variabl
 
 Specify the container working directory via `docker-compose run --workdir`.
 
-For example, `workdir: "${BUILDKITE_BUILD_CHECKOUT_PATH}"` may be used to run
-within the build directory given appropriately configured volume mounts.
-
 ### `pull-retries` (optional)
 
 A number of times to retry failed docker pull. Defaults to 0.

--- a/commands/run.sh
+++ b/commands/run.sh
@@ -101,6 +101,10 @@ if [[ "$(plugin_read_config DEPENDENCIES "true")" == "false" ]] ; then
   run_params+=(--no-deps)
 fi
 
+if [[ -n "$(plugin_read_config WORKDIR)" ]] ; then
+  run_params+=(--workdir="$(plugin_read_config WORKDIR)")
+fi
+
 run_params+=("$run_service")
 
 if [[ ! -f "$override_file" ]]; then

--- a/plugin.yml
+++ b/plugin.yml
@@ -50,6 +50,8 @@ configuration:
       type: boolean
     verbose:
       type: boolean
+    workdir:
+      type: string
   oneOf:
     - required:
       - run
@@ -71,3 +73,4 @@ configuration:
     no-cache: [ build ]
     dependencies: [ run ]
     tty: [ run ]
+    workdir: [ run ]

--- a/tests/run.bats
+++ b/tests/run.bats
@@ -58,6 +58,32 @@ load '../lib/run'
   unstub buildkite-agent
 }
 
+@test "Run without a prebuilt image and a custom workdir" {
+  export BUILDKITE_JOB_ID=1111
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RUN=myservice
+  export BUILDKITE_PIPELINE_SLUG=test
+  export BUILDKITE_BUILD_NUMBER=1
+  export BUILDKITE_COMMAND=""
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_WORKDIR=/test_workdir
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CHECK_LINKED_CONTAINERS=false
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLEANUP=false
+
+  stub docker-compose \
+    "-f docker-compose.yml -p buildkite1111 build --pull myservice : echo built myservice" \
+    "-f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 --workdir=/test_workdir myservice : echo ran myservice"
+
+  stub buildkite-agent \
+    "meta-data get docker-compose-plugin-built-image-tag-myservice : exit 1"
+
+  run $PWD/hooks/command
+
+  assert_success
+  assert_output --partial "built myservice"
+  assert_output --partial "ran myservice"
+  unstub docker-compose
+  unstub buildkite-agent
+}
+
 @test "Run without a prebuilt image with a complicated command" {
   export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RUN=myservice


### PR DESCRIPTION
Adds support for the `--workdir` option for `docker-compose run` steps
via a `workdir` plugin option. This provides support for step-specific
working directories, which may depend on the build-time environment.
This is intended to support `run` steps within the build directory when
used in combination with appropriate volume mounts.