### PR TITLE
Defaults docker compose version to 2

### DIFF
--- a/lib/shared.bash
+++ b/lib/shared.bash
@@ -115,6 +115,10 @@ function docker_compose_config_files() {
 # Returns the version from the output of docker_compose_config
 function docker_compose_config_version() {
   IFS=$'\n' read -r -a config <<< "$(docker_compose_config_files)"
+  if [ ${#config[@]} -eq 0 ] ; then
+    echo "2"
+    return
+  fi
   awk '/^\s*version:/ { print $2; }' < "${config[0]}" | sed "s/[\"']//g"
 }
 


### PR DESCRIPTION

When using the `skip-checkout` option and multi-step builds, `build_image_override_file` without a `docker-compose.yml` (it hasn't been checked out). This causes the script to fail with an error like:

```bash
[2020-07-02T00:34:10Z] /etc/buildkite-agent/plugins/github-com-buildkite-plugins-docker-compose-buildkite-plugin-v3-3-0/hooks/../lib/shared.bash: line 118: docker-compose.yml: No such file or directory
[2020-07-02T00:34:10Z] The 'build' option can only be used with Compose file versions 2.0 and above.
[2020-07-02T00:34:10Z] For more information on Docker Compose configuration file versions, see:
[2020-07-02T00:34:10Z] https://docs.docker.com/compose/compose-file/compose-versioning/#versioning
```

This PR conservatively sets `docker_compose_config_version` to 2 if no prior compose files are found (like in the case above). I selected 2 as it's the most conservative version that should a.) be able to execute the generated compose file and b.) expected to run on hosts (see comment on :146 of that file). I also specifically _didn't_ fix this more locally to the usecase (`build_image_override_file`) because it's possible there _are_ compose files but with incorrect versions and it would be difficult to pick up that case.

I believe this fixes #232 and #122.

### Test Plan

None yet. I'm new to the project and the tests dir seemed a little light. I would love some help/direction in that regard!