### PR TITLE
Add support for default volume mounts

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,6 +315,8 @@ Note: this option can only be specified on a `build` step.
 
 A list of volumes to mount into the container. If a matching volume exists in the Docker Compose config file, this option will override that definition.
 
+Additionally, volumes may be specified via the agent environment variable `BUILDKITE_DOCKER_DEFAULT_VOLUMES`, a `;` (semicolon)  delimited list of mounts in the `-v` syntax. (Ex. `buildkite:/buildkite;./app:/app`).
+
 ### `leave-volumes` (optional, run only)
 
 Prevent the removal of volumes after the command has been run.

--- a/commands/run.sh
+++ b/commands/run.sh
@@ -95,6 +95,10 @@ while IFS=$'\n' read -r vol ; do
   [[ -n "${vol:-}" ]] && run_params+=("-v" "$(expand_relative_volume_path "$vol")")
 done <<< "$(plugin_read_list VOLUMES)"
 
+while IFS=$'\n' read -r vol ; do
+  [[ -n "${vol:-}" ]] && run_params+=("-v" "$(expand_relative_volume_path "$vol")")
+done <<< "$(prefix_read_list BUILDKITE_DOCKER_DEFAULT_VOLUMES)"
+
 # Optionally disable allocating a TTY
 if [[ "$(plugin_read_config TTY "true")" == "false" ]] ; then
   run_params+=(-T)

--- a/commands/run.sh
+++ b/commands/run.sh
@@ -95,9 +95,12 @@ while IFS=$'\n' read -r vol ; do
   [[ -n "${vol:-}" ]] && run_params+=("-v" "$(expand_relative_volume_path "$vol")")
 done <<< "$(plugin_read_list VOLUMES)"
 
-while IFS=$'\n' read -r vol ; do
-  [[ -n "${vol:-}" ]] && run_params+=("-v" "$(expand_relative_volume_path "$vol")")
-done <<< "$(prefix_read_list BUILDKITE_DOCKER_DEFAULT_VOLUMES)"
+IFS=';' read -r -a default_volumes <<< "${BUILDKITE_DOCKER_DEFAULT_VOLUMES:-}"
+for vol in "${default_volumes[@]:-}"
+do
+  vol=`echo "${vol:-}"`
+  [[ -n "${vol}" ]] && run_params+=("-v" "$(expand_relative_volume_path "$vol")")
+done
 
 # Optionally disable allocating a TTY
 if [[ "$(plugin_read_config TTY "true")" == "false" ]] ; then

--- a/lib/shared.bash
+++ b/lib/shared.bash
@@ -29,7 +29,12 @@ function plugin_read_config() {
 
 # Reads either a value or a list from plugin config
 function plugin_read_list() {
-  local prefix="BUILDKITE_PLUGIN_DOCKER_COMPOSE_$1"
+  prefix_read_list "BUILDKITE_PLUGIN_DOCKER_COMPOSE_$1"
+}
+
+# Reads either a value or a list from the given env prefix
+function prefix_read_list() {
+  local prefix="$1"
   local parameter="${prefix}_0"
 
   if [[ -n "${!parameter:-}" ]]; then

--- a/tests/run.bats
+++ b/tests/run.bats
@@ -363,6 +363,57 @@ export BUILDKITE_JOB_ID=1111
   unstub buildkite-agent
 }
 
+@test "Run with an external volume" {
+  export BUILDKITE_JOB_ID=1111
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RUN=myservice
+  export BUILDKITE_PIPELINE_SLUG=test
+  export BUILDKITE_BUILD_NUMBER=1
+  export BUILDKITE_COMMAND=pwd
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CHECK_LINKED_CONTAINERS=false
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLEANUP=false
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_VOLUMES="buildkite:/buildkite"
+
+  stub docker-compose \
+    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml pull myservice : echo pulled myservice" \
+    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 -v buildkite:/buildkite myservice pwd : echo ran myservice with volumes"
+
+  stub buildkite-agent \
+    "meta-data get docker-compose-plugin-built-image-tag-myservice : echo myimage"
+
+  run $PWD/hooks/command
+
+  assert_success
+  assert_output --partial "ran myservice with volumes"
+  unstub docker-compose
+  unstub buildkite-agent
+}
+
+@test "Run with default volumes" {
+  export BUILDKITE_JOB_ID=1111
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RUN=myservice
+  export BUILDKITE_PIPELINE_SLUG=test
+  export BUILDKITE_BUILD_NUMBER=1
+  export BUILDKITE_COMMAND=pwd
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CHECK_LINKED_CONTAINERS=false
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLEANUP=false
+  export BUILDKITE_DOCKER_DEFAULT_VOLUMES_0="buildkite:/buildkite"
+  export BUILDKITE_DOCKER_DEFAULT_VOLUMES_1="./dist:/app/dist"
+
+  stub docker-compose \
+    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml pull myservice : echo pulled myservice" \
+    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 -v buildkite:/buildkite -v $PWD/dist:/app/dist myservice pwd : echo ran myservice with volumes"
+
+  stub buildkite-agent \
+    "meta-data get docker-compose-plugin-built-image-tag-myservice : echo myimage"
+
+  run $PWD/hooks/command
+
+  assert_success
+  assert_output --partial "ran myservice with volumes"
+  unstub docker-compose
+  unstub buildkite-agent
+}
+
 @test "Run with multiple config files" {
   export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RUN=myservice


### PR DESCRIPTION
Add support for the generic environment variable `BUILDKITE_DOCKER_DEFAULT_VOLUMES`, specifying a set of volume mounts that are *always* passed into `docker-compose run` invocations. 

This feature is intended to support scenarios where the `buildkite-agent` is run via `docker-compose` with the `BUILDKITE_BUILD_PATH` located on a external volume mount. `BUILDKITE_DOCKER_DEFAULT_VOLUMES` can the be used to ensure that this mount is available in `docker-compose` based pipeline steps, giving simplified access to the build directory.

For a working example see [uw-ipd/buildkite-agent](https://github.com/uw-ipd/buildkite-agent).

My hope is that a feature of this type is elevated to a roughly standard status for `buildkite-agent`-within-`docker` configurations and that `BUILDKITE_DOCKER_DEFAULT_VOLUMES` can be adopted by `docker`-based pipeline plugins as a mechanism to pass state between the build command and pipeline-based hook implementations in cases where build artifacts are not an suitable choice. For example, our [github-checks](https://github.com/uw-ipd/github-checks-buildkite-plugin) integration plugin will adopt this feature to ensure that build outputs are available as check output.