### PR TITLE
Add command parameter with support for array-based arguments

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -40,7 +40,7 @@ steps:
     plugins:
       ${BUILDKITE_REPO}#${BUILDKITE_COMMIT}:
         build: helloworld
-        image-repository: buildkiteci/docker-compose-buildkite-plugin
+        image-repository: ${DOCKER_REPO-buildkiteci/docker-compose-buildkite-plugin}
         config: tests/composefiles/docker-compose.v2.1.yml
 
   - wait
@@ -87,7 +87,7 @@ steps:
     plugins:
       ${BUILDKITE_REPO}#${BUILDKITE_COMMIT}:
         build: helloworld
-        image-repository: buildkiteci/docker-compose-buildkite-plugin
+        image-repository: ${DOCKER_REPO-buildkiteci/docker-compose-buildkite-plugin}
         image-name: llamas-build-${BUILDKITE_BUILD_NUMBER}
         config: tests/composefiles/docker-compose.v2.1.yml
 

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -45,19 +45,19 @@ steps:
 
   - wait
   - label: run after build with v2.0
-    command: /hello
     plugins:
       ${BUILDKITE_REPO}#${BUILDKITE_COMMIT}:
         run: helloworld
         config: tests/composefiles/docker-compose.v2.0.yml
+        command: /hello
 
   - wait
   - label: run after build with v2.1
-    command: /hello
     plugins:
       ${BUILDKITE_REPO}#${BUILDKITE_COMMIT}:
         run: helloworld
         config: tests/composefiles/docker-compose.v2.1.yml
+        command: ["/hello"]
 
   - wait
   - label: run with default command
@@ -68,19 +68,19 @@ steps:
 
   - wait
   - label: build, where serice has build and image-name
-    command: /hello
     plugins:
       ${BUILDKITE_REPO}#${BUILDKITE_COMMIT}:
         build: helloworldimage
         config: tests/composefiles/docker-compose.v2.1.yml
+        commmand: ["/hello"]
 
   - wait
   - label: run after build
-    command: /hello
     plugins:
       ${BUILDKITE_REPO}#${BUILDKITE_COMMIT}:
         run: helloworldimage
         config: tests/composefiles/docker-compose.v2.1.yml
+        commmand: ["/hello"]
 
   - wait
   - label: build with custom image-name
@@ -93,11 +93,11 @@ steps:
 
   - wait
   - label: run after build with custom image-name
-    command: /hello
     plugins:
       ${BUILDKITE_REPO}#${BUILDKITE_COMMIT}:
         run: helloworld
         config: tests/composefiles/docker-compose.v2.1.yml
+        commmand: ["/hello"]
 
   - wait
   - label: push after build with custom image-name

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -49,7 +49,7 @@ steps:
       ${BUILDKITE_REPO}#${BUILDKITE_COMMIT}:
         run: helloworld
         config: tests/composefiles/docker-compose.v2.0.yml
-        command: /hello
+        command: ["/hello"]
 
   - wait
   - label: run after build with v2.1

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 docker-compose.buildkite-1-override.yml 
+docker-compose-logs/

--- a/commands/build.sh
+++ b/commands/build.sh
@@ -11,6 +11,7 @@ service_name_cache_from_var() {
   echo "cache_from__${service_name//-/_}"
 }
 
+# Read any cache-from parameters provided and pull down those images first
 for line in $(plugin_read_list CACHE_FROM) ; do
   IFS=':' read -r -a tokens <<< "$line"
   service_name=${tokens[0]}
@@ -30,6 +31,8 @@ for line in $(plugin_read_list CACHE_FROM) ; do
 done
 
 # Run through all images in the build property, either a single item or a list
+# and build up a list of service name, image name and optional cache-froms to
+# write into a docker-compose override file
 service_idx=0
 for service_name in $(plugin_read_list BUILD) ; do
   image_name=$(build_image_name "${service_name}" "${service_idx}")

