### PR TITLE
Check if prebuilt image exists before doing "get"

### DIFF
--- a/lib/metadata.bash
+++ b/lib/metadata.bash
@@ -1,10 +1,19 @@
 #!/bin/bash
 
+# Check agent meta-data exists
+function plugin_check_metadata_exists() {
+  buildkite-agent meta-data exists "$1"
+}
+
 # Read agent metadata for the plugin
 function plugin_get_metadata() {
   local key="docker-compose-plugin-$1"
-  plugin_prompt buildkite-agent meta-data get "$key"
-  buildkite-agent meta-data get "$key"
+  if plugin_check_metadata_exists "$key"; then
+    plugin_prompt buildkite-agent meta-data get "$key"
+    buildkite-agent meta-data get "$key"
+  else
+	exit 1
+  fi
 }
 
 # Write agent metadata for the plugin

--- a/tests/push.bats
+++ b/tests/push.bats
@@ -15,7 +15,7 @@ load '../lib/shared'
   export BUILDKITE_BUILD_NUMBER=1
 
   stub buildkite-agent \
-    "meta-data get docker-compose-plugin-built-image-tag-app : exit 1"
+    "meta-data exists docker-compose-plugin-built-image-tag-app : exit 1"
 
   stub docker-compose \
     "-f docker-compose.yml -p buildkite1111 config : cat $PWD/tests/composefiles/docker-compose.config.v3.2.yml" \
@@ -56,8 +56,8 @@ load '../lib/shared'
     "push my.repository/myservice2:llamas : echo pushing myservice2 image"
 
   stub buildkite-agent \
-    "meta-data get docker-compose-plugin-built-image-tag-myservice1 : exit 1" \
-    "meta-data get docker-compose-plugin-built-image-tag-myservice2 : exit 1"
+    "meta-data exists docker-compose-plugin-built-image-tag-myservice1 : exit 1" \
+    "meta-data exists docker-compose-plugin-built-image-tag-myservice2 : exit 1"
 
   run $PWD/hooks/command
 
@@ -87,6 +87,7 @@ load '../lib/shared'
     "-f docker-compose.yml -p buildkite1111 config : echo blah"
 
   stub buildkite-agent \
+    "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 0" \
     "meta-data get docker-compose-plugin-built-image-tag-myservice : echo myimage"
 
   run $PWD/hooks/command
@@ -126,8 +127,11 @@ load '../lib/shared'
     "-f docker-compose.yml -p buildkite1111 config : echo blah"
 
   stub buildkite-agent \
+    "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 0" \
     "meta-data get docker-compose-plugin-built-image-tag-myservice : echo prebuilt" \
+    "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 0" \
     "meta-data get docker-compose-plugin-built-image-tag-myservice : echo prebuilt" \
+    "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 0" \
     "meta-data get docker-compose-plugin-built-image-tag-myservice : echo prebuilt"
 
   run $PWD/hooks/command
@@ -152,7 +156,7 @@ load '../lib/shared'
   export BUILDKITE_BUILD_NUMBER=1
 
   stub buildkite-agent \
-    "meta-data get docker-compose-plugin-built-image-tag-helper : exit 1"
+    "meta-data exists docker-compose-plugin-built-image-tag-helper : exit 1"
 
   stub docker-compose \
     "-f docker-compose.yml -p buildkite1111 config : cat $PWD/tests/composefiles/docker-compose.config.v3.2.yml" \

--- a/tests/run.bats
+++ b/tests/run.bats
@@ -23,7 +23,7 @@ load '../lib/run'
     "-f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 myservice /bin/sh -e -c 'echo hello world' : echo ran myservice"
 
   stub buildkite-agent \
-    "meta-data get docker-compose-plugin-built-image-tag-myservice : exit 1"
+    "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 1"
 
   run $PWD/hooks/command
 
@@ -49,7 +49,7 @@ load '../lib/run'
     "-f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 myservice : echo ran myservice"
 
   stub buildkite-agent \
-    "meta-data get docker-compose-plugin-built-image-tag-myservice : exit 1"
+    "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 1"
 
   run $PWD/hooks/command
 
@@ -76,7 +76,7 @@ load '../lib/run'
     "-f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 --workdir=/test_workdir myservice : echo ran myservice"
 
   stub buildkite-agent \
-    "meta-data get docker-compose-plugin-built-image-tag-myservice : exit 1"
+    "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 1"
 
   run $PWD/hooks/command
 
@@ -102,7 +102,7 @@ load '../lib/run'
     "-f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 myservice /bin/sh -e -c 'sh -c \'echo hello world\'' : echo ran myservice"
 
   stub buildkite-agent \
-    "meta-data get docker-compose-plugin-built-image-tag-myservice : exit 1"
+    "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 1"
 
   run $PWD/hooks/command
 
