### PR TITLE
Add entrypoint option

### DIFF
--- a/README.md
+++ b/README.md
@@ -435,6 +435,10 @@ If set to true, docker compose will remove the primary container after run. Equi
 
 The default is `true`.
 
+### `entrypoint` (optional, run only)
+
+Sets the `--entrypoint` argument when running `docker-compose`.
+
 ### `upload-container-logs` (optional, run only)
 
 Select when to upload container logs.

--- a/commands/run.sh
+++ b/commands/run.sh
@@ -150,6 +150,11 @@ if [[ "$(plugin_read_config RM "true")" == "true" ]]; then
   run_params+=(--rm)
 fi
 
+# Optionally sets --entrypoint
+if [[ -n "$(plugin_read_config ENTRYPOINT)" ]] ; then
+  run_params+=("--entrypoint \"$(plugin_read_config ENTRYPOINT)\"")
+fi
+
 run_params+=("$run_service")
 
 if [[ "${BUILDKITE_PLUGIN_DOCKER_COMPOSE_REQUIRE_PREBUILD:-}" =~ ^(true|on|1)$ ]] && [[ ! -f "$override_file" ]] ; then

--- a/tests/run.bats
+++ b/tests/run.bats
@@ -718,3 +718,32 @@ export BUILDKITE_JOB_ID=1111
   unstub docker-compose
   unstub buildkite-agent
 }
+
+@test "Run with custom entrypoint" {
+  export BUILDKITE_JOB_ID=1111
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RUN=myservice
+  export BUILDKITE_PIPELINE_SLUG=test
+  export BUILDKITE_BUILD_NUMBER=1
+  export BUILDKITE_COMMAND=""
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CHECK_LINKED_CONTAINERS=false
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLEANUP=false
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_ENTRYPOINT="my custom entrypoint"
+
+  ENTRYPOINT='--entrypoint\ \"my\ custom\ entrypoint\"'
+
+  stub docker-compose \
+    "-f docker-compose.yml -p buildkite1111 build --pull myservice : echo built myservice" \
+    "-f docker-compose.yml -p buildkite1111 up -d --scale myservice=0 : echo ran myservice dependencies" \
+    "-f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 --rm ${ENTRYPOINT} myservice : echo ran myservice"
+
+  stub buildkite-agent \
+    "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 1"
+
+  run $PWD/hooks/command
+
+  assert_success
+  assert_output --partial "built myservice"
+  assert_output --partial "ran myservice"
+  unstub docker-compose
+  unstub buildkite-agent
+}


### PR DESCRIPTION
Fixes #258 

The idea is to add an `entrypoint` option so we can override the one specified in the docker-compose file.

I don't have a lot of experience with docker or buildkite, so I'm not sure if this is the right way to do it. Please let me know if i missed anything, or if there is a better way to do this.