### PR TITLE
Add cache-from-command plugin entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -356,6 +356,10 @@ This option can also be configured on the agent machine using the environment va
 
 A list of images to pull caches from in the format `service:index.docker.io/myorg/myrepo/myapp:tag` before building, ignoring any failures. If multiple images are listed for a service, the first one to successfully pull will be used. Requires docker-compose file version `3.2+`.
 
+### `cache-from-command` (optional, build only)
+
+A command that returns a list of images to pull caches from in the format `service:index.docker.io/myorg/myrepo/myapp:tag` before building, ignoring any failures. If multiple images are listed for a service, the first one to successfully pull will be used. Requires docker-compose file version `3.2+`.
+
 ### `volumes` (optional, run only)
 
 A list of volumes to mount into the container. If a matching volume exists in the Docker Compose config file, this option will override that definition.

--- a/plugin.yml
+++ b/plugin.yml
@@ -40,6 +40,8 @@ configuration:
     cache-from:
       type: [ string, array ]
       minimum: 1
+    cache-from-command:
+      type: [ string ]
     volumes:
       type: [ string, array ]
       minimum: 1
@@ -76,6 +78,7 @@ configuration:
     pull-retries: [ build, run ]
     push-retries: [ push ]
     cache-from: [ build ]
+    cache-from-command: [ build ]
     volumes: [ run ]
     leave-volumes: [ run ]
     no-cache: [ build ]

--- a/tests/build.bats
+++ b/tests/build.bats
@@ -325,6 +325,33 @@ load '../lib/shared'
   unstub docker-compose
 }
 
+@test "Build with a cache-from-command image" {
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CONFIG="tests/composefiles/docker-compose.v3.2.yml"
+  export BUILDKITE_JOB_ID=1111
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD_0=helloworld
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CACHE_FROM_COMMAND="cachier my.repository/myservice_cache:latest"
+  export BUILDKITE_PIPELINE_SLUG=test
+  export BUILDKITE_BUILD_NUMBER=1
+
+  stub cachier \
+    "my.repository/myservice_cache:latest : echo helloworld:my.repository/myservice_cache:latest"
+
+  stub docker \
+    "pull my.repository/myservice_cache:latest : echo pulled cache image"
+
+  stub docker-compose \
+    "-f tests/composefiles/docker-compose.v3.2.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml build --pull helloworld : echo built helloworld"
+
+  run $PWD/hooks/command
+
+  assert_success
+  assert_output --partial "pulled cache image"
+  assert_output --partial "- my.repository/myservice_cache:latest"
+  assert_output --partial "built helloworld"
+  unstub docker
+  unstub docker-compose
+}
+
 @test "Build with a custom image-name" {
   export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD=myservice


### PR DESCRIPTION
This adds the ability to pull cache image(s) from a command rather than a
static string.

This is useful when determining the latest image from metadata other than
a docker tag like latest.

![](https://media3.giphy.com/media/JIX9t2j0ZTN9S/200w.gif)

Signed-off-by: Elliott Davis <elliott@excellent.io>