@@ -130,7 +130,7 @@ cmd3"
     "-f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 myservice /bin/sh -e -c 'cmd1\ncmd2\ncmd3' : echo ran myservice"
 
   stub buildkite-agent \
-    "meta-data get docker-compose-plugin-built-image-tag-myservice : exit 1"
+    "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 1"
 
   run $PWD/hooks/command
 
@@ -158,7 +158,7 @@ cmd3"
     "-f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 myservice echo hello world' : echo ran myservice"
 
   stub buildkite-agent \
-    "meta-data get docker-compose-plugin-built-image-tag-myservice : exit 1"
+    "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 1"
 
   run $PWD/hooks/command
 
@@ -189,7 +189,7 @@ cmd3"
     "-f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 -e MYENV=0 -e MYENV -e MYENV=2 -e MYENV -e ANOTHER=this\ is\ a\ long\ string\ with\ spaces\;\ and\ semi-colons myservice /bin/sh -e -c 'pwd' : echo ran myservice"
 
   stub buildkite-agent \
-    "meta-data get docker-compose-plugin-built-image-tag-myservice : exit 1"
+    "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 1"
 
   run $PWD/hooks/command
 
@@ -214,6 +214,7 @@ cmd3"
     "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 myservice /bin/sh -e -c 'pwd' : echo ran myservice"
 
   stub buildkite-agent \
+    "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 0" \
     "meta-data get docker-compose-plugin-built-image-tag-myservice : echo myimage"
 
   run $PWD/hooks/command
@@ -240,6 +241,7 @@ cmd3"
     "-f tests/composefiles/docker-compose.v2.0.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 myservice /bin/sh -e -c 'pwd' : echo ran myservice"
 
   stub buildkite-agent \
+    "meta-data exists docker-compose-plugin-built-image-tag-myservice-tests/composefiles/docker-compose.v2.0.yml : exit 0" \
     "meta-data get docker-compose-plugin-built-image-tag-myservice-tests/composefiles/docker-compose.v2.0.yml : echo myimage"
 
   run $PWD/hooks/command
@@ -267,6 +269,7 @@ export BUILDKITE_JOB_ID=1111
     "-f tests/composefiles/docker-compose.v2.0.yml -f tests/composefiles/docker-compose.v2.1.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 myservice /bin/sh -e -c 'pwd' : echo ran myservice"
 
   stub buildkite-agent \
+    "meta-data exists docker-compose-plugin-built-image-tag-myservice-tests/composefiles/docker-compose.v2.0.yml-tests/composefiles/docker-compose.v2.1.yml : exit 0" \
     "meta-data get docker-compose-plugin-built-image-tag-myservice-tests/composefiles/docker-compose.v2.0.yml-tests/composefiles/docker-compose.v2.1.yml : echo myimage"
 
   run $PWD/hooks/command
@@ -290,6 +293,7 @@ export BUILDKITE_JOB_ID=1111
     "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml pull myservice : exit 2"
 
   stub buildkite-agent \
+    "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 0" \
     "meta-data get docker-compose-plugin-built-image-tag-myservice : echo myimage"
 
   run $PWD/hooks/command
@@ -317,6 +321,7 @@ export BUILDKITE_JOB_ID=1111
     "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 myservice /bin/sh -e -c 'pwd' : echo ran myservice"
 
   stub buildkite-agent \
+    "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 0" \
     "meta-data get docker-compose-plugin-built-image-tag-myservice : echo myimage"
 
   run $PWD/hooks/command
@@ -344,6 +349,7 @@ export BUILDKITE_JOB_ID=1111
     "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 -T myservice /bin/sh -e -c 'pwd' : echo ran myservice without tty"
 
   stub buildkite-agent \
+    "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 0" \
     "meta-data get docker-compose-plugin-built-image-tag-myservice : echo myimage"
 
   run $PWD/hooks/command
@@ -369,6 +375,7 @@ export BUILDKITE_JOB_ID=1111
     "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 --no-deps myservice /bin/sh -e -c 'pwd' : echo ran myservice without dependencies"
 
   stub buildkite-agent \
+    "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 0" \
     "meta-data get docker-compose-plugin-built-image-tag-myservice : echo myimage"
 
   run $PWD/hooks/command
@@ -395,6 +402,7 @@ export BUILDKITE_JOB_ID=1111
     "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 --no-ansi myservice /bin/sh -e -c 'pwd' : echo ran myservice without ansi output"
 
   stub buildkite-agent \
+    "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 0" \
     "meta-data get docker-compose-plugin-built-image-tag-myservice : echo myimage"
 
   run $PWD/hooks/command
