### PR TITLE
Fix run+push never executing the push stage

### DIFF
--- a/commands/run.sh
+++ b/commands/run.sh
@@ -305,4 +305,4 @@ if [[ -n "${BUILDKITE_AGENT_ACCESS_TOKEN:-}" ]] ; then
   fi
 fi
 
-exit $exitcode
+return $exitcode


### PR DESCRIPTION
In #224 we added the ability to do a build/run + push in a single step, but unfortunately there was a bug in the `run` command (the use of `exit`) that prevents the `build` stage ever being run. 

This PR replaces the `exit` with a `return`, which allows a successful `run` to continue on to `build`.

Fixes: #259