### PR TITLE
Add all-logs and rm options

### DIFF
--- a/README.md
+++ b/README.md
@@ -417,6 +417,12 @@ Sets `docker-compose` to run with `--verbose`
 
 The default is `false`.
 
+### `all-logs` (optional)
+
+If set to false, only upload failed container logs.
+
+The default is `true`.
+
 ## Developing
 
 To run the tests:

--- a/commands/run.sh
+++ b/commands/run.sh
@@ -131,6 +131,11 @@ if [[ "$(plugin_read_config USE_ALIASES "false")" == "true" ]]; then
   run_params+=(--use-aliases)
 fi
 
+# Optionally remove containers after run
+if [[ "$(plugin_read_config RM "true")" == "true" ]]; then
+  run_params+=(--rm)
+fi
+
 run_params+=("$run_service")
 
 if [[ "${BUILDKITE_PLUGIN_DOCKER_COMPOSE_REQUIRE_PREBUILD:-}" =~ ^(true|on|1)$ ]] && [[ ! -f "$override_file" ]]; then

--- a/commands/run.sh
+++ b/commands/run.sh
@@ -23,36 +23,36 @@ pull_services=()
 prebuilt_candidates=("$run_service")
 
 # Build a list of services that need to be pulled down
-while read -r name ; do
-  if [[ -n "$name" ]] ; then
+while read -r name; do
+  if [[ -n "$name" ]]; then
     pull_services+=("$name")
 
-    if ! in_array "$name" "${prebuilt_candidates[@]}" ; then
+    if ! in_array "$name" "${prebuilt_candidates[@]}"; then
       prebuilt_candidates+=("$name")
     fi
   fi
-done <<< "$(plugin_read_list PULL)"
+done <<<"$(plugin_read_list PULL)"
 
 # A list of tuples of [service image cache_from] for build_image_override_file
 prebuilt_service_overrides=()
 prebuilt_services=()
 
 # We look for a prebuilt images for all the pull services and the run_service.
-for service_name in "${prebuilt_candidates[@]}" ; do
-  if prebuilt_image=$(get_prebuilt_image "$service_name") ; then
+for service_name in "${prebuilt_candidates[@]}"; do
+  if prebuilt_image=$(get_prebuilt_image "$service_name"); then
     echo "~~~ :docker: Found a pre-built image for $service_name"
     prebuilt_service_overrides+=("$service_name" "$prebuilt_image" "")
     prebuilt_services+=("$service_name")
 
     # If it's prebuilt, we need to pull it down
-    if [[ -z "${pull_services:-}" ]] || ! in_array "$service_name" "${pull_services[@]}" ; then
+    if [[ -z "${pull_services:-}" ]] || ! in_array "$service_name" "${pull_services[@]}"; then
       pull_services+=("$service_name")
-   fi
+    fi
   fi
 done
 
 # If there are any prebuilts, we need to generate an override docker-compose file
