### PR TITLE
Support use aliases so network aliases can be used with the plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -392,6 +392,12 @@ If set to false, disables the ansi output from containers.
 
 The default is `true`.
 
+### `use-aliases` (optional, run only)
+
+If set to true, docker compose will use the service's network aliases in the network(s) the container connects to.
+
+The default is `false`.
+
 ### `verbose` (optional)
 
 Sets `docker-compose` to run with `--verbose`

--- a/commands/run.sh
+++ b/commands/run.sh
@@ -112,6 +112,11 @@ if [[ "$(plugin_read_config ANSI "true")" == "false" ]] ; then
   run_params+=(--no-ansi)
 fi
 
+# Enable alias support for networks
+if [[ "$(plugin_read_config USE_ALIASES "false")" == "true" ]] ; then
+  run_params+=(--use-aliases)
+fi
+
 run_params+=("$run_service")
 
 if [[ ! -f "$override_file" ]]; then

--- a/plugin.yml
+++ b/plugin.yml
@@ -47,6 +47,8 @@ configuration:
       type: boolean
     no-cache:
       type: boolean
+    use-aliases:
+      type: boolean
     tty:
       type: boolean
     dependencies:
@@ -77,6 +79,7 @@ configuration:
     volumes: [ run ]
     leave-volumes: [ run ]
     no-cache: [ build ]
+    use-aliases: [ run ]
     dependencies: [ run ]
     ansi: [ run ]
     tty: [ run ]

--- a/tests/run.bats
+++ b/tests/run.bats
@@ -338,6 +338,31 @@ export BUILDKITE_JOB_ID=1111
   unstub buildkite-agent
 }
 
+@test "Run with use aliases" {
+  export BUILDKITE_JOB_ID=1111
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RUN=myservice
+  export BUILDKITE_PIPELINE_SLUG=test
+  export BUILDKITE_BUILD_NUMBER=1
+  export BUILDKITE_COMMAND=pwd
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CHECK_LINKED_CONTAINERS=false
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLEANUP=false
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_USE_ALIASES=true
+
+  stub docker-compose \
+    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml pull myservice : echo pulled myservice" \
+    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 --use-aliases myservice pwd : echo ran myservice with use aliases output"
+
+  stub buildkite-agent \
+    "meta-data get docker-compose-plugin-built-image-tag-myservice : echo myimage"
+
+  run $PWD/hooks/command
+
+  assert_success
+  assert_output --partial "ran myservice with use aliases output"
+  unstub docker-compose
+  unstub buildkite-agent
+}
+
 @test "Run with a volumes option" {
   export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RUN=myservice


### PR DESCRIPTION
I use network aliases during some of our pipelines and so the `docker-compose run` command needs to have the `--use-aliases` option so that they actually take effect.