### PR TITLE
WIP: Add optional dependent services to start

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,6 +297,10 @@ A list of services to push in the format `service:image:tag`. If an image has be
 
 Pull down multiple pre-built images. By default only the service that is being run will be pulled down, but this allows multiple images to be specified to handle prebuilt dependent images.
 
+### `deps` (optional, run only)
+
+Start dependent services for your service. By default only your service is started (and any accompanying linked services). However, since links is officially deprecated this command is useful for starting what would normally be linked services.
+
 ### `config` (optional)
 
 The file name of the Docker Compose configuration file to use. Can also be a list of filenames.

--- a/plugin.yml
+++ b/plugin.yml
@@ -17,6 +17,9 @@ configuration:
     pull:
       type: [ string, array ]
       minimum: 1
+    deps:
+      type: [ string, array ]
+      minimum: 1
     config:
       type: [ string, array ]
       minimum: 1
@@ -76,6 +79,7 @@ configuration:
   additionalProperties: false
   dependencies:
     pull: [ run ]
+    deps: [ run ]
     image-repository: [ build ]
     image-name: [ build ]
     env: [ run ]


### PR DESCRIPTION
I wanted to get this PR out early and get notes before I moved too far along with it.

The gist of it is, links in docker-compose are deprecated and there really isn't a clean way (that I've found) to start dependent services inside of compose unless you do it manually. That's what this PR adds, a deps array to specify dependent services in your yaml that will be started at a scale of 1 for you to test against.

I'm happy to take any feedback or questions you might have around motive or what the end result looks like.

![](https://media0.giphy.com/media/hfYnqeqVeO4pO/200w.gif)

Signed-off-by: Elliott Davis <elliott@excellent.io>