### PR TITLE
Add all-logs option

### DIFF
--- a/README.md
+++ b/README.md
@@ -427,6 +427,16 @@ If set to true, docker compose will remove the primary container after run. Equi
 
 The default is `true`.
 
+### `upload-container-logs` (optional, run only)
+
+Select when to upload container logs.
+
+- `on-error` Upload logs for all containers when an error occurs
+- `always` Always upload logs for all container
+- `never` Never upload logs for all container
+
+The default is `on-error`.
+
 ## Developing
 
 To run the tests:

--- a/commands/run.sh
+++ b/commands/run.sh
@@ -294,7 +294,9 @@ if [[ -n "${BUILDKITE_AGENT_ACCESS_TOKEN:-}" ]] ; then
         --format 'table {{.Label "com.docker.compose.service"}}\t{{ .ID }}\t{{ .Status }}'
     fi
 
-    check_linked_containers_and_save_logs "$run_service" "docker-compose-logs"
+    check_linked_containers_and_save_logs \
+      "$run_service" "docker-compose-logs" \
+      "$(plugin_read_config UPLOAD_CONTAINER_LOGS "on-error")"
 
     if [[ -d "docker-compose-logs" ]] && test -n "$(find docker-compose-logs/ -maxdepth 1 -name '*.log' -print)"; then
       echo "~~~ Uploading linked container logs"

