### PR TITLE
Allow build and run in one step

### DIFF
--- a/hooks/command
+++ b/hooks/command
@@ -12,14 +12,6 @@ commands=()
 
 [[ -n "$(plugin_read_list BUILD)" ]] && commands+=("BUILD")
 [[ -n "$(plugin_read_list RUN)" ]] && commands+=("RUN")
-
-# Check we've only got one of BUILD or RUN
-if [[ ${#commands[@]} -gt 1 ]] ; then
-  echo "+++ Docker Compose plugin error"
-  echo "Only one of build or run is supported. More than one was used."
-  exit 1
-fi
-
 [[ -n "$(plugin_read_list PUSH)" ]] && commands+=("PUSH")
 
 # Don't convert paths on gitbash on windows


### PR DESCRIPTION
Inspired by #224, this removes the final restriction on using build and run together.

The use case for this is that for simply running a script in docker with a shared cached build, having to have `docker-compose build` > `wait` > `docker-compose run` overcomplicates the pipeline unnecessarily. In particular it prevents running many similar steps in parallel because of the `wait`.

As far as I can see there's no reason this shouldn't work: `build` sets the magic meta-data, `run` then immediately reads it like normal. It's worked so far in our testing.

Probably need to update the README and plugin schema including the changes from #224, not sure if I'm the right person to do that though.