### PR TITLE
Allow docker container creation during run to also receive build options

### DIFF
--- a/README.md
+++ b/README.md
@@ -387,15 +387,15 @@ Prevent the removal of volumes after the command has been run.
 
 The default is `false`.
 
-### `no-cache` (optional, build only)
+### `no-cache` (optional, build and run only)
 
-Sets the build step to run with `--no-cache`, causing Docker Compose to not use any caches when building the image.
+Build with `--no-cache`, causing Docker Compose to not use any caches when building the image.
 
 The default is `false`.
 
-### `build-parallel` (optional, build only)
+### `build-parallel` (optional, build and run only)
 
-Set the build step to run with `--parallel`, causing Docker Compose to run builds in parallel. Requires docker-compose `1.23+`.
+Build with `--parallel`, causing Docker Compose to run builds in parallel. Requires docker-compose `1.23+`.
 
 The default is `false`.
 

--- a/commands/run.sh
+++ b/commands/run.sh
@@ -157,6 +157,20 @@ fi
 
 run_params+=("$run_service")
 
+build_params=(--pull)
+
+if [[ "$(plugin_read_config NO_CACHE "false")" == "true" ]] ; then
+  build_params+=(--no-cache)
+fi
+
+if [[ "$(plugin_read_config BUILD_PARALLEL "false")" == "true" ]] ; then
+  build_params+=(--parallel)
+fi
+
+while read -r arg ; do
+  [[ -n "${arg:-}" ]] && build_params+=("--build-arg" "${arg}")
+done <<< "$(plugin_read_list ARGS)"
+
 if [[ "${BUILDKITE_PLUGIN_DOCKER_COMPOSE_REQUIRE_PREBUILD:-}" =~ ^(true|on|1)$ ]] && [[ ! -f "$override_file" ]] ; then
   echo "+++ 🚨 No pre-built image found from a previous 'build' step for this service and config file."
   echo "The step specified that it was required"
@@ -169,7 +183,7 @@ elif [[ ! -f "$override_file" ]]; then
   # Ideally we'd do a pull with a retry first here, but we need the conditional pull behaviour here
   # for when an image and a build is defined in the docker-compose.ymk file, otherwise we try and
   # pull an image that doesn't exist
-  run_docker_compose build --pull "$run_service"
+  run_docker_compose build "${build_params[@]}" "$run_service"
 
   # Sometimes docker-compose pull leaves unfinished ansi codes
   echo

--- a/tests/run.bats
+++ b/tests/run.bats
@@ -747,3 +747,31 @@ export BUILDKITE_JOB_ID=1111
   unstub docker-compose
   unstub buildkite-agent
 }
+
+@test "Run with various build arguments" {
+  export BUILDKITE_JOB_ID=1111
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RUN=myservice
+  export BUILDKITE_PIPELINE_SLUG=test
+  export BUILDKITE_BUILD_NUMBER=1
+  export BUILDKITE_COMMAND="echo hello world"
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CHECK_LINKED_CONTAINERS=false
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLEANUP=false
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_NO_CACHE=true
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD_PARALLEL=true
+
+  stub docker-compose \
+    "-f docker-compose.yml -p buildkite1111 build --pull --no-cache --parallel myservice : echo built myservice" \
+    "-f docker-compose.yml -p buildkite1111 up -d --scale myservice=0 : echo ran myservice dependencies" \
+    "-f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 --rm myservice /bin/sh -e -c 'echo hello world' : echo ran myservice"
+
+  stub buildkite-agent \
+    "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 1"
+
+  run $PWD/hooks/command
+
+  assert_success
+  assert_output --partial "built myservice"
+  assert_output --partial "ran myservice"
+  unstub docker-compose
+  unstub buildkite-agent
+}


### PR DESCRIPTION
I found it handy that I could define a step to run a command on a docker container without the pre-requisite of having that container pre-built already. However, the underlying `docker-compose` doesn't receive the same support for the plugin options that are only limited to the `build` run type.

I specifically wanted the ability to specify `ARGS` so I lifted the code from the `build.sh` command and dropped it in to the `run` command. This also allows for the `--no-cache` and `--parallel` options to be passed on as well.

My bash-fu isn't that great so not sure if there is a better way to DRY this up instead of copying & pasting but wanted to see if this was an acceptable idea.