### PR TITLE
Set default Buildkit output mode to `plain`

### DIFF
--- a/hooks/pre-command
+++ b/hooks/pre-command
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -ueo pipefail
+
+# If they're using Buildkit, make sure it doesn't output the '---' lines that
+# mess up Buildkite's log output grouping
+export BUILDKIT_PROGRESS=plain

--- a/tests/pre-command.bats
+++ b/tests/pre-command.bats
@@ -1,0 +1,13 @@
+#!/usr/bin/env bats
+
+load '/usr/local/lib/bats/load.bash'
+
+@test "Pre-command sets Buildkit to use plain output" {
+  BUILDKIT_PROGRESS=
+
+  source "$PWD/hooks/pre-command"
+
+  assert_equal "plain" "${BUILDKIT_PROGRESS}"
+
+  unset BUILDKIT_PROGRESS
+}


### PR DESCRIPTION
As mentioned in #256, if you use [Buildkit](https://docs.docker.com/develop/develop-images/build_enhancements/) the default output can create a bunch of erroneous [log output groups](https://buildkite.com/docs/pipelines/managing-log-output#collapsing-output).

This change sets the default Buildkit output to `plain` to avoid this.

Fixes #256