### PR TITLE
Fix --no-ansi option for docker-compose run

### DIFF
--- a/commands/run.sh
+++ b/commands/run.sh
@@ -76,6 +76,11 @@ if [[ ${#pull_services[@]} -gt 0 ]] ; then
   echo
 fi
 
+# Optionally disable ansi output
+if [[ "$(plugin_read_config ANSI "true")" == "false" ]] ; then
+  run_params+=(--no-ansi)
+fi
+
 # We set a predictable container name so we can find it and inspect it later on
 run_params+=("run" "--name" "$container_name")
 
@@ -133,11 +138,6 @@ fi
 # Optionally run as specified username or uid
 if [[ "$(plugin_read_config PROPAGATE_UID_GID "false")" == "true" ]] ; then
   run_params+=("--user=$(id -u):$(id -g)")
-fi
-
-# Optionally disable ansi output
-if [[ "$(plugin_read_config ANSI "true")" == "false" ]] ; then
-  run_params+=(--no-ansi)
 fi
 
 # Enable alias support for networks

--- a/tests/run.bats
+++ b/tests/run.bats
@@ -454,7 +454,7 @@ export BUILDKITE_JOB_ID=1111
   stub docker-compose \
     "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml pull myservice : echo pulled myservice" \
     "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml up -d --scale myservice=0 myservice : echo started dependencies for myservice" \
-    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 --no-ansi --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice without ansi output"
+    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml --no-ansi run --name buildkite1111_myservice_build_1 --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice without ansi output"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 0" \


### PR DESCRIPTION
The `--no-ansi` option is an option for `docker-compose`, so it should come before `run`, otherwise the command is not valid.