-if [[ ${#prebuilt_services[@]} -gt 0 ]] ; then
+if [[ ${#prebuilt_services[@]} -gt 0 ]]; then
   echo "~~~ :docker: Creating docker-compose override file for prebuilt services"
   build_image_override_file "${prebuilt_service_overrides[@]}" | tee "$override_file"
   run_params+=(-f "$override_file")
@@ -61,14 +61,14 @@ if [[ ${#prebuilt_services[@]} -gt 0 ]] ; then
 fi
 
 # If there are multiple services to pull, run it in parallel (although this is now the default)
-if [[ ${#pull_services[@]} -gt 1 ]] ; then
+if [[ ${#pull_services[@]} -gt 1 ]]; then
   pull_params+=("pull" "--parallel" "${pull_services[@]}")
-elif [[ ${#pull_services[@]} -eq 1 ]] ; then
+elif [[ ${#pull_services[@]} -eq 1 ]]; then
   pull_params+=("pull" "${pull_services[0]}")
 fi
 
 # Pull down specified services
-if [[ ${#pull_services[@]} -gt 0 ]] ; then
+if [[ ${#pull_services[@]} -gt 0 ]]; then
   echo "~~~ :docker: Pulling services ${pull_services[0]}"
   retry "$pull_retries" run_docker_compose "${pull_params[@]}"
 fi
@@ -77,20 +77,20 @@ fi
 run_params+=("run" "--name" "$container_name")
 
 # append env vars provided in ENV or ENVIRONMENT, these are newline delimited
-while IFS=$'\n' read -r env ; do
+while IFS=$'\n' read -r env; do
   [[ -n "${env:-}" ]] && run_params+=("-e" "${env}")
-done <<< "$(printf '%s\n%s' \
+done <<<"$(printf '%s\n%s' \
   "$(plugin_read_list ENV)" \
   "$(plugin_read_list ENVIRONMENT)")"
 
-while IFS=$'\n' read -r vol ; do
+while IFS=$'\n' read -r vol; do
   [[ -n "${vol:-}" ]] && run_params+=("-v" "$(expand_relative_volume_path "$vol")")
-done <<< "$(plugin_read_list VOLUMES)"
+done <<<"$(plugin_read_list VOLUMES)"
 
 # Parse BUILDKITE_DOCKER_DEFAULT_VOLUMES delimited by semi-colons, normalized to
 # ignore spaces and leading or trailing semi-colons
-IFS=';' read -r -a default_volumes <<< "${BUILDKITE_DOCKER_DEFAULT_VOLUMES:-}"
-for vol in "${default_volumes[@]:-}" ; do
+IFS=';' read -r -a default_volumes <<<"${BUILDKITE_DOCKER_DEFAULT_VOLUMES:-}"
+for vol in "${default_volumes[@]:-}"; do
   trimmed_vol="$(echo -n "$vol" | sed -e 's/^[[:space:]]*//' | sed -e 's/[[:space:]]*$//')"
   [[ -n "$trimmed_vol" ]] && run_params+=("-v" "$(expand_relative_volume_path "$trimmed_vol")")
 done
@@ -98,42 +98,42 @@ done
 tty_default='true'
 
 # Set operating system specific defaults
-if is_windows ; then
+if is_windows; then
   tty_default='false'
 fi
 
 # Optionally disable allocating a TTY
-if [[ "$(plugin_read_config TTY "$tty_default")" == "false" ]] ; then
+if [[ "$(plugin_read_config TTY "$tty_default")" == "false" ]]; then
   run_params+=(-T)
 fi
 
 # Optionally disable dependencies
-if [[ "$(plugin_read_config DEPENDENCIES "true")" == "false" ]] ; then
+if [[ "$(plugin_read_config DEPENDENCIES "true")" == "false" ]]; then
   run_params+=(--no-deps)
 fi
 
-if [[ -n "$(plugin_read_config WORKDIR)" ]] ; then
+if [[ -n "$(plugin_read_config WORKDIR)" ]]; then
   run_params+=("--workdir=$(plugin_read_config WORKDIR)")
 fi
 
 # Optionally run as specified username or uid
-if [[ -n "$(plugin_read_config USER)" ]] ; then
+if [[ -n "$(plugin_read_config USER)" ]]; then
   run_params+=("--user=$(plugin_read_config USER)")
 fi
 
 # Optionally disable ansi output
-if [[ "$(plugin_read_config ANSI "true")" == "false" ]] ; then
+if [[ "$(plugin_read_config ANSI "true")" == "false" ]]; then
   run_params+=(--no-ansi)
 fi
 
 # Enable alias support for networks
-if [[ "$(plugin_read_config USE_ALIASES "false")" == "true" ]] ; then
+if [[ "$(plugin_read_config USE_ALIASES "false")" == "true" ]]; then
   run_params+=(--use-aliases)
 fi
 
 run_params+=("$run_service")
 
-if [[ "${BUILDKITE_PLUGIN_DOCKER_COMPOSE_REQUIRE_PREBUILD:-}" =~ ^(true|on|1)$ ]] && [[ ! -f "$override_file" ]] ; then
+if [[ "${BUILDKITE_PLUGIN_DOCKER_COMPOSE_REQUIRE_PREBUILD:-}" =~ ^(true|on|1)$ ]] && [[ ! -f "$override_file" ]]; then
   echo "+++ 🚨 No pre-built image found from a previous 'build' step for this service and config file."
   echo "The step specified that it was required"
   exit 1
@@ -149,9 +149,9 @@ elif [[ ! -f "$override_file" ]]; then
 fi
 
 # Start up service dependencies in a different header to keep the main run with less noise
-if [[ "$(plugin_read_config DEPENDENCIES "true")" == "true" ]] ; then
+if [[ "$(plugin_read_config DEPENDENCIES "true")" == "true" ]]; then
   echo "~~~ :docker: Starting dependencies"
-  if [[ ${#up_params[@]} -gt 0 ]] ; then
+  if [[ ${#up_params[@]} -gt 0 ]]; then
     run_docker_compose "${up_params[@]}" up -d --scale "${run_service}=0" "${run_service}"
   else
     run_docker_compose up -d --scale "${run_service}=0" "${run_service}"
@@ -170,11 +170,11 @@ if [[ -n "${BUILDKITE_COMMAND}" ]]; then
 fi
 
 # Handle shell being disabled
-if [[ "${BUILDKITE_PLUGIN_DOCKER_COMPOSE_SHELL:-}" =~ ^(false|off|0)$ ]] ; then
+if [[ "${BUILDKITE_PLUGIN_DOCKER_COMPOSE_SHELL:-}" =~ ^(false|off|0)$ ]]; then
   shell_disabled=1
 
-# Show a helpful error message if a string version of shell is used
-elif [[ -n "${BUILDKITE_PLUGIN_DOCKER_COMPOSE_SHELL:-}" ]] ; then
+  # Show a helpful error message if a string version of shell is used
+elif [[ -n "${BUILDKITE_PLUGIN_DOCKER_COMPOSE_SHELL:-}" ]]; then
   echo -n "🚨 The Docker Compose Plugin’s shell configuration option must be specified as an array. "
   echo -n "Please update your pipeline.yml to use an array, "
   echo "for example: [\"/bin/sh\", \"-e\", \"-u\"]."
@@ -183,17 +183,17 @@ elif [[ -n "${BUILDKITE_PLUGIN_DOCKER_COMPOSE_SHELL:-}" ]] ; then
   echo "the option entirely"
   exit 1
 
-# Handle shell being provided as a string or list
-elif plugin_read_list_into_result BUILDKITE_PLUGIN_DOCKER_COMPOSE_SHELL ; then
+  # Handle shell being provided as a string or list
+elif plugin_read_list_into_result BUILDKITE_PLUGIN_DOCKER_COMPOSE_SHELL; then
   shell_disabled=''
-  for arg in "${result[@]}" ; do
+  for arg in "${result[@]}"; do
     shell+=("$arg")
   done
 fi
 
 # Set a default shell if one is needed
-if [[ -z $shell_disabled ]] && [[ ${#shell[@]} -eq 0 ]] ; then
-  if is_windows ; then
+if [[ -z $shell_disabled ]] && [[ ${#shell[@]} -eq 0 ]]; then
+  if is_windows; then
     shell=("CMD.EXE" "/c")
   else
     shell=("/bin/sh" "-e" "-c")
@@ -203,19 +203,19 @@ fi
 command=()
 
 # Show a helpful error message if string version of command is used
-if [[ -n "${BUILDKITE_PLUGIN_DOCKER_COMPOSE_COMMAND:-}" ]] ; then
+if [[ -n "${BUILDKITE_PLUGIN_DOCKER_COMPOSE_COMMAND:-}" ]]; then
   echo "🚨 The Docker Compose Plugin’s command configuration option must be an array."
   exit 1
 fi
 
 # Parse plugin command if provided
-if plugin_read_list_into_result BUILDKITE_PLUGIN_DOCKER_COMPOSE_COMMAND ; then
-  for arg in "${result[@]}" ; do
+if plugin_read_list_into_result BUILDKITE_PLUGIN_DOCKER_COMPOSE_COMMAND; then
+  for arg in "${result[@]}"; do
     command+=("$arg")
   done
 fi
 
-if [[ ${#command[@]} -gt 0 ]] && [[ -n "${BUILDKITE_COMMAND}" ]] ; then
+if [[ ${#command[@]} -gt 0 ]] && [[ -n "${BUILDKITE_COMMAND}" ]]; then
   echo "+++ Error: Can't use both a step level command and the command parameter of the plugin"
   exit 1
 fi
@@ -224,18 +224,18 @@ fi
 
 display_command=()
 
-if [[ ${#shell[@]} -gt 0 ]] ; then
-  for shell_arg in "${shell[@]}" ; do
+if [[ ${#shell[@]} -gt 0 ]]; then
+  for shell_arg in "${shell[@]}"; do
     run_params+=("$shell_arg")
     display_command+=("$shell_arg")
   done
 fi
 
-if [[ -n "${BUILDKITE_COMMAND}" ]] ; then
+if [[ -n "${BUILDKITE_COMMAND}" ]]; then
   run_params+=("${BUILDKITE_COMMAND}")
   display_command+=("'${BUILDKITE_COMMAND}'")
-elif [[ ${#command[@]} -gt 0 ]] ; then
-  for command_arg in "${command[@]}" ; do
+elif [[ ${#command[@]} -gt 0 ]]; then
+  for command_arg in "${command[@]}"; do
     run_params+=("$command_arg")
     display_command+=("${command_arg}")
   done
@@ -255,14 +255,16 @@ exitcode=$?
 # Restore -e as an option.
 set -e
 
-if [[ $exitcode -ne 0 ]] ; then
+if [[ $exitcode -ne 0 ]]; then
   echo "^^^ +++"
   echo "+++ :warning: Failed to run command, exited with $exitcode"
 fi
 
-if [[ -n "${BUILDKITE_AGENT_ACCESS_TOKEN:-}" ]] ; then
-  if [[ "$(plugin_read_config CHECK_LINKED_CONTAINERS "true")" == "true" ]] ; then
-    check_linked_containers_and_save_logs "$run_service" "docker-compose-logs"
+if [[ -n "${BUILDKITE_AGENT_ACCESS_TOKEN:-}" ]]; then
+  if [[ "$(plugin_read_config CHECK_LINKED_CONTAINERS "true")" == "true" ]]; then
+    check_linked_containers_and_save_logs \
+      "$run_service" "docker-compose-logs" \
+      "$(plugin_read_config ALL_LOGS "true")"
 
     if [[ -d "docker-compose-logs" ]] && test -n "$(find docker-compose-logs/ -maxdepth 1 -name '*.log' -print)"; then
       echo "~~~ Uploading linked container logs"

--- a/commands/run.sh
+++ b/commands/run.sh
@@ -267,6 +267,10 @@ fi
 
 if [[ -n "${BUILDKITE_AGENT_ACCESS_TOKEN:-}" ]]; then
   if [[ "$(plugin_read_config CHECK_LINKED_CONTAINERS "true")" == "true" ]]; then
+    echo "~~~ Checking containers"
+    docker_ps_by_project \
+      --format 'table {{.Label "com.docker.compose.service"}}\t{{ .ID }}\t{{ .Status }}'
+
     check_linked_containers_and_save_logs \
       "$run_service" "docker-compose-logs" \
       "$(plugin_read_config ALL_LOGS "true")"

--- a/lib/run.bash
+++ b/lib/run.bash
@@ -29,6 +29,11 @@ check_linked_containers_and_save_logs() {
   mkdir -p "$logdir"
 
   while read -r line; do
+    if [[ -z "${line}" ]]; then
+      # Skip empty lines
+      continue
+    fi
+
     service_name="$(cut -d$'\t' -f2 <<<"$line")"
     service_container_id="$(cut -d$'\t' -f1 <<<"$line")"
 

--- a/plugin.yml
+++ b/plugin.yml
@@ -9,28 +9,28 @@ configuration:
     run:
       type: string
     build:
-      type: [ string, array ]
+      type: [string, array]
       minimum: 1
     push:
-      type: [ string, array ]
+      type: [string, array]
       minimum: 1
     pull:
-      type: [ string, array ]
+      type: [string, array]
       minimum: 1
     config:
-      type: [ string, array ]
+      type: [string, array]
       minimum: 1
     env:
-      type: [ string, array ]
+      type: [string, array]
       minimum: 1
     environment:
-      type: [ string, array ]
+      type: [string, array]
       minimum: 1
     args:
-      type: [ string, array ]
+      type: [string, array]
       minimum: 1
     build-alias:
-      type: [ string, array ]
+      type: [string, array]
       minimum: 1
     image-repository:
       type: string
@@ -41,10 +41,10 @@ configuration:
     push-retries:
       type: integer
     cache-from:
-      type: [ string, array ]
+      type: [string, array]
       minimum: 1
     volumes:
-      type: [ string, array ]
+      type: [string, array]
       minimum: 1
     command:
       type: array
@@ -66,29 +66,31 @@ configuration:
       type: boolean
     workdir:
       type: string
+    all-logs:
+      type: boolean
   oneOf:
     - required:
-      - run
+        - run
     - required:
-      - build
+        - build
     - required:
-      - push
+        - push
   additionalProperties: false
   dependencies:
-    pull: [ run ]
-    image-repository: [ build ]
-    image-name: [ build ]
-    env: [ run ]
-    environment: [ run ]
-    pull-retries: [ build, run ]
-    push-retries: [ push ]
-    cache-from: [ build ]
-    volumes: [ run ]
-    leave-volumes: [ run ]
-    no-cache: [ build ]
-    use-aliases: [ run ]
-    dependencies: [ run ]
-    ansi: [ run ]
-    tty: [ run ]
-    workdir: [ run ]
-    user: [ run ]
+    pull: [run]
+    image-repository: [build]
+    image-name: [build]
+    env: [run]
+    environment: [run]
+    pull-retries: [build, run]
+    push-retries: [push]
+    cache-from: [build]
+    volumes: [run]
+    leave-volumes: [run]
+    no-cache: [build]
+    use-aliases: [run]
+    dependencies: [run]
+    ansi: [run]
+    tty: [run]
+    workdir: [run]
+    user: [run]

--- a/plugin.yml
+++ b/plugin.yml
@@ -68,6 +68,8 @@ configuration:
       type: string
     all-logs:
       type: boolean
+    rm:
+      type: boolean
   oneOf:
     - required:
         - run


### PR DESCRIPTION
Related to: 
- #205 
- #206 
- #196

## Why
#### All Logs
As explained in #206, in many cases other container logs are required in order to properly troubleshoot a failed run.

#### `--rm` Option
Adding the `--rm` option and making it default to ensure you can run multiple runs of the same container or compose file.

#### Re-add linked container PS status
This allows for looking at the status before exit, I don't understand why it was removed in #196 as its quite useful for debugging a container being OOMd or similar.

## What
- Add `all-logs`
- Add `rm`
- Add linked container status output

### TODO
- [ ] Add tests
- [ ] Update docs