### PR TITLE
Output status of the containers on exit

### DIFF
--- a/commands/run.sh
+++ b/commands/run.sh
@@ -261,7 +261,20 @@ if [[ $exitcode -ne 0 ]] ; then
 fi
 
 if [[ -n "${BUILDKITE_AGENT_ACCESS_TOKEN:-}" ]] ; then
-  if [[ "$(plugin_read_config CHECK_LINKED_CONTAINERS "true")" == "true" ]] ; then
+  if [[ "$(plugin_read_config CHECK_LINKED_CONTAINERS "true")" != "false" ]] ; then
+
+    # Get list of failed containers
+    failed_containers=($(
+      docker inspect -f '{{if ne 0 .State.ExitCode}}{{.Name}}.{{.State.ExitCode}}{{ end }}' \
+      $(docker_ps_by_project -q)
+    ))
+
+    if [[ 0 != "${#failed_containers[@]}" ]] ; then
+      echo "+++ :warning: Some containers had non-zero exit codes"
+      docker_ps_by_project \
+        --format 'table {{.Label "com.docker.compose.service"}}\t{{ .ID }}\t{{ .Status }}'
+    fi
+
     check_linked_containers_and_save_logs "$run_service" "docker-compose-logs"
 
     if [[ -d "docker-compose-logs" ]] && test -n "$(find docker-compose-logs/ -maxdepth 1 -name '*.log' -print)"; then

--- a/tests/output.bats
+++ b/tests/output.bats
@@ -1,0 +1,91 @@
+#!/usr/bin/env bats
+
+load '/usr/local/lib/bats/load.bash'
+load '../lib/shared'
+load '../lib/run'
+
+# export BUILDKITE_AGENT_STUB_DEBUG=/dev/tty
+# export DOCKER_COMPOSE_STUB_DEBUG=/dev/tty
+# export DOCKER_STUB_DEBUG=/dev/tty
+# export BATS_MOCK_TMPDIR=$PWD
+
+
+@test "Detect some failed containers" {
+  export BUILDKITE_AGENT_ACCESS_TOKEN="123123"
+  export BUILDKITE_JOB_ID=1111
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RUN=myservice
+  export BUILDKITE_PIPELINE_SLUG=test
+  export BUILDKITE_BUILD_NUMBER=1
+  export BUILDKITE_COMMAND=""
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_COMMAND_0=echo
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_COMMAND_1="hello world"
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CHECK_LINKED_CONTAINERS=true
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLEANUP=false
+
+
+  stub buildkite-agent \
+    "meta-data get docker-compose-plugin-built-image-tag-myservice : exit 1" \
+    "artifact upload : exit 0"
+
+  stub docker-compose \
+    "-f docker-compose.yml -p buildkite1111 build --pull myservice : echo built myservice" \
+    "-f docker-compose.yml -p buildkite1111 up -d --scale myservice=0 : echo ran myservice dependencies" \
+    "-f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 myservice echo 'hello world' : echo ran myservice"
+
+  stub docker \
+    "ps -a --filter label=com.docker.compose.project=buildkite1111 -q : echo 123123" \
+    "inspect -f {{if\ ne\ 0\ .State.ExitCode}}{{.Name}}.{{.State.ExitCode}}{{\ end\ }} 123123 : echo 123123.1" \
+    "ps -a --filter label=com.docker.compose.project=buildkite1111 --format : echo 123123 1" \
+    "ps -a --filter label=com.docker.compose.project=buildkite1111 --format : echo 123123 myservice" \
+    "inspect --format={{.State.ExitCode}} 123123\ myservice : echo 1" \
+    "logs : exit 0" \
+    "logs : exit 0"
+
+  run $PWD/hooks/command
+
+  assert_success
+  assert_output --partial "built myservice"
+  assert_output --partial "ran myservice"
+  assert_output --partial "Some containers had non-zero exit codes"
+  unstub buildkite-agent
+  unstub docker-compose
+  unstub docker
+}
+
+@test "Detect no failed containers" {
+  export BUILDKITE_AGENT_ACCESS_TOKEN="123123"
+  export BUILDKITE_JOB_ID=1111
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RUN=myservice
+  export BUILDKITE_PIPELINE_SLUG=test
+  export BUILDKITE_BUILD_NUMBER=1
+  export BUILDKITE_COMMAND=""
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_COMMAND_0=echo
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_COMMAND_1="hello world"
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CHECK_LINKED_CONTAINERS=true
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLEANUP=false
+
+
+  stub buildkite-agent \
+    "meta-data get docker-compose-plugin-built-image-tag-myservice : exit 1" \
+
+  stub docker-compose \
+    "-f docker-compose.yml -p buildkite1111 build --pull myservice : echo built myservice" \
+    "-f docker-compose.yml -p buildkite1111 up -d --scale myservice=0 : echo ran myservice dependencies" \
+    "-f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 myservice echo 'hello world' : echo ran myservice"
+
+  stub docker \
+    "ps -a --filter label=com.docker.compose.project=buildkite1111 -q : echo 123123" \
+    "inspect -f {{if\ ne\ 0\ .State.ExitCode}}{{.Name}}.{{.State.ExitCode}}{{\ end\ }} 123123 : " \
+    "ps -a --filter : echo myservice 123123 0" \
+    "inspect --format={{.State.ExitCode}} myservice\ 123123\ 0 : echo 0"
+
+  run $PWD/hooks/command
+
+  assert_success
+  assert_output --partial "built myservice"
+  assert_output --partial "ran myservice"
+  refute_output --partial "Some containers had non-zero exit codes"
+  unstub docker
+  unstub docker-compose
+  unstub buildkite-agent
+}


### PR DESCRIPTION
Related to: 
- #207  
- #196

## Why
#### Re-add linked container PS status
This allows for looking at the status before exit, I don't understand why it was removed in #196 as its quite useful for debugging a container being OOMd or similar.

## What
- Add linked container status output