### PR TITLE
add --no-ansi optional parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,6 +318,12 @@ If set to false, doesn't start linked services.
 
 The default is `true`.
 
+### `ansi` (optional, run only)
+
+If set to false, disables the ansi output from containers.
+
+The default is `true`.
+
 ### `verbose` (optional)
 
 Sets `docker-compose` to run with `--verbose`

--- a/commands/run.sh
+++ b/commands/run.sh
@@ -101,6 +101,11 @@ if [[ "$(plugin_read_config DEPENDENCIES "true")" == "false" ]] ; then
   run_params+=(--no-deps)
 fi
 
+# Optionally disable ansi output
+if [[ "$(plugin_read_config ANSI "true")" == "false" ]] ; then
+  run_params+=(--no-ansi)
+fi
+
 run_params+=("$run_service")
 
 if [[ ! -f "$override_file" ]]; then

--- a/plugin.yml
+++ b/plugin.yml
@@ -48,6 +48,8 @@ configuration:
       type: boolean
     dependencies:
       type: boolean
+    ansi:
+      type: boolean
     verbose:
       type: boolean
   oneOf:
@@ -70,4 +72,5 @@ configuration:
     leave-volumes: [ run ]
     no-cache: [ build ]
     dependencies: [ run ]
+    ansi: [ run ]
     tty: [ run ]

--- a/tests/run.bats
+++ b/tests/run.bats
@@ -286,6 +286,31 @@ export BUILDKITE_JOB_ID=1111
   unstub buildkite-agent
 }
 
+@test "Run without ansi output" {
+  export BUILDKITE_JOB_ID=1111
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RUN=myservice
+  export BUILDKITE_PIPELINE_SLUG=test
+  export BUILDKITE_BUILD_NUMBER=1
+  export BUILDKITE_COMMAND=pwd
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CHECK_LINKED_CONTAINERS=false
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLEANUP=false
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_ANSI=false
+
+  stub docker-compose \
+    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml pull myservice : echo pulled myservice" \
+    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 --no-ansi myservice pwd : echo ran myservice without ansi output"
+
+  stub buildkite-agent \
+    "meta-data get docker-compose-plugin-built-image-tag-myservice : echo myimage"
+
+  run $PWD/hooks/command
+
+  assert_success
+  assert_output --partial "ran myservice without ansi output"
+  unstub docker-compose
+  unstub buildkite-agent
+}
+
 @test "Run with multiple config files" {
   export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RUN=myservice


### PR DESCRIPTION
This PR adds an option to run the docker compose plugin with `--no-ansi` flag enabled. This is needed because sometimes ansi enabled outputs mess up the step timing in Buildkite's UI which ends up showing the timing in the wrong steps.