--- a/commands/run.sh
+++ b/commands/run.sh
@@ -168,7 +168,7 @@ command=()
 
 # Show a helpful error message if string version of command is used
 if [[ -n "${BUILDKITE_PLUGIN_DOCKER_COMPOSE_COMMAND:-}" ]] ; then
-  echo -n "🚨 The Docker Compose Plugin’s command configuration option must be an array."
+  echo "🚨 The Docker Compose Plugin’s command configuration option must be an array."
   exit 1
 fi
 

--- a/lib/shared.bash
+++ b/lib/shared.bash
@@ -50,6 +50,28 @@ function prefix_read_list() {
   fi
 }
 
+# Reads either a value or a list from plugin config into a global result array
+# Returns success if values were read
+function plugin_read_list_into_result() {
+  local prefix="$1"
+  local parameter="${prefix}_0"
+  result=()
+
+  if [[ -n "${!parameter:-}" ]]; then
+    local i=0
+    local parameter="${prefix}_${i}"
+    while [[ -n "${!parameter:-}" ]]; do
+      result+=("${!parameter}")
+      i=$((i+1))
+      parameter="${prefix}_${i}"
+    done
+  elif [[ -n "${!prefix:-}" ]]; then
+    result+=("${!prefix}")
+  fi
+
+  [[ ${#result[@]} -gt 0 ]] || return 1
+}
+
 # Returns the name of the docker compose project for this build
 function docker_compose_project_name() {
   # No dashes or underscores because docker-compose will remove them anyways

--- a/tests/run.bats
+++ b/tests/run.bats
@@ -19,7 +19,7 @@ load '../lib/run'
 
   stub docker-compose \
     "-f docker-compose.yml -p buildkite1111 build --pull myservice : echo built myservice" \
-    "-f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 myservice echo hello world : echo ran myservice"
+    "-f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 myservice /bin/sh -e -c 'echo hello world' : echo ran myservice"
 
   stub buildkite-agent \
     "meta-data get docker-compose-plugin-built-image-tag-myservice : exit 1"
@@ -95,7 +95,34 @@ load '../lib/run'
 
   stub docker-compose \
     "-f docker-compose.yml -p buildkite1111 build --pull myservice : echo built myservice" \
-    "-f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 myservice $BUILDKITE_COMMAND : echo ran myservice"
+    "-f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 myservice /bin/sh -e -c 'sh -c \'echo hello world\'' : echo ran myservice"
+
+  stub buildkite-agent \
+    "meta-data get docker-compose-plugin-built-image-tag-myservice : exit 1"
+
+  run $PWD/hooks/command
+
+  assert_success
+  assert_output --partial "built myservice"
+  assert_output --partial "ran myservice"
+  unstub docker-compose
+  unstub buildkite-agent
+}
+
+@test "Run without a prebuilt image with a command config" {
+  export BUILDKITE_JOB_ID=1111
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RUN=myservice
+  export BUILDKITE_PIPELINE_SLUG=test
+  export BUILDKITE_BUILD_NUMBER=1
+  export BUILDKITE_COMMAND=""
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_COMMAND_0=echo
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_COMMAND_1="hello world"
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CHECK_LINKED_CONTAINERS=false
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLEANUP=false
+
+  stub docker-compose \
+    "-f docker-compose.yml -p buildkite1111 build --pull myservice : echo built myservice" \
+    "-f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 myservice echo hello world' : echo ran myservice"
 
   stub buildkite-agent \
     "meta-data get docker-compose-plugin-built-image-tag-myservice : exit 1"
@@ -125,7 +152,7 @@ load '../lib/run'
 
   stub docker-compose \
     "-f docker-compose.yml -p buildkite1111 build --pull myservice : echo built myservice" \
-    "-f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 -e MYENV=0 -e MYENV -e MYENV=2 -e MYENV -e ANOTHER=this\ is\ a\ long\ string\ with\ spaces\;\ and\ semi-colons myservice pwd : echo ran myservice"
+    "-f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 -e MYENV=0 -e MYENV -e MYENV=2 -e MYENV -e ANOTHER=this\ is\ a\ long\ string\ with\ spaces\;\ and\ semi-colons myservice /bin/sh -e -c 'pwd' : echo ran myservice"
 
   stub buildkite-agent \
     "meta-data get docker-compose-plugin-built-image-tag-myservice : exit 1"
@@ -149,7 +176,7 @@ load '../lib/run'
 
   stub docker-compose \
     "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml pull myservice : echo pulled myservice" \
-    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 myservice pwd : echo ran myservice"
+    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 myservice /bin/sh -e -c 'pwd' : echo ran myservice"
 
   stub buildkite-agent \
     "meta-data get docker-compose-plugin-built-image-tag-myservice : echo myimage"
@@ -174,7 +201,7 @@ load '../lib/run'
 
   stub docker-compose \
     "-f tests/composefiles/docker-compose.v2.0.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml pull myservice : echo pulled myservice" \
-    "-f tests/composefiles/docker-compose.v2.0.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 myservice pwd : echo ran myservice"
+    "-f tests/composefiles/docker-compose.v2.0.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 myservice /bin/sh -e -c 'pwd' : echo ran myservice"
 
   stub buildkite-agent \
     "meta-data get docker-compose-plugin-built-image-tag-myservice-tests/composefiles/docker-compose.v2.0.yml : echo myimage"
@@ -200,7 +227,7 @@ export BUILDKITE_JOB_ID=1111
 
   stub docker-compose \
     "-f tests/composefiles/docker-compose.v2.0.yml -f tests/composefiles/docker-compose.v2.1.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml pull myservice : echo pulled myservice" \
-    "-f tests/composefiles/docker-compose.v2.0.yml -f tests/composefiles/docker-compose.v2.1.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 myservice pwd : echo ran myservice"
+    "-f tests/composefiles/docker-compose.v2.0.yml -f tests/composefiles/docker-compose.v2.1.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 myservice /bin/sh -e -c 'pwd' : echo ran myservice"
 
   stub buildkite-agent \
     "meta-data get docker-compose-plugin-built-image-tag-myservice-tests/composefiles/docker-compose.v2.0.yml-tests/composefiles/docker-compose.v2.1.yml : echo myimage"
@@ -249,7 +276,7 @@ export BUILDKITE_JOB_ID=1111
   stub docker-compose \
     "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml pull myservice : exit 2" \
     "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml pull myservice : echo pulled myservice" \
-    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 myservice pwd : echo ran myservice"
+    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 myservice /bin/sh -e -c 'pwd' : echo ran myservice"
 
   stub buildkite-agent \
     "meta-data get docker-compose-plugin-built-image-tag-myservice : echo myimage"
@@ -275,7 +302,7 @@ export BUILDKITE_JOB_ID=1111
 
   stub docker-compose \
     "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml pull myservice : echo pulled myservice" \
-    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 -T myservice pwd : echo ran myservice without tty"
+    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 -T myservice /bin/sh -e -c 'pwd' : echo ran myservice without tty"
 
   stub buildkite-agent \
     "meta-data get docker-compose-plugin-built-image-tag-myservice : echo myimage"
@@ -300,7 +327,7 @@ export BUILDKITE_JOB_ID=1111
 
   stub docker-compose \
     "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml pull myservice : echo pulled myservice" \
-    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 --no-deps myservice pwd : echo ran myservice without dependencies"
+    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 --no-deps myservice /bin/sh -e -c 'pwd' : echo ran myservice without dependencies"
 
   stub buildkite-agent \
     "meta-data get docker-compose-plugin-built-image-tag-myservice : echo myimage"
@@ -325,7 +352,7 @@ export BUILDKITE_JOB_ID=1111
 
   stub docker-compose \
     "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml pull myservice : echo pulled myservice" \
-    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 --no-ansi myservice pwd : echo ran myservice without ansi output"
+    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 --no-ansi myservice /bin/sh -e -c 'pwd' : echo ran myservice without ansi output"
 
   stub buildkite-agent \
     "meta-data get docker-compose-plugin-built-image-tag-myservice : echo myimage"
@@ -376,7 +403,7 @@ export BUILDKITE_JOB_ID=1111
 
   stub docker-compose \
     "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml pull myservice : echo pulled myservice" \
-    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 -v $PWD/dist:/app/dist -v $PWD/pkg:/app/pkg myservice pwd : echo ran myservice with volumes"
+    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 -v $PWD/dist:/app/dist -v $PWD/pkg:/app/pkg myservice /bin/sh -e -c 'pwd' : echo ran myservice with volumes"
 
   stub buildkite-agent \
     "meta-data get docker-compose-plugin-built-image-tag-myservice : echo myimage"
@@ -401,7 +428,7 @@ export BUILDKITE_JOB_ID=1111
 
   stub docker-compose \
     "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml pull myservice : echo pulled myservice" \
-    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 -v buildkite:/buildkite myservice pwd : echo ran myservice with volumes"
+    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 -v buildkite:/buildkite myservice /bin/sh -e -c 'pwd' : echo ran myservice with volumes"
 
   stub buildkite-agent \
     "meta-data get docker-compose-plugin-built-image-tag-myservice : echo myimage"
@@ -428,7 +455,7 @@ export BUILDKITE_JOB_ID=1111
 
   stub docker-compose \
     "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml pull myservice : echo pulled myservice" \
-    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 -v buildkite:/buildkite -v $PWD/dist:/app/dist myservice pwd : echo ran myservice with volumes"
+    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 -v buildkite:/buildkite -v $PWD/dist:/app/dist myservice /bin/sh -e -c 'pwd' : echo ran myservice with volumes"
 
   stub buildkite-agent \
     "meta-data get docker-compose-plugin-built-image-tag-myservice : echo myimage"
@@ -453,7 +480,7 @@ export BUILDKITE_JOB_ID=1111
 
   stub docker-compose \
     "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml pull myservice : echo pulled myservice" \
-    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 -v buildkite:/buildkite -v $PWD/dist:/app/dist myservice pwd : echo ran myservice with volumes"
+    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 -v buildkite:/buildkite -v $PWD/dist:/app/dist myservice /bin/sh -e -c 'pwd' : echo ran myservice with volumes"
 
   stub buildkite-agent \
     "meta-data get docker-compose-plugin-built-image-tag-myservice : echo myimage"
@@ -480,7 +507,7 @@ export BUILDKITE_JOB_ID=1111
 
   stub docker-compose \
     "-f llamas1.yml -f llamas2.yml -f llamas3.yml -p buildkite1111 build --pull myservice : echo built myservice" \
-    "-f llamas1.yml -f llamas2.yml -f llamas3.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 myservice echo hello world : echo ran myservice"
+    "-f llamas1.yml -f llamas2.yml -f llamas3.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 myservice /bin/sh -e -c 'echo hello world' : echo ran myservice"
 
   stub buildkite-agent \
     "meta-data get docker-compose-plugin-built-image-tag-myservice-llamas1.yml-llamas2.yml-llamas3.yml : exit 1"
@@ -505,7 +532,7 @@ export BUILDKITE_JOB_ID=1111
 
   stub docker-compose \
     "-f docker-compose.yml -p buildkite1111 build --pull myservice : echo built myservice" \
-    "-f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 myservice pwd : exit 2"
+    "-f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 myservice /bin/sh -e -c 'pwd' : exit 2"
 
   stub buildkite-agent \
     "meta-data get docker-compose-plugin-built-image-tag-myservice : exit 1"
@@ -532,7 +559,7 @@ export BUILDKITE_JOB_ID=1111
 
   stub docker-compose \
     "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml pull --parallel myservice1 myservice2 : echo pulled myservice1 and myservice2" \
-    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice1_build_1 myservice1 pwd : echo ran myservice1"
+    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice1_build_1 myservice1 /bin/sh -e -c 'pwd' : echo ran myservice1"
 
   stub buildkite-agent \
     "meta-data get docker-compose-plugin-built-image-tag-myservice1 : echo myimage1" \

--- a/tests/run.bats
+++ b/tests/run.bats
@@ -377,7 +377,7 @@ export BUILDKITE_JOB_ID=1111
 
   stub docker-compose \
     "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml pull myservice : echo pulled myservice" \
-    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 --use-aliases myservice pwd : echo ran myservice with use aliases output"
+    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 --use-aliases myservice /bin/sh -e -c 'pwd' : echo ran myservice with use aliases output"
 
   stub buildkite-agent \
     "meta-data get docker-compose-plugin-built-image-tag-myservice : echo myimage"
@@ -586,7 +586,7 @@ export BUILDKITE_JOB_ID=1111
 
   stub docker-compose \
     "-f docker-compose.yml -p buildkite1111 build --pull myservice : echo built myservice" \
-    "-f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 --user=1000 myservice $BUILDKITE_COMMAND : echo ran myservice"
+    "-f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 --user=1000 myservice /bin/sh -e -c 'sh -c \'whoami\'' : echo ran myservice"
 
   stub buildkite-agent \
     "meta-data get docker-compose-plugin-built-image-tag-myservice : exit 1"


### PR DESCRIPTION
This is a port of the learnings from https://github.com/buildkite-plugins/docker-buildkite-plugin/pull/68.

It changes the default behaviour from trying to parse the `$BUILDKITE_COMMAND` into tokens into defaulting to `/bin/sh -e -c "$BUILDKITE_COMMAND"`. This removes the need to try and tokenize the arguments, which has lead to a lot of historical bugs and confusion.

Using a shell is useful because often users assume that a shell exists, and use commands with shell-isms like:

* `command1 && command2`
* `command > outfile`
* `echo hello world`
* `command < myfile.txt`
* `command1; command2; command3`

Also, critically, a shell is needed for multi-line commands, which are currently unsupported (closes  #59).

To support images that don't have `/bin/sh` in them, or where the `entrypoint` is set such that passing a shell wouldn't make sense, a new config option of `shell` and `command` are added.

## New: `shell` config

The `shell` parameter allows for the customization of the shell vs the default:

```yaml
steps:
  - command: "npm run tests"
     plugins:
       - docker-compose:
           run: "windows-app"
           shell: ["CMD.EXE", "/C"]
```

or you can disable the shell to get the previous behaviour:

```yaml
steps:
  - command: "npm run tests"
     plugins:
       - docker-compose:
           run: "app"
           shell: false
```

## New: `command` config

The `command` config also allows for very specific parsing of arguments to pass directly to the `docker-compose` command. A shell is not inferred when the `command` config is used. 

```yaml
steps:
  - plugins:
       - docker-compose:
           run: "app"
           command: ["yarn", "run", "tests"]
```

## Breaking change: Images are assumed to have a shell

The plugin now assumes the container running your command has a shell accessible at `/bin/sh`.

* If your container doesn’t have a shell, you’ll need to install a shell by adding one to your `Dockerfile`, or switching to using the new `command` plugin option.
* If your container has a shell in a location other than `/bin/sh` use the new `shell` plugin option to customize the path.
* If your container has a custom entrypoint that expects the raw arguments, use the new `command` plugin option.

## Breaking change: Windows support 

A subsequent PR will add automatic Windows detection, but in the meantime to use this plugin on Windows images set the new plugin `shell` option to `["CMD.EXE","/C"]`. 