### PR TITLE
allow multiple cache images for one service

### DIFF
--- a/commands/build.sh
+++ b/commands/build.sh
@@ -15,10 +15,15 @@ for line in $(plugin_read_list CACHE_FROM) ; do
   IFS=':' read -r -a tokens <<< "$line"
   service_name=${tokens[0]}
   service_image=$(IFS=':'; echo "${tokens[*]:1}")
+  cache_image_name="$(service_name_cache_from_var "$service_name")"
+
+  if [[ -n ${!cache_image_name+x} ]]; then
+    continue # skipping since there's already a pulled cache image for this service
+  fi
 
   echo "~~~ :docker: Pulling cache image for $service_name"
   if retry "$pull_retries" plugin_prompt_and_run docker pull "$service_image" ; then
-    printf -v "$(service_name_cache_from_var "$service_name")" "%s" "$service_image"
+    printf -v "$cache_image_name" "%s" "$service_image"
   else
     echo "!!! :docker: Pull failed. $service_image will not be used as a cache for $service_name"
   fi

--- a/tests/build.bats
+++ b/tests/build.bats
@@ -197,6 +197,59 @@ load '../lib/shared'
   unstub docker-compose
 }
 
+@test "Build with several cache-from images for one service" {
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CONFIG="tests/composefiles/docker-compose.v3.2.yml"
+  export BUILDKITE_JOB_ID=1111
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD_0=helloworld
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CACHE_FROM_0=helloworld:my.repository/myservice_cache:branch-name
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CACHE_FROM_1=helloworld:my.repository/myservice_cache:latest
+  export BUILDKITE_PIPELINE_SLUG=test
+  export BUILDKITE_BUILD_NUMBER=1
+
+  stub docker \
+    "pull my.repository/myservice_cache:branch-name : echo pulled cache image"
+
+  stub docker-compose \
+    "-f tests/composefiles/docker-compose.v3.2.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml build --pull helloworld : echo built helloworld"
+
+  run $PWD/hooks/command
+
+  assert_success
+  assert_output --partial "pulled cache image"
+  assert_output --partial "- my.repository/myservice_cache:branch-name"
+  refute_output --partial "- my.repository/myservice_cache:latest"
+  assert_output --partial "built helloworld"
+  unstub docker
+  unstub docker-compose
+}
+
+@test "Build with several cache-from images for one service with first image being not available" {
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CONFIG="tests/composefiles/docker-compose.v3.2.yml"
+  export BUILDKITE_JOB_ID=1111
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD_0=helloworld
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CACHE_FROM_0=helloworld:my.repository/myservice_cache:branch-name
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CACHE_FROM_1=helloworld:my.repository/myservice_cache:latest
+  export BUILDKITE_PIPELINE_SLUG=test
+  export BUILDKITE_BUILD_NUMBER=1
+
+  stub docker \
+    "pull my.repository/myservice_cache:branch-name : exit 1" \
+    "pull my.repository/myservice_cache:latest : echo pulled cache image"
+
+  stub docker-compose \
+    "-f tests/composefiles/docker-compose.v3.2.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml build --pull helloworld : echo built helloworld"
+
+  run $PWD/hooks/command
+
+  assert_success
+  assert_output --partial "pulled cache image"
+  refute_output --partial "- my.repository/myservice_cache:branch-name"
+  assert_output --partial "- my.repository/myservice_cache:latest"
+  assert_output --partial "built helloworld"
+  unstub docker
+  unstub docker-compose
+}
+
 @test "Build with a cache-from image when pulling of the cache-from image failed" {
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CONFIG="tests/composefiles/docker-compose.v3.2.yml"
   export BUILDKITE_JOB_ID=1111


### PR DESCRIPTION
First image that gets successfully pulled stops the chain for this service. The idea is to have
```yml
cache-from:
  - app:myrepo/myapp:${BUILDKITE_BRANCH}
  - app:myrepo/myapp:latest
```
so that subsequent builds for a branch will use the cache for this specific branch