### PR TITLE
Expand local volume paths

### DIFF
--- a/commands/run.sh
+++ b/commands/run.sh
@@ -92,7 +92,7 @@ done <<< "$(printf '%s\n%s' \
   "$(plugin_read_list ENVIRONMENT)")"
 
 while IFS=$'\n' read -r vol ; do
-  [[ -n "${vol:-}" ]] && run_params+=("-v" "${vol}")
+  [[ -n "${vol:-}" ]] && run_params+=("-v" "$(expand_relative_volume_path "$vol")")
 done <<< "$(plugin_read_list VOLUMES)"
 
 # Optionally disable allocating a TTY

--- a/lib/run.bash
+++ b/lib/run.bash
@@ -40,3 +40,12 @@ check_linked_containers_and_save_logs() {
     fi
   done
 }
+
+# docker-compose's -v arguments don't do local path expansion like the .yml
+# versions do. So we add very simple support, for the common and basic case.
+# 
+# "./foo:/foo" => "/buildkite/builds/.../foo:/foo"
+expand_relative_volume_path() {
+  local path="$1"
+  echo "${path/.\//$PWD/}"
+}

--- a/tests/run.bats
+++ b/tests/run.bats
@@ -350,7 +350,7 @@ export BUILDKITE_JOB_ID=1111
 
   stub docker-compose \
     "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml pull myservice : echo pulled myservice" \
-    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 -v ./dist:/app/dist -v ./pkg:/app/pkg myservice pwd : echo ran myservice with volumes"
+    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 -v $PWD/dist:/app/dist -v $PWD/pkg:/app/pkg myservice pwd : echo ran myservice with volumes"
 
   stub buildkite-agent \
     "meta-data get docker-compose-plugin-built-image-tag-myservice : echo myimage"


### PR DESCRIPTION
Fixes #155, and the following example from the documentation, by expanding `./` to `$PWD` at run-time, because docker-compose only does relative volumes paths in the YAML-style configuration:

```yml
steps:
  - command: generate-dist.sh
    artifact_paths: "dist/*"
    plugins:
      docker-compose#v2.4.0:
        run: app
        volumes:
          - "./dist:/app/dist"
```