--- a/lib/run.bash
+++ b/lib/run.bash
@@ -36,10 +36,11 @@ check_linked_containers_and_save_logs() {
   [[ -d "$logdir" ]] && rm -rf "$logdir"
   mkdir -p "$logdir"
 
+  # Get array of containers
   containers=$(docker_ps_by_project --format '{{.ID}}\t{{.Label "com.docker.compose.service"}}')
-  IFS=$'\n'
+  IFS=$'\n' # Change IFS to new line
   for line in ${containers} ; do
-    if [[ -z "${line}" ]]; then
+    if [[ -z "${line}" ]] ; then
       # Skip empty lines
       continue
     fi

--- a/lib/run.bash
+++ b/lib/run.bash
@@ -23,6 +23,15 @@ compose_cleanup() {
 check_linked_containers_and_save_logs() {
   local service="$1"
   local logdir="$2"
+  local uploadlogs="$3"
+  local uploadall="false"
+
+  if [[ "$uploadlogs" =~ ^(false|off|0|never)$ ]]; then
+    # Skip all if we are not uploading logs
+    return
+  elif [[ "$uploadlogs" =~ ^(true|on|1|always)$ ]]; then
+    uploadall="true"
+  fi
 
   [[ -d "$logdir" ]] && rm -rf "$logdir"
   mkdir -p "$logdir"
@@ -38,6 +47,7 @@ check_linked_containers_and_save_logs() {
     service_name="$(cut -d$'\t' -f2 <<<"$line")"
     service_container_id="$(cut -d$'\t' -f1 <<<"$line")"
 
+    # Skip uploading logs for the primary service container
     if [[ "$service_name" == "$service" ]] ; then
       continue
     fi
@@ -48,7 +58,9 @@ check_linked_containers_and_save_logs() {
     if [[ "$service_exit_code" -ne 0 ]] ; then
       echo "+++ :warning: Linked service $service_name exited with $service_exit_code"
       plugin_prompt_and_run docker logs --timestamps --tail 5 "$service_container_id"
-      docker logs -t "$service_container_id" &> "${logdir}/${service_name}.log"
+      docker logs -t "$service_container_id" &>"${logdir}/${service_name}.log"
+    elif $uploadall; then
+      docker logs -t "$service_container_id" &>"${logdir}/${service_name}.log"
     fi
   done
 }

--- a/lib/run.bash
+++ b/lib/run.bash
@@ -38,6 +38,7 @@ check_linked_containers_and_save_logs() {
 
   # Get array of containers
   containers=$(docker_ps_by_project --format '{{.ID}}\t{{.Label "com.docker.compose.service"}}')
+  OLDIFS="$IFS"
   IFS=$'\n' # Change IFS to new line
   for line in ${containers} ; do
     if [[ -z "${line}" ]] ; then
@@ -64,6 +65,7 @@ check_linked_containers_and_save_logs() {
       docker logs -t "$service_container_id" &>"${logdir}/${service_name}.log"
     fi
   done
+  OLDIFS="$IFS"
 }
 
 # docker-compose's -v arguments don't do local path expansion like the .yml

--- a/lib/run.bash
+++ b/lib/run.bash
@@ -37,10 +37,8 @@ check_linked_containers_and_save_logs() {
   mkdir -p "$logdir"
 
   # Get array of containers
-  containers=$(docker_ps_by_project --format '{{.ID}}\t{{.Label "com.docker.compose.service"}}')
-  OLDIFS="$IFS"
-  IFS=$'\n' # Change IFS to new line
-  for line in ${containers} ; do
+  mapfile -t containers < <(docker_ps_by_project --format '{{.ID}}\t{{.Label "com.docker.compose.service"}}')
+  for line in "${containers[@]}" ; do
     if [[ -z "${line}" ]] ; then
       # Skip empty lines
       continue
@@ -65,7 +63,6 @@ check_linked_containers_and_save_logs() {
       docker logs -t "$service_container_id" &>"${logdir}/${service_name}.log"
     fi
   done
-  OLDIFS="$IFS"
 }
 
 # docker-compose's -v arguments don't do local path expansion like the .yml

--- a/plugin.yml
+++ b/plugin.yml
@@ -68,6 +68,8 @@ configuration:
       type: string
     rm:
       type: boolean
+    upload-container-logs:
+      type: string
   oneOf:
     - required:
       - run

--- a/tests/logs.bats
+++ b/tests/logs.bats
@@ -1,0 +1,95 @@
+#!/usr/bin/env bats
+
+load '/usr/local/lib/bats/load.bash'
+load '../lib/run'
+load '../lib/shared'
+
+# export DOCKER_PS_BY_PROJECT_STUB_DEBUG=/dev/tty
+# export CHECK_LINKED_CONTAINERS_AND_SAVE_LOGS_STUB_DEBUG=/dev/tty
+# export DOCKER_STUB_DEBUG=/dev/tty
+
+@test "Upload log settings: on-error" {
+  export LOG_DIR="docker-compose-logs"
+
+  function docker_ps_by_project() {
+    echo -e "
+232323\tmain
+454545\tfailed
+676767\tlinkedworked
+898989\tlinkedworked2
+"
+  }
+
+  function plugin_prompt_and_run() {
+    echo "ran plugin_prompt_and_run"
+  }
+
+  stub docker \
+    "inspect --format={{.State.ExitCode}} 454545 : echo 1" \
+    "logs -t 454545 : echo got logs for failed" \
+    "inspect --format={{.State.ExitCode}} 676767 : echo 0" \
+    "inspect --format={{.State.ExitCode}} 898989 : echo 0"
+
+  run check_linked_containers_and_save_logs \
+    "main" "/tmp/docker-compose-logs" "on-error"
+
+  assert_success
+  assert_output --partial "ran plugin_prompt_and_run"
+
+  unstub docker
+}
+
+@test "Upload log settings: always" {
+  export LOG_DIR="docker-compose-logs"
+
+  function docker_ps_by_project() {
+    echo -e "
+232323\tmain
+454545\tfailed
+676767\tlinkedworked
+898989\tlinkedworked2
+"
+  }
+
+  function plugin_prompt_and_run() {
+    echo "ran plugin_prompt_and_run"
+  }
+
+  stub docker \
+    "inspect --format={{.State.ExitCode}} 454545 : echo 1" \
+    "logs -t 454545 : echo got logs for failed" \
+    "inspect --format={{.State.ExitCode}} 676767 : echo 0" \
+    "logs -t 676767 : echo got logs for failed" \
+    "inspect --format={{.State.ExitCode}} 898989 : echo 0" \
+    "logs -t 898989 : echo got logs for failed"
+
+  run check_linked_containers_and_save_logs \
+    "main" "/tmp/docker-compose-logs" "always"
+
+  assert_success
+  assert_output --partial "ran plugin_prompt_and_run"
+
+  unstub docker
+}
+
+@test "Upload log settings: never" {
+  export LOG_DIR="docker-compose-logs"
+
+  function docker_ps_by_project() {
+    echo -e "
+232323\tmain
+454545\tfailed
+676767\tlinkedworked
+898989\tlinkedworked2
+"
+  }
+
+  function plugin_prompt_and_run() {
+    echo "ran plugin_prompt_and_run"
+  }
+
+  run check_linked_containers_and_save_logs \
+    "main" "/tmp/docker-compose-logs" "never"
+
+  assert_success
+}

--- a/tests/logs.bats
+++ b/tests/logs.bats
@@ -12,12 +12,7 @@ load '../lib/shared'
   export LOG_DIR="docker-compose-logs"
 
   function docker_ps_by_project() {
-    echo -e "
-232323\tmain
-454545\tfailed
-676767\tlinkedworked
-898989\tlinkedworked2
-"
+    cat tests/fixtures/id-service-multiple-services.txt
   }
 
   function plugin_prompt_and_run() {
@@ -25,10 +20,9 @@ load '../lib/shared'
   }
 
   stub docker \
-    "inspect --format={{.State.ExitCode}} 454545 : echo 1" \
-    "logs -t 454545 : echo got logs for failed" \
-    "inspect --format={{.State.ExitCode}} 676767 : echo 0" \
-    "inspect --format={{.State.ExitCode}} 898989 : echo 0"
+    "inspect --format={{.State.ExitCode}} 456456 : echo 1" \
+    "logs -t 456456 : echo got logs for failed" \
+    "inspect --format={{.State.ExitCode}} 789789 : echo 0"
 
   run check_linked_containers_and_save_logs \
     "main" "/tmp/docker-compose-logs" "on-error"
@@ -43,12 +37,7 @@ load '../lib/shared'
   export LOG_DIR="docker-compose-logs"
 
   function docker_ps_by_project() {
-    echo -e "
-232323\tmain
-454545\tfailed
-676767\tlinkedworked
-898989\tlinkedworked2
-"
+    cat tests/fixtures/id-service-multiple-services.txt
   }
 
   function plugin_prompt_and_run() {
@@ -56,12 +45,10 @@ load '../lib/shared'
   }
 
   stub docker \
-    "inspect --format={{.State.ExitCode}} 454545 : echo 1" \
-    "logs -t 454545 : echo got logs for failed" \
-    "inspect --format={{.State.ExitCode}} 676767 : echo 0" \
-    "logs -t 676767 : echo got logs for failed" \
-    "inspect --format={{.State.ExitCode}} 898989 : echo 0" \
-    "logs -t 898989 : echo got logs for failed"
+    "inspect --format={{.State.ExitCode}} 456456 : echo 1" \
+    "logs -t 456456 : echo got logs for failed" \
+    "inspect --format={{.State.ExitCode}} 789789 : echo 0" \
+    "logs -t 789789 : echo got logs for failed"
 
   run check_linked_containers_and_save_logs \
     "main" "/tmp/docker-compose-logs" "always"
@@ -76,12 +63,7 @@ load '../lib/shared'
   export LOG_DIR="docker-compose-logs"
 
   function docker_ps_by_project() {
-    echo -e "
-232323\tmain
-454545\tfailed
-676767\tlinkedworked
-898989\tlinkedworked2
-"
+    cat tests/fixtures/id-service-multiple-services.txt
   }
 
   function plugin_prompt_and_run() {


### PR DESCRIPTION
Related to:
- #206
- #207 

## Why
#### All Logs
As explained in #206, in many cases other container logs are required in order to properly troubleshoot a failed run.

## What
- Add `all-logs`
- Restore upload all logs as the default behavior

### TODO
- [x] Add tests
- [x] Update docs

### Notes
Contains whitespace fixes, a product of `shfmt`. I would recommend we do enable and set it, so we stop having PRs from different people having different formats.