### PR TITLE
Use a local registry for testing docker push/pull

### DIFF
--- a/.buildkite/hooks/post-command
+++ b/.buildkite/hooks/post-command
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -ueo pipefail
+
+if [[ -n "${PERSIST_REGISTRY:-}" ]]; then
+  echo "~~~ Uploading test Docker registry data"
+  tar -czf "${PERSIST_REGISTRY}" tmp/registry
+  buildkite-agent artifact upload "${PERSIST_REGISTRY}"
+fi

--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -ueo pipefail
+
+if [[ -n "${RESTORE_REGISTRY:-}" ]]; then
+  echo "~~~ Downloading test Docker registry data"
+  buildkite-agent artifact download "${RESTORE_REGISTRY}" .
+  tar -xzf "${RESTORE_REGISTRY}"
+fi
+
+echo "~~~ Starting test Docker registry"
+docker run -d \
+  -p 5005:5000 \
+  --name docker-compose-plugin-registry \
+  -v "$(pwd)/tmp/registry:/var/lib/registry" \
+  registry:2

--- a/.buildkite/hooks/pre-exit
+++ b/.buildkite/hooks/pre-exit
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -ueo pipefail
+
+echo "~~~ Stopping test Docker registry"
+docker container stop docker-compose-plugin-registry && docker container rm -v docker-compose-plugin-registry

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,3 +1,9 @@
+env:
+  # Some of these are end-to-end integration tests that require a Docker
+  # registry to run. We boot one up in the .hooks/pre-command, and then use that
+  # registry for doing all the push/pull testing.
+  IMAGE_REPO: "localhost:5005/docker-compose-test"
+
 steps:
   - label: ":shell: Shellcheck"
     plugins:
@@ -17,7 +23,8 @@ steps:
       ${BUILDKITE_REPO}#${BUILDKITE_COMMIT}:
         run: tests
 
-  - wait
+  # The rest of the steps are integration tests
+
   - label: run, with links that fail
     command: echo hello from alpine
     plugins:
@@ -25,7 +32,6 @@ steps:
         run: alpinewithfailinglink
         config: tests/composefiles/docker-compose.v2.1.yml
 
-  - wait
   - label: run, with environment
     plugins:
       ${BUILDKITE_REPO}#${BUILDKITE_COMMIT}:
@@ -34,7 +40,6 @@ steps:
         environment:
           - ALPACAS=sometimes
 
-  - wait
   - label: run, with multi-line command
     command: |
       echo \
@@ -45,17 +50,21 @@ steps:
         run: alpinewithenv
         config: tests/composefiles/docker-compose.v2.1.yml
 
-  - wait
   - label: prebuild with v2.0
+    key: prebuild-2-0
+    env:
+      PERSIST_REGISTRY: "registry-prebuild-2.0.tar.gz"
     command: /hello
     plugins:
       ${BUILDKITE_REPO}#${BUILDKITE_COMMIT}:
         build: helloworld
-        image-repository: ${DOCKER_REPO-buildkiteci/docker-compose-buildkite-plugin}
+        image-repository: "$IMAGE_REPO"
         config: tests/composefiles/docker-compose.v2.0.yml
 
-  - wait
   - label: run after build with v2.0
+    depends_on: prebuild-2-0
+    env:
+      RESTORE_REGISTRY: "registry-prebuild-2.0.tar.gz"
     plugins:
       ${BUILDKITE_REPO}#${BUILDKITE_COMMIT}:
         run: helloworld
@@ -63,42 +72,41 @@ steps:
         config: tests/composefiles/docker-compose.v2.0.yml
         command: ["/hello"]
 
-  - wait
   - label: prebuild with v2.1
+    key: prebuild-2-1
+    env:
+      PERSIST_REGISTRY: "registry-prebuild-2.1.tar.gz"
     command: /hello
     plugins:
       ${BUILDKITE_REPO}#${BUILDKITE_COMMIT}:
         build: helloworld
