### PR TITLE
[bug] Fix custom image path when a build repository is defined

### DIFF
--- a/commands/build.sh
+++ b/commands/build.sh
@@ -31,7 +31,7 @@ for service_name in $(plugin_read_list BUILD) ; do
   service_idx=$((service_idx+1))
 
   if [[ -n "$image_repository" ]]; then
-    image_name="${image_repository}:${image_name}"
+    image_name="${image_repository}/${image_name}"
   fi
 
   build_images+=("$service_name" "$image_name")


### PR DESCRIPTION
This issue affects the `build` step, specifically the path creation of an image to push when a repository and image name are specified.

## Example Config:
```json
{
    "plugins": {
        "docker-compose": {
            "build": "app",
            "config": "some/directory/docker-compose.yml",
            "image-repository": "gcr.io/project/repo",
            "image-name": "app:latest"
        }
    }
}
```

## Problem/Solution:
The resulting image path would end up malformed.

#### Before fix:
`${image_repository}:${image_name}`
`gcr.io/project/repo:app:latest`

#### After fix:
`${image_repository}/${image_name}`
`gcr.io/project/repo/app:latest`