### PR TITLE
Ensure docker_compose_config_version only matches "version: ..."

### DIFF
--- a/lib/shared.bash
+++ b/lib/shared.bash
@@ -115,7 +115,7 @@ function docker_compose_config_files() {
 # Returns the version from the output of docker_compose_config
 function docker_compose_config_version() {
   IFS=$'\n' read -r -a config <<< "$(docker_compose_config_files)"
-  awk '/\s*version:/ { print $2; }' < "${config[0]}" | sed "s/[\"']//g"
+  awk '/^\s*version:/ { print $2; }' < "${config[0]}" | sed "s/[\"']//g"
 }
 
 # Build an docker-compose file that overrides the image for a set of


### PR DESCRIPTION
The version matching regex will match things like `blahblahversion: blah` as well as just `version: '3.7'`. This can result in an invalid compose file which has a multiple line version.

Adding the '^' will ensure that we match from the beginning of the line and so exclude anything that doesn't begin with `version:`.