### PR TITLE
Properly handle whitespace-only entries in default-volumes.

### DIFF
--- a/commands/run.sh
+++ b/commands/run.sh
@@ -98,8 +98,9 @@ done <<< "$(plugin_read_list VOLUMES)"
 IFS=';' read -r -a default_volumes <<< "${BUILDKITE_DOCKER_DEFAULT_VOLUMES:-}"
 for vol in "${default_volumes[@]:-}"
 do
-  vol=`echo "${vol:-}"`
-  [[ -n "${vol}" ]] && run_params+=("-v" "$(expand_relative_volume_path "$vol")")
+  # Trim all whitespace when checking for variable definition, handling cases
+  # with repeated delimiters.
+  [[ ! -z "${vol// }" ]] && run_params+=("-v" "$(expand_relative_volume_path "$vol")")
 done
 
 # Optionally disable allocating a TTY

--- a/tests/run.bats
+++ b/tests/run.bats
@@ -398,7 +398,7 @@ export BUILDKITE_JOB_ID=1111
   export BUILDKITE_COMMAND=pwd
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CHECK_LINKED_CONTAINERS=false
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLEANUP=false
-  export BUILDKITE_DOCKER_DEFAULT_VOLUMES="buildkite:/buildkite; ./dist:/app/dist;;"
+  export BUILDKITE_DOCKER_DEFAULT_VOLUMES="buildkite:/buildkite; ./dist:/app/dist;; ;   ;"
 
   stub docker-compose \
     "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml pull myservice : echo pulled myservice" \


### PR DESCRIPTION
Property handle instances of whitespace-only entries between extras
delimiters when parsing DOCKER_BUILDKITE_DEFAULT_VOLUMES. Fixes linting
error in shellcheck.