-        image-repository: ${DOCKER_REPO-buildkiteci/docker-compose-buildkite-plugin}
+        image-repository: "$IMAGE_REPO"
         config: tests/composefiles/docker-compose.v2.1.yml
 
-  - wait
-  - label: run after build with v2.1
-    plugins:
-      ${BUILDKITE_REPO}#${BUILDKITE_COMMIT}:
-        run: helloworld
-        require-prebuild: true
-        config: tests/composefiles/docker-compose.v2.1.yml
-        command: ["/hello"]
-
-  - wait
   - label: run with default command
+    depends_on: prebuild-2-1
+    env:
+      RESTORE_REGISTRY: "registry-prebuild-2.1.tar.gz"
     plugins:
       ${BUILDKITE_REPO}#${BUILDKITE_COMMIT}:
         run: helloworld
         config: tests/composefiles/docker-compose.v2.1.yml
 
-  - wait
-  - label: prebuild, where service has build and image-name
+  - label: prebuild, where service has build and image-repo
+    key: prebuild-2-1-build-image-repo
+    env:
+      PERSIST_REGISTRY: "registry-prebuild-2.1-build-image-repo.tar.gz"
     plugins:
       ${BUILDKITE_REPO}#${BUILDKITE_COMMIT}:
         build: helloworldimage
-        image-repository: ${DOCKER_REPO-buildkiteci/docker-compose-buildkite-plugin}
+        image-repository: "$IMAGE_REPO"
         config: tests/composefiles/docker-compose.v2.1.yml
         commmand: ["/hello"]
 
-  - wait
   - label: run after prebuild
+    depends_on: prebuild-2-1-build-image-repo
+    env:
+      RESTORE_REGISTRY: "registry-prebuild-2.1-build-image-repo.tar.gz"
     plugins:
       ${BUILDKITE_REPO}#${BUILDKITE_COMMIT}:
         run: helloworldimage
@@ -106,17 +114,21 @@ steps:
         config: tests/composefiles/docker-compose.v2.1.yml
         commmand: ["/hello"]
 
-  - wait
   - label: prebuild with custom image-name
+    key: prebuild-custom-image-name
+    env:
+      PERSIST_REGISTRY: "registry-prebuild-custom-image-name.tar.gz"
     plugins:
       ${BUILDKITE_REPO}#${BUILDKITE_COMMIT}:
         build: helloworld
-        image-repository: ${DOCKER_REPO-buildkiteci/docker-compose-buildkite-plugin}
+        image-repository: "$IMAGE_REPO"
         image-name: llamas-build-${BUILDKITE_BUILD_NUMBER}
         config: tests/composefiles/docker-compose.v2.1.yml
 
-  - wait
   - label: run after prebuild with custom image-name
+    depends_on: prebuild-custom-image-name
+    env:
+      RESTORE_REGISTRY: "registry-prebuild-custom-image-name.tar.gz"
     plugins:
       ${BUILDKITE_REPO}#${BUILDKITE_COMMIT}:
         run: helloworld
@@ -124,8 +136,10 @@ steps:
         config: tests/composefiles/docker-compose.v2.1.yml
         commmand: ["/hello"]
 
-  - wait
   - label: push after build with custom image-name
+    depends_on: prebuild-custom-image-name
+    env:
+      RESTORE_REGISTRY: "registry-prebuild-custom-image-name.tar.gz"
     plugins:
       ${BUILDKITE_REPO}#${BUILDKITE_COMMIT}:
         push: helloworld

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 docker-compose.buildkite-1-override.yml 
 docker-compose-logs/
+tmp/
+registry-*.tar.gz


### PR DESCRIPTION
Currently the integration tests require push/pull access to a remote registry, which is hard to run locally or in untrusted VMs. This sets up a local Docker registry for testing, and uses buildkite artifacts to persist and restore the registry data as needed between the steps.