### PR TITLE
Check service names in cache-from against the services being built

### DIFF
--- a/commands/build.sh
+++ b/commands/build.sh
@@ -38,6 +38,7 @@ for line in $(plugin_read_list CACHE_FROM) ; do
     echo "    $line"
     echo "Service name '$service_name' is not one of the services being built:"
     echo "    ${build_services[*]}"
+    exit 1
   fi
 
   echo "~~~ :docker: Pulling cache image for $service_name"

--- a/tests/build.bats
+++ b/tests/build.bats
@@ -399,6 +399,32 @@ load '../lib/shared'
   unstub docker-compose
 }
 
+@test "Build with cache-from with service not being built" {
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CONFIG="tests/composefiles/docker-compose.v3.2.yml"
+  export BUILDKITE_JOB_ID=1111
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD_0=helloworld
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CACHE_FROM_0=different_service:my.repository/myservice_cache:latest
+  export BUILDKITE_PIPELINE_SLUG=test
+  export BUILDKITE_BUILD_NUMBER=1
+
+  stub docker \
+    "pull my.repository/myservice_cache:latest : echo pulled cache image"
+
+  stub docker-compose \
+    "-f tests/composefiles/docker-compose.v3.2.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml build --pull helloworld : echo built helloworld"
+
+  run $PWD/hooks/command
+
+  assert_success
+  assert_output --partial "cache-from refers to service 'different_service' that is not being built"
+  assert_output --partial "pulled cache image"
+  # make sure it doesn't appear in a cache-from line
+  refute_output --partial "- my.repository/myservice_cache:latest"
+  assert_output --partial "built helloworld"
+  unstub docker
+  unstub docker-compose
+}
+
 @test "Build with a custom image-name" {
   export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD=myservice


### PR DESCRIPTION
The service names in the cache-from lines are used to place
`cache_from: ...` configurations into the appropriate place in the
modified docker-compose config. Without that `cache_from`, the pulled
image cannot be used for caching, and so all the effort there is
useless.

Previously, a configuration like:

    build:
    - foo
    cache_from:
    - foo-bar-baz:example.com/foo-bar-baz:latest

would download the image, but be unable to use it for caching
purposes. This patch makes the plugin flag this as a soft error,
alerting the user that the `foo-bar-baz` cache-from line doesn't
correspond to any of the services being built.

This came up for us when we had long image names, and
abbreviated service names, and we'd accidentally used the
image name before the colon. It took a while to work out
why the caching wasn't behaving as expected.