### PR TITLE
Allow for building an image with multiple --cache-from images

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ You can use the [environment key in docker-compose.yml](https://docs.docker.com/
 variables from outside docker-compose.
 
 If you want to add extra environment above what is declared in your `docker-compose.yml`,
-this plugin offers a `environment` block of it's own:
+this plugin offers a `environment` block of its own:
 
 ```yml
 steps:
@@ -151,7 +151,7 @@ Note how the values in the list can either be just a key (so the value is source
 
 You can use the [build args key in docker-compose.yml](https://docs.docker.com/compose/compose-file/#args) to set specific build arguments when building an image.
 
-Alternatively, if you want to set build arguments when pre-building an image, this plugin offers an `args` block of it's own:
+Alternatively, if you want to set build arguments when pre-building an image, this plugin offers an `args` block of its own:
 
 ```yml
 steps:
@@ -264,8 +264,8 @@ steps:
           username: xyz
       - docker-compose#v3.9.0:
           push:
-          - app:index.docker.io/myorg/myrepo/myapp
-          - app:index.docker.io/myorg/myrepo/myapp:latest
+            - app:index.docker.io/myorg/myrepo/myapp
+            - app:index.docker.io/myorg/myrepo/myapp:latest
 ```
 
 ## Reusing caches from images
@@ -285,9 +285,61 @@ steps:
     plugins:
       - docker-compose#v3.9.0:
           push:
-          - app:index.docker.io/myorg/myrepo/myapp
-          - app:index.docker.io/myorg/myrepo/myapp:latest
+            - app:index.docker.io/myorg/myrepo/myapp
+            - app:index.docker.io/myorg/myrepo/myapp:latest
 ```
+
+#### Multiple cache-from values
+
+This plugin allows for the value of `cache-from` to be a string or a list. If it's a list, as below, then the first successfully pulled image will be used.
+
+```yaml
+steps:
+  - label: ":docker Build an image"
+    plugins:
+      - docker-compose#v3.2.0:
+          build: app
+          image-repository: index.docker.io/myorg/myrepo
+          cache-from:
+            - app:index.docker.io/myorg/myrepo/myapp:my-branch
+            - app:index.docker.io/myorg/myrepo/myapp:latest
+  - wait
+  - label: ":docker: Push to final repository"
+    plugins:
+      - docker-compose#v3.2.0:
+          push:
+            - app:index.docker.io/myorg/myrepo/myapp
+            - app:index.docker.io/myorg/myrepo/myapp:my-branch
+            - app:index.docker.io/myorg/myrepo/myapp:latest
+```
+
+You may actually want to build your image with multiple cache-from values, for instance, with the cached images of multiple stages in a multi-stage build.
+By adding a grouping tag to the end of a cache-from list item, this plugin can differentiate between groups within which only the first successfully downloaded image should be used.
+This way, not all of the images need to be downloaded and used as cache, and also not just the first.
+
+```yaml
+steps:
+  - label: ":docker Build an image"
+    plugins:
+      - docker-compose#v3.2.0:
+          build: app
+          image-repository: index.docker.io/myorg/myrepo
+          cache-from:
+            - app:index.docker.io/myorg/myrepo/myapp-intermediate-target:this-build-number:intermediate
+            - app:index.docker.io/myorg/myrepo/myapp:my-branch
+            - app:index.docker.io/myorg/myrepo/myapp:latest
+  - wait
+  - label: ":docker: Push to final repository"
+    plugins:
+      - docker-compose#v3.2.0:
+          push:
+            - app:index.docker.io/myorg/myrepo/myapp
+            - app:index.docker.io/myorg/myrepo/myapp:my-branch
+            - app:index.docker.io/myorg/myrepo/myapp:latest
+```
+
+In the example above, the `myapp-intermediate-target:this-build-number` is one group named "intermediate", and `myapp:my-branch` and `myapp:latest`
+are another (with a default name). The first successfully downloaded image in each group will be used as a cache.
 
 ## Configuration
 

--- a/commands/run.sh
+++ b/commands/run.sh
@@ -41,7 +41,7 @@ prebuilt_services=()
 for service_name in "${prebuilt_candidates[@]}" ; do
   if prebuilt_image=$(get_prebuilt_image "$service_name") ; then
     echo "~~~ :docker: Found a pre-built image for $service_name"
-    prebuilt_service_overrides+=("$service_name" "$prebuilt_image" "")
+    prebuilt_service_overrides+=("$service_name" "$prebuilt_image" 0)
     prebuilt_services+=("$service_name")
 
     # If it's prebuilt, we need to pull it down

--- a/lib/shared.bash
+++ b/lib/shared.bash
@@ -134,7 +134,7 @@ function docker_compose_supports_cache_from() {
 }
 
 # Build an docker-compose file that overrides the image for a specific
-# docker-compose version and set of [ service, image, cache_from ] tuples
+# docker-compose version and set of [ service, image, num_cache_from, cache_from1, cache_from2, ... ] tuples
 function build_image_override_file_with_version() {
   local version="$1"
 
@@ -153,7 +153,7 @@ function build_image_override_file_with_version() {
     printf "  %s:\\n" "$1"
     printf "    image: %s\\n" "$2"
 
-    if [[ -n "$3" ]] ; then
+    if [[ "$3" -gt 0 ]] ; then
       if ! docker_compose_supports_cache_from "$version" ; then
         echo "Unsupported Docker Compose config file version: $version"
         echo "The 'cache_from' option can only be used with Compose file versions 2.2 or 3.2 and above."
@@ -164,7 +164,10 @@ function build_image_override_file_with_version() {
 
       printf "    build:\\n"
       printf "      cache_from:\\n"
-      printf "        - %s\\n" "$3"
+      for cache_from_i in $(seq 4 "$((3 + $3))"); do
+        printf "        - %s\\n" "${!cache_from_i}"
+      done
+      shift "$3"
     fi
 
     shift 3

--- a/tests/build.bats
+++ b/tests/build.bats
@@ -318,6 +318,42 @@ load '../lib/shared'
   unstub docker-compose
 }
 
+@test "Build with several cache-from image groups for one service" {
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CONFIG="tests/composefiles/docker-compose.v3.2.yml"
+  export BUILDKITE_JOB_ID=1111
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD_0=helloworld
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CACHE_FROM_0=helloworld:my.repository/myservice_cache:build-target-build-1:target1
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CACHE_FROM_1=helloworld:my.repository/myservice_cache:build-target-latest:target1
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CACHE_FROM_2=helloworld:my.repository/myservice_cache:install-target-build-1:target2
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CACHE_FROM_3=helloworld:my.repository/myservice_cache:branch-name
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CACHE_FROM_4=helloworld:my.repository/myservice_cache:latest
+  export BUILDKITE_PIPELINE_SLUG=test
+  export BUILDKITE_BUILD_NUMBER=1
+
+  stub docker \
+    "pull my.repository/myservice_cache:build-target-build-1 : echo pulled cache image build-target" \
+    "pull my.repository/myservice_cache:install-target-build-1 : echo pulled cache image install-target" \
+    "pull my.repository/myservice_cache:branch-name : echo pulled cache image branch-name"
+
+  stub docker-compose \
+    "-f tests/composefiles/docker-compose.v3.2.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml build --pull helloworld : echo built helloworld"
+
+  run $PWD/hooks/command
+
+  assert_success
+  assert_output --partial "pulled cache image build-target"
+  assert_output --partial "pulled cache image install-target"
+  assert_output --partial "pulled cache image branch-name"
+  assert_output --partial "- my.repository/myservice_cache:build-target-build-1"
+  refute_output --partial "- my.repository/myservice_cache:build-target-latest"
+  assert_output --partial "- my.repository/myservice_cache:install-target-build-1"
+  assert_output --partial "- my.repository/myservice_cache:branch-name"
+  refute_output --partial "- my.repository/myservice_cache:latest"
+  assert_output --partial "built helloworld"
+  unstub docker
+  unstub docker-compose
+}
+
 @test "Build with several cache-from images for one service with first image being not available" {
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CONFIG="tests/composefiles/docker-compose.v3.2.yml"
   export BUILDKITE_JOB_ID=1111

--- a/tests/image-override-file.bats
+++ b/tests/image-override-file.bats
@@ -32,61 +32,80 @@ services:
 EOF
 )
 
-@test "Build an docker-compose override file" {
-  run build_image_override_file_with_version "2.1" "myservice" "newimage:1.0.0" ""
+myservice_override_file4=$(cat <<-EOF
+version: '3.2'
+services:
+  myservice:
+    image: newimage:1.0.0
+    build:
+      cache_from:
+        - my.repository/myservice:latest
+        - my.repository/myservice:target
+EOF
+)
+
+@test "Build a docker-compose override file" {
+  run build_image_override_file_with_version "2.1" "myservice" "newimage:1.0.0" 0
 
   assert_success
   assert_output "$myservice_override_file1"
 }
 
-@test "Build an docker-compose override file with multiple entries" {
+@test "Build a docker-compose override file with multiple entries" {
   run build_image_override_file_with_version "2.1" \
-    "myservice1" "newimage1:1.0.0" "" \
-    "myservice2" "newimage2:1.0.0" ""
+    "myservice1" "newimage1:1.0.0" 0 \
+    "myservice2" "newimage2:1.0.0" 0
 
   assert_success
   assert_output "$myservice_override_file2"
 }
 
 @test "Build a docker-compose file with cache-from" {
-  run build_image_override_file_with_version "3.2" "myservice" "newimage:1.0.0" "my.repository/myservice:latest"
+  run build_image_override_file_with_version "3.2" "myservice" "newimage:1.0.0" 1 "my.repository/myservice:latest"
 
   assert_success
   assert_output "$myservice_override_file3"
 }
 
+@test "Build a docker-compose file with multiple cache-from entries" {
+  run build_image_override_file_with_version "3.2" "myservice" "newimage:1.0.0" 2 "my.repository/myservice:latest" "my.repository/myservice:target"
+
+  assert_success
+  assert_output "$myservice_override_file4"
+}
+
 @test "Build a docker-compose file with cache-from and compose-file version 2" {
-  run build_image_override_file_with_version "2" "myservice" "newimage:1.0.0" "my.repository/myservice:latest"
+  run build_image_override_file_with_version "2" "myservice" "newimage:1.0.0" 1 "my.repository/myservice:latest"
 
   assert_failure
 }
 
 @test "Build a docker-compose file with cache-from and compose-file version 2.0" {
-  run build_image_override_file_with_version "2.0" "myservice" "newimage:1.0.0" "my.repository/myservice:latest"
+  run build_image_override_file_with_version "2.0" "myservice" "newimage:1.0.0" 1 "my.repository/myservice:latest"
 
   assert_failure
 }
 
 @test "Build a docker-compose file with cache-from and compose-file version 2.1" {
-  run build_image_override_file_with_version "2.1" "myservice" "newimage:1.0.0" "my.repository/myservice:latest"
+  run build_image_override_file_with_version "2.1" "myservice" "newimage:1.0.0" 1 "my.repository/myservice:latest"
 
   assert_failure
 }
 
 @test "Build a docker-compose file with cache-from and compose-file version 3" {
-  run build_image_override_file_with_version "3" "myservice" "newimage:1.0.0" "my.repository/myservice:latest"
+  run build_image_override_file_with_version "3" "myservice" "newimage:1.0.0" 1 "my.repository/myservice:latest"
 
   assert_failure
 }
 
 @test "Build a docker-compose file with cache-from and compose-file version 3.0" {
-  run build_image_override_file_with_version "3.0" "myservice" "newimage:1.0.0" "my.repository/myservice:latest"
+  run build_image_override_file_with_version "3.0" "myservice" "newimage:1.0.0" 1 "my.repository/myservice:latest"
 
   assert_failure
 }
 
 @test "Build a docker-compose file with cache-from and compose-file version 3.1" {
-  run build_image_override_file_with_version "3.1" "myservice" "newimage:1.0.0" "my.repository/myservice:latest"
+  run build_image_override_file_with_version "3.1" "myservice" "newimage:1.0.0" 1 "my.repository/myservice:latest"
 
   assert_failure
 }


### PR DESCRIPTION
We're using this to `--cache-from` intermediate and final stages of a multi-stage docker build, instead of busting the cache every time on building the intermediate target.

Would definitely appreciate a review of the interface and implementation.