### PR TITLE
Add build aliases

### DIFF
--- a/README.md
+++ b/README.md
@@ -335,6 +335,10 @@ This option can also be configured on the agent machine using the environment va
 
 The name to use when tagging pre-built images. If multiple images are built in the build phase, you must provide an array of image names.
 
+### `alias` (optional, build only)
+
+Other docker-compose services that should be aliased to the main service that was built. This is for when different docker-compose services share the same prebuilt image.
+
 ### `args` (optional, build only)
 
 A list of KEY=VALUE that are passed through as build arguments when image is being built.

--- a/README.md
+++ b/README.md
@@ -335,7 +335,7 @@ This option can also be configured on the agent machine using the environment va
 
 The name to use when tagging pre-built images. If multiple images are built in the build phase, you must provide an array of image names.
 
-### `alias` (optional, build only)
+### `build-alias` (optional, build only)
 
 Other docker-compose services that should be aliased to the main service that was built. This is for when different docker-compose services share the same prebuilt image.
 

--- a/commands/build.sh
+++ b/commands/build.sh
@@ -92,7 +92,7 @@ if [[ -n "$image_repository" ]] ; then
     set_prebuilt_image "${build_images[0]}" "${build_images[1]}"
 
     # set aliases
-    for service_alias in $(plugin_read_list ALIAS) ; do
+    for service_alias in $(plugin_read_list BUILD_ALIAS) ; do
       set_prebuilt_image "$service_alias" "${build_images[1]}"
     done
 

--- a/commands/build.sh
+++ b/commands/build.sh
@@ -87,8 +87,16 @@ if [[ -n "$image_repository" ]] ; then
   echo "~~~ :docker: Pushing built images to $image_repository"
   retry "$push_retries" run_docker_compose -f "$override_file" push "${services[@]}"
 
+  # iterate over build images
   while [[ ${#build_images[@]} -gt 0 ]] ; do
     set_prebuilt_image "${build_images[0]}" "${build_images[1]}"
+
+    # set aliases
+    for service_alias in $(plugin_read_list ALIAS) ; do
+      set_prebuilt_image "$service_alias" "${build_images[1]}"
+    done
+
+    # pop-off the last build image
     build_images=("${build_images[@]:3}")
   done
 fi

--- a/plugin.yml
+++ b/plugin.yml
@@ -29,6 +29,9 @@ configuration:
     args:
       type: [ string, array ]
       minimum: 1
+    alias:
+      type: [ string, array ]
+      minimum:
     image-repository:
       type: string
     image-name:

--- a/plugin.yml
+++ b/plugin.yml
@@ -29,7 +29,7 @@ configuration:
     args:
       type: [ string, array ]
       minimum: 1
-    alias:
+    build-alias:
       type: [ string, array ]
       minimum: 1
     image-repository:

--- a/plugin.yml
+++ b/plugin.yml
@@ -31,7 +31,7 @@ configuration:
       minimum: 1
     alias:
       type: [ string, array ]
-      minimum:
+      minimum: 1
     image-repository:
       type: string
     image-name:

--- a/tests/build.bats
+++ b/tests/build.bats
@@ -82,12 +82,12 @@ load '../lib/shared'
   unstub buildkite-agent
 }
 
-@test "Build with a repository and multiple aliases" {
+@test "Build with a repository and multiple build aliases" {
   export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD=myservice
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_IMAGE_REPOSITORY=my.repository/llamas
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_ALIAS_0=myservice-1
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_ALIAS_1=myservice-2
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD_ALIAS_0=myservice-1
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD_ALIAS_1=myservice-2
   export BUILDKITE_PIPELINE_SLUG=test
   export BUILDKITE_BUILD_NUMBER=1
 

--- a/tests/build.bats
+++ b/tests/build.bats
@@ -82,6 +82,36 @@ load '../lib/shared'
   unstub buildkite-agent
 }
 
+@test "Build with a repository and multiple aliases" {
+  export BUILDKITE_JOB_ID=1111
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD=myservice
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_IMAGE_REPOSITORY=my.repository/llamas
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_ALIAS_0=myservice-1
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_ALIAS_1=myservice-2
+  export BUILDKITE_PIPELINE_SLUG=test
+  export BUILDKITE_BUILD_NUMBER=1
+
+  stub docker-compose \
+    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml build --pull myservice : echo built myservice" \
+    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml push myservice : echo pushed myservice" \
+
+  stub buildkite-agent \
+    "meta-data set docker-compose-plugin-built-image-tag-myservice my.repository/llamas:test-myservice-build-1 : echo set image metadata for myservice" \
+    "meta-data set docker-compose-plugin-built-image-tag-myservice-1 my.repository/llamas:test-myservice-build-1 : echo set image metadata for myservice-1" \
+    "meta-data set docker-compose-plugin-built-image-tag-myservice-2 my.repository/llamas:test-myservice-build-1 : echo set image metadata for myservice-2"
+
+  run $PWD/hooks/command
+
+  assert_success
+  assert_output --partial "built myservice"
+  assert_output --partial "pushed myservice"
+  assert_output --partial "set image metadata for myservice"
+  assert_output --partial "set image metadata for myservice-1"
+  assert_output --partial "set image metadata for myservice-2"
+  unstub docker-compose
+  unstub buildkite-agent
+}
+
 @test "Build with a repository and push retries" {
   export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD=myservice


### PR DESCRIPTION
Often docker-compose setups will have multiple variants of services with different dependencies. For example:

```yml
version: “3”
services:
  app: &app
    build: .
  app-with-mysql:
    <<: *app
    depends_on: [ mysql ]
  app-with-postgres:
    <<: *app
    depends_on: [ postgres ]
  mysql:
    image: mysql
  postgres:
    image: postgres
```

Currently this needs to be expressed in a `build` as:

```yaml
steps:
  - label: ":docker: Build"
    plugins:
      - docker-compose#v2.6.0:
          build: [ app, app-with-mysql, app-with-postgres ]
  - wait
  - label: ":mysql:"
    plugins:
      - docker-compose#v2.6.0:
          run: app-with-mysql
  - label: ":postgres:"
    plugins:
      - docker-compose#v2.6.0:
          run: app-with-postgres
```

This works, because it re-uses the docker cache, but it ends up running the docker-compose build and then subsequent pushes three times, which is slow. 

This new syntax allows for aliasing services, which will do a single push and use that image for any future step matching the service and alias names:

```yaml
steps:
  - label: ":docker: Build"
    plugins:
      - docker-compose#v2.6.0:
          build: app
          build-alias: [ app-with-mysql, app-with-postgres ]
  - wait
  - label: ":mysql:"
    plugins:
      - docker-compose#v2.6.0:
          run: app-with-mysql
  - label: ":postgres:"
    plugins:
      - docker-compose#v2.6.0:
          run: app-with-postgres
```

Feels @matthewd @toolmantim? 