### PR TITLE
Move cleanup to a pre-exit hook to handle cancel

### DIFF
--- a/commands/run.sh
+++ b/commands/run.sh
@@ -9,20 +9,10 @@ container_name="$(docker_compose_project_name)_${run_service}_build_${BUILDKITE_
 override_file="docker-compose.buildkite-${BUILDKITE_BUILD_NUMBER}-override.yml"
 pull_retries="$(plugin_read_config PULL_RETRIES "0")"
 
-cleanup() {
-  # shellcheck disable=SC2181
-  if [[ $? -ne 0 ]] ; then
-    echo "^^^ +++"
-  fi
-
-  echo "~~~ :docker: Cleaning up after docker-compose" >&2
-  compose_cleanup
+expand_headers_on_error() {
+  echo "^^^ +++"
 }
-
-# clean up docker containers on EXIT
-if [[ "$(plugin_read_config CLEANUP "true")" == "true" ]] ; then
-  trap cleanup EXIT
-fi
+trap cleanup ERR
 
 test -f "$override_file" && rm "$override_file"
 

--- a/commands/run.sh
+++ b/commands/run.sh
@@ -152,7 +152,7 @@ if [[ $exitcode -ne 0 ]] ; then
   echo "+++ :warning: Failed to run command, exited with $exitcode"
 fi
 
-if [[ ! -z "${BUILDKITE_AGENT_ACCESS_TOKEN:-}" ]] ; then
+if [[ -n "${BUILDKITE_AGENT_ACCESS_TOKEN:-}" ]] ; then
   if [[ "$(plugin_read_config CHECK_LINKED_CONTAINERS "true")" == "true" ]] ; then
     docker_ps_by_project \
       --format 'table {{.Label "com.docker.compose.service"}}\t{{ .ID }}\t{{ .Status }}'

--- a/hooks/pre-exit
+++ b/hooks/pre-exit
@@ -1,0 +1,19 @@
+#!/bin/bash
+set -ueo pipefail
+
+DIR="$(cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd)"
+
+# shellcheck source=lib/shared.bash
+. "$DIR/../lib/shared.bash"
+# shellcheck source=lib/metadata.bash
+. "$DIR/../lib/metadata.bash"
+
+# clean up resources after a run command. we do this here so that it will
+# run after a job is cancelled
+if [[ -n "$(plugin_read_list RUN)" ]] && [[ "$(plugin_read_config CLEANUP "true")" == "true" ]] ; then
+  # shellcheck source=lib/run.bash
+  . "$DIR/../lib/run.bash"
+
+  echo "~~~ :docker: Cleaning up after docker-compose" >&2
+  compose_cleanup
+fi

--- a/tests/cleanup.bats
+++ b/tests/cleanup.bats
@@ -1,0 +1,29 @@
+#!/usr/bin/env bats
+
+load '/usr/local/lib/bats/load.bash'
+load '../lib/shared'
+load '../lib/run'
+
+# export DOCKER_COMPOSE_STUB_DEBUG=/dev/tty
+# export BATS_MOCK_TMPDIR=$PWD
+
+@test "Cleanup runs after a run command" {
+  export BUILDKITE_JOB_ID=1111
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RUN=myservice
+  export BUILDKITE_PIPELINE_SLUG=test
+  export BUILDKITE_BUILD_NUMBER=1
+  export BUILDKITE_COMMAND=pwd
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CHECK_LINKED_CONTAINERS=false
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLEANUP=true
+
+  stub docker-compose \
+    "-f docker-compose.yml -p buildkite1111 kill : echo killing containers" \
+    "-f docker-compose.yml -p buildkite1111 rm --force -v : echo removing stopped containers" \
+    "-f docker-compose.yml -p buildkite1111 down --volumes : echo removing everything"
+
+  run $PWD/hooks/pre-exit
+
+  assert_success
+  assert_output --partial "Cleaning up after docker-compose"
+  unstub docker-compose
+}

--- a/tests/run.bats
+++ b/tests/run.bats
@@ -469,33 +469,6 @@ export BUILDKITE_JOB_ID=1111
   unstub buildkite-agent
 }
 
-@test "Run with a failure still runs cleanup" {
-  export BUILDKITE_JOB_ID=1111
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RUN=myservice
-  export BUILDKITE_PIPELINE_SLUG=test
-  export BUILDKITE_BUILD_NUMBER=1
-  export BUILDKITE_COMMAND=pwd
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CHECK_LINKED_CONTAINERS=false
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLEANUP=true
-
-  stub docker-compose \
-    "-f docker-compose.yml -p buildkite1111 build --pull myservice : echo built myservice" \
-    "-f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 myservice pwd : exit 1" \
-    "-f docker-compose.yml -p buildkite1111 kill : echo killing containers" \
-    "-f docker-compose.yml -p buildkite1111 rm --force -v : echo removing stopped containers" \
-    "-f docker-compose.yml -p buildkite1111 down --volumes : echo removing everything"
-
-  stub buildkite-agent \
-    "meta-data get docker-compose-plugin-built-image-tag-myservice : exit 1"
-
-  run $PWD/hooks/command
-
-  assert_failure
-  assert_output --partial "Failed to run command, exited with 1"
-  unstub docker-compose
-  unstub buildkite-agent
-}
-
 @test "Run with a failure should expand previous group" {
   export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RUN=myservice


### PR DESCRIPTION
Currently when a job is cancelled, it will kill the command hook and often docker-compose won't have time to cleanup. This moves the cancellation to a `pre-exit` hook to give it more time to run.

Closes #169.