### PR TITLE
make clear -no-cache is boolean

### DIFF
--- a/README.md
+++ b/README.md
@@ -385,6 +385,8 @@ The default is `false`.
 
 Sets the build step to run with `--no-cache`, causing Docker Compose to not use any caches when building the image.
 
+The default is false.
+
 ### `build-parallel` (optional, build only)
 
 Set the build step to run with `--parallel`, causing Docker Compose to run builds in parallel. Requires docker-compose `1.23+`.

--- a/README.md
+++ b/README.md
@@ -385,7 +385,7 @@ The default is `false`.
 
 Sets the build step to run with `--no-cache`, causing Docker Compose to not use any caches when building the image.
 
-The default is false.
+The default is `false`.
 
 ### `build-parallel` (optional, build only)
 


### PR DESCRIPTION
Updates the docs so that it's clear for users that `-no-cache` is a boolean that can be set to `true` or `false`