### PR TITLE
Fix expand_relative_volume_path on windows

### DIFF
--- a/lib/run.bash
+++ b/lib/run.bash
@@ -72,5 +72,14 @@ check_linked_containers_and_save_logs() {
 # "./foo:/foo" => "/buildkite/builds/.../foo:/foo"
 expand_relative_volume_path() {
   local path="$1"
-  echo "${path/.\//$PWD/}"
+  local pwd="$PWD"
+
+  # docker-compose's -v expects native paths on windows, so convert back.
+  #
+  # "/c/Users/..." => "C:\Users\..."
+  if is_windows ; then
+    pwd="$(cygpath -w "$PWD")"
+  fi
+
+  echo "${path/.\//$pwd/}"
 }


### PR DESCRIPTION
Fixes #249.

I've tested this with a Windows container using a configuration like:

```
          volumes:
            - ./artifacts:C:\\workspace\\artifacts
```

I believe Linux containers on Windows also need the host path to be in native format, so it shouldn't break anything there, but I haven't personally tried that.