### PR TITLE
Add skip checkout option

### DIFF
--- a/README.md
+++ b/README.md
@@ -357,6 +357,10 @@ Set the shell to use for the command. Set it to `false` to pass the command dire
 
 Example: `[ "powershell", "-Command" ]`
 
+### `skip-checkout` (optional, run only)
+
+Whether to skip the repository checkout phase. This is useful for steps that use a pre-built image. This will fail if there is no pre-built image.
+
 ### `workdir` (optional, run only)
 
 Specify the container working directory via `docker-compose run --workdir`.

--- a/hooks/pre-checkout
+++ b/hooks/pre-checkout
@@ -9,7 +9,7 @@ DIR="$(cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd)"
 . "$DIR/../lib/metadata.bash"
 
 # skip checkout if skip-checkout is set
-if [[ "$(plugin_read_config SKIP_CHECKOUT "true")" == "true" ]] ; then
+if [[ "$(plugin_read_config SKIP_CHECKOUT "false")" == "true" ]] ; then
   export BUILDKITE_REPO=""
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_REQUIRE_PREBUILD="true"
 fi

--- a/hooks/pre-checkout
+++ b/hooks/pre-checkout
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -ueo pipefail
+
+DIR="$(cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd)"
+
+# shellcheck source=lib/shared.bash
+. "$DIR/../lib/shared.bash"
+# shellcheck source=lib/metadata.bash
+. "$DIR/../lib/metadata.bash"
+
+# skip checkout if skip-checkout is set
+if [[ "$(plugin_read_config SKIP_CHECKOUT "true")" == "true" ]] ; then
+  export BUILDKITE_REPO=""
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_REQUIRE_PREBUILD="true"
+fi

--- a/plugin.yml
+++ b/plugin.yml
@@ -45,6 +45,8 @@ configuration:
       minimum: 1
     command:
       type: array
+    skip-checkout:
+      type: boolean
     leave-volumes:
       type: boolean
     no-cache:


### PR DESCRIPTION
Often steps that use prebuilt images don't need to checkout the repo code. This allows the checkout to be skipped:

```yaml
steps:
  - label: ":docker: Build"
    plugins:
      - docker-compose#v2.6.0:
          build: app
  - wait
  - label: "Run"
    plugins:
      - docker-compose#v2.6.0:
          run: app
          skip-checkout: true
```