### PR TITLE
mirror mount-buildkite-agent implementation from docker-buildkite-plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -359,6 +359,12 @@ Whether to match the user ID and group ID for the container user to the user ID 
 
 Using this option ensures that any files created on shared mounts from within the container will be accessible to the host user. It is otherwise common to accidentally create root-owned files that Buildkite will be unable to remove, since containers by default run as the root user.
 
+### `mount-buildkite-agent` (optional, run-only, boolean)
+
+Whether to automatically mount the `buildkite-agent` binary and associated environment variables from the host agent machine into the container.
+
+Default: `false`
+
 ### `pull-retries` (optional)
 
 A number of times to retry failed docker pull. Defaults to 0.

--- a/commands/run.sh
+++ b/commands/run.sh
@@ -155,6 +155,28 @@ if [[ -n "$(plugin_read_config ENTRYPOINT)" ]] ; then
   run_params+=("--entrypoint \"$(plugin_read_config ENTRYPOINT)\"")
 fi
 
+# Optionally handle the mount-buildkite-agent option
+if [[ "$(plugin_read_config MOUNT_BUILDKITE_AGENT "false")" == "true" ]]; then
+  if [[ -z "${BUILDKITE_AGENT_BINARY_PATH:-}" ]] ; then
+    if ! command -v buildkite-agent >/dev/null 2>&1 ; then
+      echo -n "+++ 🚨 Failed to find buildkite-agent in PATH to mount into container, "
+      echo "you can disable this behaviour with 'mount-buildkite-agent:false'"
+    else
+      BUILDKITE_AGENT_BINARY_PATH=$(command -v buildkite-agent)
+    fi
+  fi
+fi
+
+# Mount buildkite-agent if we have a path for it
+if [[ -n "${BUILDKITE_AGENT_BINARY_PATH:-}" ]] ; then
+  run_params+=(
+    "--env" "BUILDKITE_JOB_ID"
+    "--env" "BUILDKITE_BUILD_ID"
+    "--env" "BUILDKITE_AGENT_ACCESS_TOKEN"
+    "--volume" "$BUILDKITE_AGENT_BINARY_PATH:/usr/bin/buildkite-agent"
+  )
+fi
+
 run_params+=("$run_service")
 
 build_params=(--pull)

--- a/commands/run.sh
+++ b/commands/run.sh
@@ -320,7 +320,8 @@ set -e
 
 if [[ $exitcode -ne 0 ]] ; then
   echo "^^^ +++"
-  echo "+++ :warning: Failed to run command, exited with $exitcode"
+  echo "+++ :warning: Failed to run command, exited with $exitcode, run params:"
+  echo "${run_params[@]}"
 fi
 
 if [[ -n "${BUILDKITE_AGENT_ACCESS_TOKEN:-}" ]] ; then

--- a/commands/run.sh
+++ b/commands/run.sh
@@ -170,10 +170,10 @@ fi
 # Mount buildkite-agent if we have a path for it
 if [[ -n "${BUILDKITE_AGENT_BINARY_PATH:-}" ]] ; then
   run_params+=(
-    "--env" "BUILDKITE_JOB_ID"
-    "--env" "BUILDKITE_BUILD_ID"
-    "--env" "BUILDKITE_AGENT_ACCESS_TOKEN"
-    "--volume" "$BUILDKITE_AGENT_BINARY_PATH:/usr/bin/buildkite-agent"
+    "-e" "BUILDKITE_JOB_ID"
+    "-e" "BUILDKITE_BUILD_ID"
+    "-e" "BUILDKITE_AGENT_ACCESS_TOKEN"
+    "-v" "$BUILDKITE_AGENT_BINARY_PATH:/usr/bin/buildkite-agent"
   )
 fi
 

--- a/plugin.yml
+++ b/plugin.yml
@@ -72,6 +72,8 @@ configuration:
       type: string
     propagate-uid-gid:
       type: boolean
+    mount-buildkite-agent:
+      type: boolean
   oneOf:
     - required:
       - run
@@ -97,3 +99,4 @@ configuration:
     workdir: [ run ]
     user: [ run ]
     propagate-uid-gid: [ run ]
+    mount-buildkite-agent: [ run ]

--- a/tests/run.bats
+++ b/tests/run.bats
@@ -803,6 +803,33 @@ export BUILDKITE_JOB_ID=1111
   unstub buildkite-agent
 }
 
+@test "Run with mount-buildkite-agent enabled" {
+  export BUILDKITE_JOB_ID=1111
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RUN=myservice
+  export BUILDKITE_PIPELINE_SLUG=test
+  export BUILDKITE_BUILD_NUMBER=1
+  export BUILDKITE_COMMAND=""
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CHECK_LINKED_CONTAINERS=false
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLEANUP=false
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_MOUNT_BUILDKITE_AGENT=true
+
+  stub docker-compose \
+    "-f docker-compose.yml -p buildkite1111 build --pull myservice : echo built myservice" \
+    "-f docker-compose.yml -p buildkite1111 up -d --scale myservice=0 : echo ran myservice dependencies" \
+    "-f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 --rm -e BUILDKITE_JOB_ID -e BUILDKITE_BUILD_ID -e BUILDKITE_AGENT_ACCESS_TOKEN -v $BATS_MOCK_TMPDIR/bin/buildkite-agent:/usr/bin/buildkite-agent myservice : echo ran myservice"
+
+  stub buildkite-agent \
+    "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 1"
+
+  run $PWD/hooks/command
+
+  assert_success
+  assert_output --partial "built myservice"
+  assert_output --partial "ran myservice"
+  unstub docker-compose
+  unstub buildkite-agent
+}
+
 @test "Run with various build arguments" {
   export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RUN=myservice


### PR DESCRIPTION
Per this discussion here https://github.com/buildkite-plugins/docker-compose-buildkite-plugin/issues/158

This is implemented the same way that docker-buildkite-plugin does.  https://github.com/buildkite-plugins/docker-buildkite-plugin/blob/c3acef02fa694b8be6951de36e7c34725dadf6c6/hooks/command#L210-L230

As such, it suffers from all the same strengths and weaknesses.  It also means we can easily improve it in the same conceptual manner if docker-buildkite-plugin improves its implementation, and vice versa.