### PR TITLE
skip pulling cached images if no-cache is set to true

### DIFF
--- a/tests/build.bats
+++ b/tests/build.bats
@@ -271,6 +271,27 @@ load '../lib/shared'
   unstub docker-compose
 }
 
+@test "Build with a cache-from image with no-cache also set" {
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CONFIG="tests/composefiles/docker-compose.v3.2.yml"
+  export BUILDKITE_JOB_ID=1111
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD_0=helloworld
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CACHE_FROM_0=helloworld:my.repository/myservice_cache:latest
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_NO_CACHE=true
+  export BUILDKITE_PIPELINE_SLUG=test
+  export BUILDKITE_BUILD_NUMBER=1
+
+  stub docker-compose \
+    "-f tests/composefiles/docker-compose.v3.2.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml build --pull --no-cache helloworld : echo built helloworld"
+
+  run $PWD/hooks/command
+
+  assert_success
+  refute_output --partial "pulled cache image"
+  refute_output --partial "- my.repository/myservice_cache:latest"
+  assert_output --partial "built helloworld"
+  unstub docker-compose
+}
+
 @test "Build with several cache-from images for one service" {
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CONFIG="tests/composefiles/docker-compose.v3.2.yml"
   export BUILDKITE_JOB_ID=1111


### PR DESCRIPTION
Updates the script such that If `no-cache` is set to true, `--cache-from` images are not pulled