### PR TITLE
Add support for running service with the --service-ports flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,6 +276,10 @@ A list of KEY=VALUE that are passed through as build arguments when image is bei
 
 A list of either KEY or KEY=VALUE that are passed through as environment variables to the container.
 
+### `service-ports` (optional, run only)
+
+Map the services ports to the host via `docker-compose run --service-ports`.
+
 ### `pull-retries` (optional)
 
 A number of times to retry failed docker pull. Defaults to 0.

--- a/commands/run.sh
+++ b/commands/run.sh
@@ -101,6 +101,11 @@ if [[ "$(plugin_read_config DEPENDENCIES "true")" == "false" ]] ; then
   run_params+=(--no-deps)
 fi
 
+# Optionally enable mapping service ports to host
+if [[ "$(plugin_read_config SERVICE_PORTS "false")" == "true" ]] ; then
+  run_params+=(--service-ports)
+fi
+
 run_params+=("$run_service")
 
 if [[ ! -f "$override_file" ]]; then

--- a/plugin.yml
+++ b/plugin.yml
@@ -50,6 +50,8 @@ configuration:
       type: boolean
     verbose:
       type: boolean
+    service-ports:
+      type: boolean
   oneOf:
     - required:
       - run
@@ -71,3 +73,4 @@ configuration:
     no-cache: [ build ]
     dependencies: [ run ]
     tty: [ run ]
+    service-ports: [ run ]

--- a/tests/run.bats
+++ b/tests/run.bats
@@ -111,6 +111,32 @@ load '../lib/run'
   unstub buildkite-agent
 }
 
+@test "Run without a prebuilt image with service-ports enabled" {
+  export BUILDKITE_JOB_ID=1111
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RUN=myservice
+  export BUILDKITE_PIPELINE_SLUG=test
+  export BUILDKITE_BUILD_NUMBER=1
+  export BUILDKITE_COMMAND=""
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_SERVICE_PORTS=true
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CHECK_LINKED_CONTAINERS=false
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLEANUP=false
+
+  stub docker-compose \
+    "-f docker-compose.yml -p buildkite1111 build --pull myservice : echo built myservice" \
+    "-f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 --service-ports myservice : echo ran myservice"
+
+  stub buildkite-agent \
+    "meta-data get docker-compose-plugin-built-image-tag-myservice : exit 1"
+
+  run $PWD/hooks/command
+
+  assert_success
+  assert_output --partial "built myservice"
+  assert_output --partial "ran myservice"
+  unstub docker-compose
+  unstub buildkite-agent
+}
+
 @test "Run with a prebuilt image" {
   export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RUN=myservice


### PR DESCRIPTION
Docker compose does to map service ports to the host when using the `run` command by default, even when it is configured in the docker-compose.yml file. You can use the `--service-ports` flag with the `run` command to enable mapping the ports to the host.

This adds a `service-ports` plugin option to allow using the `--service-ports` flag in the `run` command.