### PR TITLE
Document `command` caveats

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,18 @@ steps:
         run: app
 ```
 
+Note that the `command` of any step run within Docker Compose must consist of only a single command. This is because Docker Compose itself is only capable of running one command at a time.
+
+If you need to run multiple commands, and your Docker image contains a suitable shell, you can use an approach like this:
+
+```yml
+steps:
+  - command: sh -c "rubocop; rspec"
+    plugins:
+      docker-compose#v2.5.1:
+        run: app
+```
+
 ## Artifacts
 
 If you’re generating artifacts in the build step, you’ll need to ensure your Docker Compose configuration volume mounts the host machine directory into the container where those artifacts are created.


### PR DESCRIPTION
`command` steps don’t have the same semantics when run within Docker Compose; only a single command may be run, and we do not convert multi-line steps to a single-line call to any shell.

Documents #59.