### PR TITLE
Support cache_from directive in composefile 2.2+

### DIFF
--- a/lib/shared.bash
+++ b/lib/shared.bash
@@ -97,6 +97,14 @@ function build_image_override_file() {
     "$(docker_compose_config_version)" "$@"
 }
 
+# Checks that a specific version of docker-compose supports cache_from
+function docker_compose_supports_cache_from() {
+  local version="$1"
+  if [[ -z "$version" || "$version" == 1* || "$version" =~ ^(2|3)(\.[01])?$ ]] ; then
+    return 1
+  fi
+}
+
 # Build an docker-compose file that overrides the image for a specific
 # docker-compose version and set of [ service, image, cache_from ] tuples
 function build_image_override_file_with_version() {
@@ -118,9 +126,9 @@ function build_image_override_file_with_version() {
     printf "    image: %s\\n" "$2"
 
     if [[ -n "$3" ]] ; then
-      if [[ -z "$version" || "$version" == 2* || "$version" == 3 || "$version" == 3.0* || "$version" == 3.1* ]]; then
+      if ! docker_compose_supports_cache_from "$version" ; then
         echo "Unsupported Docker Compose config file version: $version"
-        echo "The 'cache_from' option can only be used with Compose file versions 3.2 and above."
+        echo "The 'cache_from' option can only be used with Compose file versions 2.2 or 3.2 and above."
         echo "For more information on Docker Compose configuration file versions, see:"
         echo "https://docs.docker.com/compose/compose-file/compose-versioning/#versioning"
         exit 1

--- a/tests/docker-compose-config.bats
+++ b/tests/docker-compose-config.bats
@@ -51,3 +51,35 @@ load '../lib/shared'
   assert_success
   assert_output "2.1"
 }
+
+@test "Whether docker-compose supports cache_from directive" {
+  run docker_compose_supports_cache_from ""
+  assert_failure
+
+  run docker_compose_supports_cache_from "1.0"
+  assert_failure
+
+  run docker_compose_supports_cache_from "2"
+  assert_failure
+
+  run docker_compose_supports_cache_from "2.1"
+  assert_failure
+
+  run docker_compose_supports_cache_from "2.2"
+  assert_success
+
+  run docker_compose_supports_cache_from "2.3"
+  assert_success
+
+  run docker_compose_supports_cache_from "3"
+  assert_failure
+
+  run docker_compose_supports_cache_from "3.1"
+  assert_failure
+
+  run docker_compose_supports_cache_from "3.2"
+  assert_success
+
+  run docker_compose_supports_cache_from "3.3"
+  assert_success
+}


### PR DESCRIPTION
Based on discussion in https://github.com/buildkite-plugins/docker-compose-buildkite-plugin/commit/e454d2bef1498fc5020a9d4201b9986fd468386d#commitcomment-30002868, this allows `cache_from` usage in compose file versions 2.2, where previously we only allowed 3.2. 

/cc @bjeanes @dreyks