### PR TITLE
Fix entrypoint param

### DIFF
--- a/commands/run.sh
+++ b/commands/run.sh
@@ -152,7 +152,8 @@ fi
 
 # Optionally sets --entrypoint
 if [[ -n "$(plugin_read_config ENTRYPOINT)" ]] ; then
-  run_params+=("--entrypoint \"$(plugin_read_config ENTRYPOINT)\"")
+  run_params+=(--entrypoint)
+  run_params+=("$(plugin_read_config ENTRYPOINT)")
 fi
 
 run_params+=("$run_service")

--- a/tests/run.bats
+++ b/tests/run.bats
@@ -789,7 +789,7 @@ export BUILDKITE_JOB_ID=1111
   stub docker-compose \
     "-f docker-compose.yml -p buildkite1111 build --pull myservice : echo built myservice" \
     "-f docker-compose.yml -p buildkite1111 up -d --scale myservice=0 : echo ran myservice dependencies" \
-    "-f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 --rm ${ENTRYPOINT} myservice : echo ran myservice"
+    "-f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 --rm --entrypoint 'my custom entrypoint' myservice : echo ran myservice"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 1"


### PR DESCRIPTION
I think i made a mistake in https://github.com/buildkite-plugins/docker-compose-buildkite-plugin/pull/262 😞  , which was causing the entrypoint option to be wrapped in quotes and not interpreted correctly by docker-compose. Sorry about that!

I think it should work now, i was able to test it with one of my BK pipeline using this branch (should have done that with my previous PR)