@@ -421,6 +429,7 @@ export BUILDKITE_JOB_ID=1111
     "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 --use-aliases myservice /bin/sh -e -c 'pwd' : echo ran myservice with use aliases output"
 
   stub buildkite-agent \
+    "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 0" \
     "meta-data get docker-compose-plugin-built-image-tag-myservice : echo myimage"
 
   run $PWD/hooks/command
@@ -448,6 +457,7 @@ export BUILDKITE_JOB_ID=1111
     "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 -v $PWD/dist:/app/dist -v $PWD/pkg:/app/pkg myservice /bin/sh -e -c 'pwd' : echo ran myservice with volumes"
 
   stub buildkite-agent \
+    "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 0" \
     "meta-data get docker-compose-plugin-built-image-tag-myservice : echo myimage"
 
   run $PWD/hooks/command
@@ -474,6 +484,7 @@ export BUILDKITE_JOB_ID=1111
     "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 -v buildkite:/buildkite myservice /bin/sh -e -c 'pwd' : echo ran myservice with volumes"
 
   stub buildkite-agent \
+    "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 0" \
     "meta-data get docker-compose-plugin-built-image-tag-myservice : echo myimage"
 
   run $PWD/hooks/command
@@ -503,6 +514,7 @@ export BUILDKITE_JOB_ID=1111
     "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 -v buildkite:/buildkite -v $PWD/dist:/app/dist myservice /bin/sh -e -c 'pwd' : echo ran myservice with volumes"
 
   stub buildkite-agent \
+    "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 0" \
     "meta-data get docker-compose-plugin-built-image-tag-myservice : echo myimage"
 
   run $PWD/hooks/command
@@ -529,6 +541,7 @@ export BUILDKITE_JOB_ID=1111
     "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 -v buildkite:/buildkite -v $PWD/dist:/app/dist myservice /bin/sh -e -c 'pwd' : echo ran myservice with volumes"
 
   stub buildkite-agent \
+    "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 0" \
     "meta-data get docker-compose-plugin-built-image-tag-myservice : echo myimage"
 
   run $PWD/hooks/command
@@ -557,7 +570,7 @@ export BUILDKITE_JOB_ID=1111
     "-f llamas1.yml -f llamas2.yml -f llamas3.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 myservice /bin/sh -e -c 'echo hello world' : echo ran myservice"
 
   stub buildkite-agent \
-    "meta-data get docker-compose-plugin-built-image-tag-myservice-llamas1.yml-llamas2.yml-llamas3.yml : exit 1"
+    "meta-data exists docker-compose-plugin-built-image-tag-myservice-llamas1.yml-llamas2.yml-llamas3.yml : exit 1"
 
   run $PWD/hooks/command
 
@@ -583,7 +596,7 @@ export BUILDKITE_JOB_ID=1111
     "-f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 myservice /bin/sh -e -c 'pwd' : exit 2"
 
   stub buildkite-agent \
-    "meta-data get docker-compose-plugin-built-image-tag-myservice : exit 1"
+    "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 1"
 
   run $PWD/hooks/command
 
@@ -611,7 +624,9 @@ export BUILDKITE_JOB_ID=1111
     "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice1_build_1 myservice1 /bin/sh -e -c 'pwd' : echo ran myservice1"
 
   stub buildkite-agent \
+    "meta-data exists docker-compose-plugin-built-image-tag-myservice1 : exit 0" \
     "meta-data get docker-compose-plugin-built-image-tag-myservice1 : echo myimage1" \
+    "meta-data exists docker-compose-plugin-built-image-tag-myservice2 : exit 0" \
     "meta-data get docker-compose-plugin-built-image-tag-myservice2 : echo myimage2"
 
   run $PWD/hooks/command
@@ -639,7 +654,7 @@ export BUILDKITE_JOB_ID=1111
     "-f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 --user=1000 myservice /bin/sh -e -c 'sh -c \'whoami\'' : echo ran myservice"
 
   stub buildkite-agent \
-    "meta-data get docker-compose-plugin-built-image-tag-myservice : exit 1"
+    "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 1"
 
   run $PWD/hooks/command
 

--- a/tests/run.bats
+++ b/tests/run.bats
@@ -681,6 +681,7 @@ export BUILDKITE_JOB_ID=1111
     "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 myservice /bin/sh -e -c 'pwd' : echo ran myservice without tty"
 
   stub buildkite-agent \
+    "meta-data exists docker-compose-plugin-built-image-tag-myservice : echo myimage" \
     "meta-data get docker-compose-plugin-built-image-tag-myservice : echo myimage"
 
   run $PWD/hooks/command


### PR DESCRIPTION
Fixes #215 

Check for prebuilt image in meta data before attempting to get it. Stops FATAL error from appearing in build logs which led to confusion when debugging failed pipelines

