### PR TITLE
Add propagate-uid-gid option

### DIFF
--- a/README.md
+++ b/README.md
@@ -353,6 +353,12 @@ Specify the container working directory via `docker-compose run --workdir`.
 
 Run as specified username or uid via `docker-compose run --user`.
 
+### `propagate-uid-gid` (optional, run-only, boolean)
+
+Whether to match the user ID and group ID for the container user to the user ID and group ID for the host user. It is similar to specifying user: 1000:1000, except it avoids hardcoding a particular user/group ID.
+
+Using this option ensures that any files created on shared mounts from within the container will be accessible to the host user. It is otherwise common to accidentally create root-owned files that Buildkite will be unable to remove, since containers by default run as the root user.
+
 ### `pull-retries` (optional)
 
 A number of times to retry failed docker pull. Defaults to 0.

--- a/commands/run.sh
+++ b/commands/run.sh
@@ -119,9 +119,20 @@ if [[ -n "$(plugin_read_config WORKDIR)" ]] ; then
   run_params+=("--workdir=$(plugin_read_config WORKDIR)")
 fi
 
+# Can't set both user and propagate-uid-gid
+if [[ -n "$(plugin_read_config USER)" ]] && [[ -n "$(plugin_read_config PROPAGATE_UID_GID)" ]]; then
+  echo "+++ Error: Can't set both user and propagate-uid-gid"
+  exit 1
+fi
+
 # Optionally run as specified username or uid
 if [[ -n "$(plugin_read_config USER)" ]] ; then
   run_params+=("--user=$(plugin_read_config USER)")
+fi
+
+# Optionally run as specified username or uid
+if [[ "$(plugin_read_config PROPAGATE_UID_GID "false")" == "true" ]] ; then
+  run_params+=("--user=$(id -u):$(id -g)")
 fi
 
 # Optionally disable ansi output

--- a/plugin.yml
+++ b/plugin.yml
@@ -70,6 +70,8 @@ configuration:
       type: boolean
     upload-container-logs:
       type: string
+    propagate-uid-gid:
+      type: boolean
   oneOf:
     - required:
       - run
@@ -96,3 +98,4 @@ configuration:
     tty: [ run ]
     workdir: [ run ]
     user: [ run ]
+    propagate-uid-gid: [ run ]

--- a/tests/run.bats
+++ b/tests/run.bats
@@ -665,6 +665,33 @@ export BUILDKITE_JOB_ID=1111
   unstub buildkite-agent
 }
 
+@test "Run without a prebuilt image and a custom user and group" {
+  export BUILDKITE_JOB_ID=1111
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RUN=myservice
+  export BUILDKITE_PIPELINE_SLUG=test
+  export BUILDKITE_BUILD_NUMBER=1
+  export BUILDKITE_COMMAND="sh -c 'whoami'"
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CHECK_LINKED_CONTAINERS=false
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLEANUP=false
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_USER="1000"
+
+  stub docker-compose \
+    "-f docker-compose.yml -p buildkite1111 build --pull myservice : echo built myservice" \
+    "-f docker-compose.yml -p buildkite1111 up -d --scale myservice=0 myservice : echo started dependencies for myservice" \
+    "-f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 --user=1000:1000 myservice /bin/sh -e -c 'sh -c \'whoami\'' : echo ran myservice"
+
+  stub buildkite-agent \
+    "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 1"
+
+  run $PWD/hooks/command
+
+  assert_success
+  assert_output --partial "built myservice"
+  assert_output --partial "ran myservice"
+  unstub docker-compose
+  unstub buildkite-agent
+}
+
 @test "Run without --rm" {
   export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RUN=myservice


### PR DESCRIPTION
Similarly to what `docker-plugin` has, this PR is to add an option to choose whether to match the user ID and group ID for the container user to the user ID and group ID for the host user. It is similar to specifying user: 1000:1000, except it avoids hardcoding a particular user/group ID.

Using this option ensures that any files created on shared mounts from within the container will be accessible to the host user. It is otherwise common to accidentally create root-owned files that Buildkite will be unable to remove, since containers by default run as the root user.