### PR TITLE
Added build-parallel build only option

### DIFF
--- a/README.md
+++ b/README.md
@@ -387,7 +387,7 @@ Sets the build step to run with `--no-cache`, causing Docker Compose to not use 
 
 ### `build-parallel` (optional, build only)
 
-Set the build step to run with `--parallel`, causing Docker Compose to run builds in parallel.
+Set the build step to run with `--parallel`, causing Docker Compose to run builds in parallel. Requires docker-compose `1.23+`.
 
 The default is `false`.
 

--- a/README.md
+++ b/README.md
@@ -385,6 +385,10 @@ The default is `false`.
 
 Sets the build step to run with `--no-cache`, causing Docker Compose to not use any caches when building the image.
 
+### `build-parallel` (optional, build only)
+
+Set the build step to run with `--parallel`, causing Docker Compose to run builds in parallel.
+
 The default is `false`.
 
 ### `tty` (optional, run only)

--- a/commands/build.sh
+++ b/commands/build.sh
@@ -76,6 +76,10 @@ if [[ "$(plugin_read_config NO_CACHE "false")" == "true" ]] ; then
   build_params+=(--no-cache)
 fi
 
+if [[ "$(plugin_read_config BUILD_PARALLEL "false")" == "true" ]] ; then
+  build_params+=(--parallel)
+fi
+
 while read -r arg ; do
   [[ -n "${arg:-}" ]] && build_params+=("--build-arg" "${arg}")
 done <<< "$(plugin_read_list ARGS)"

--- a/tests/build.bats
+++ b/tests/build.bats
@@ -40,6 +40,23 @@ load '../lib/shared'
   unstub docker-compose
 }
 
+@test "Build with parallel" {
+  export BUILDKITE_JOB_ID=1111
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD=myservice
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD_PARALLEL=true
+  export BUILDKITE_PIPELINE_SLUG=test
+  export BUILDKITE_BUILD_NUMBER=1
+
+  stub docker-compose \
+    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml build --pull --parallel myservice : echo built myservice"
+
+  run $PWD/hooks/command
+
+  assert_success
+  assert_output --partial "built myservice"
+  unstub docker-compose
+}
+
 @test "Build with build args" {
   export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD=myservice


### PR DESCRIPTION
Give access to the `--parallel` option in docker-compose build to help run builds faster.