### PR TITLE
Correctly handle . in docker compose service names.

### DIFF
--- a/lib/push.bash
+++ b/lib/push.bash
@@ -5,7 +5,7 @@ compose_image_for_service() {
   local image=""
 
   image=$(run_docker_compose config \
-    | grep -E "^(  [_[:alnum:]-]+:|    image:)" \
+    | grep -E "^(  [_[:alnum:]-.]+:|    image:)" \
     | grep -E "(  ${service}:)" -A 1 \
     | grep -oE '  image: (.+)' \
     | awk '{print $2}')


### PR DESCRIPTION
Prior to this fix a service with periods in such as "kafka-0.broker.kafka" may cause the plugin to mistakenly use the kafka service's image for other services which didn't specify an image.

docker-compose has supported periods since 2015: https://github.com/docker/compose/pull/1624.