### PR TITLE
Support buildkite-agent's git-mirrors; mount BUILDKITE_GIT_MIRROR_PATH

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ The following pipeline will run `test.sh` inside a `app` service container using
 steps:
   - command: test.sh
     plugins:
-      - docker-compose#v3.5.0:
+      - docker-compose#v3.7.0:
           run: app
 ```
 
@@ -26,7 +26,7 @@ through if you need:
 steps:
   - command: test.sh
     plugins:
-      - docker-compose#v3.5.0:
+      - docker-compose#v3.7.0:
           run: app
           config: docker-compose.tests.yml
           env:
@@ -39,7 +39,7 @@ or multiple config files:
 steps:
   - command: test.sh
     plugins:
-      - docker-compose#v3.5.0:
+      - docker-compose#v3.7.0:
           run: app
           config:
             - docker-compose.yml
@@ -53,7 +53,7 @@ steps:
   - plugins:
       - docker-login#v2.0.1:
           username: xyz
-      - docker-compose#v3.5.0:
+      - docker-compose#v3.7.0:
           build: app
           image-repository: index.docker.io/myorg/myrepo
   - wait
@@ -61,7 +61,7 @@ steps:
     plugins:
       - docker-login#v2.0.1:
           username: xyz
-      - docker-compose#v3.5.0:
+      - docker-compose#v3.7.0:
           run: app
 ```
 
@@ -70,7 +70,7 @@ If you want to control how your command is passed to docker-compose, you can use
 ```yml
 steps:
   - plugins:
-      - docker-compose#v3.5.0:
+      - docker-compose#v3.7.0:
           run: app
           command: ["custom", "command", "values"]
 ```
@@ -86,7 +86,7 @@ steps:
   - command: generate-dist.sh
     artifact_paths: "dist/*"
     plugins:
-      - docker-compose#v3.5.0:
+      - docker-compose#v3.7.0:
           run: app
 ```
 
@@ -104,7 +104,7 @@ steps:
   - command: generate-dist.sh
     artifact_paths: "dist/*"
     plugins:
-      - docker-compose#v3.5.0:
+      - docker-compose#v3.7.0:
           run: app
           volumes:
             - "./dist:/app/dist"
@@ -125,7 +125,7 @@ this plugin offers a `environment` block of it's own:
 steps:
   - command: generate-dist.sh
     plugins:
-      - docker-compose#v3.5.0:
+      - docker-compose#v3.7.0:
           run: app
           env:
             - BUILDKITE_BUILD_NUMBER
@@ -145,7 +145,7 @@ Alternatively, if you want to set build arguments when pre-building an image, th
 steps:
   - command: generate-dist.sh
     plugins:
-      - docker-compose#v3.5.0:
+      - docker-compose#v3.7.0:
           build: app
           image-repository: index.docker.io/myorg/myrepo
           args:
@@ -162,7 +162,7 @@ To speed up run steps that use the same service/image (such as steps that run in
 steps:
   - label: ":docker: Build"
     plugins:
-      - docker-compose#v3.5.0:
+      - docker-compose#v3.7.0:
           build: app
           image-repository: index.docker.io/myorg/myrepo
 
@@ -172,7 +172,7 @@ steps:
     command: test.sh
     parallelism: 25
     plugins:
-      - docker-compose#v3.5.0:
+      - docker-compose#v3.7.0:
           run: app
 ```
 
@@ -188,7 +188,7 @@ steps:
     agents:
       queue: docker-builder
     plugins:
-      - docker-compose#v3.5.0:
+      - docker-compose#v3.7.0:
           build:
             - app
             - tests
@@ -200,7 +200,7 @@ steps:
     command: test.sh
     parallelism: 25
     plugins:
-      - docker-compose#v3.5.0:
+      - docker-compose#v3.7.0:
           run: tests
 ```
 
@@ -212,7 +212,7 @@ If you want to push your Docker images ready for deployment, you can use the `pu
 steps:
   - label: ":docker: Push"
     plugins:
-      - docker-compose#v3.5.0:
+      - docker-compose#v3.7.0:
           push: app
 ```
 
@@ -224,7 +224,7 @@ steps:
     plugins:
       - docker-login#v2.0.1:
           username: xyz
-      - docker-compose#v3.5.0:
+      - docker-compose#v3.7.0:
           push: app
 ```
 
@@ -236,7 +236,7 @@ steps:
     plugins:
       - docker-login#v2.0.1:
           username: xyz
-      - docker-compose#v3.5.0:
+      - docker-compose#v3.7.0:
           push:
             - first-service
             - second-service
@@ -250,7 +250,7 @@ steps:
     plugins:
       - docker-login#v2.0.1:
           username: xyz
-      - docker-compose#v3.5.0:
+      - docker-compose#v3.7.0:
           push:
           - app:index.docker.io/myorg/myrepo/myapp
           - app:index.docker.io/myorg/myrepo/myapp:latest
@@ -264,14 +264,14 @@ A newly spawned agent won't contain any of the docker caches for the first run w
 steps:
   - label: ":docker Build an image"
     plugins:
-      - docker-compose#v3.5.0:
+      - docker-compose#v3.7.0:
           build: app
           image-repository: index.docker.io/myorg/myrepo
           cache-from: app:index.docker.io/myorg/myrepo/myapp:latest
   - wait
   - label: ":docker: Push to final repository"
     plugins:
-      - docker-compose#v3.5.0:
+      - docker-compose#v3.7.0:
           push:
           - app:index.docker.io/myorg/myrepo/myapp
           - app:index.docker.io/myorg/myrepo/myapp:latest

--- a/commands/run.sh
+++ b/commands/run.sh
@@ -103,6 +103,11 @@ for vol in "${default_volumes[@]:-}" ; do
   [[ -n "$trimmed_vol" ]] && run_params+=("-v" "$(expand_relative_volume_path "$trimmed_vol")")
 done
 
+# If there's a git mirror, mount it so that git references can be followed.
+if [[ -n "${BUILDKITE_REPO_MIRROR:-}" ]]; then
+  run_params+=("-v" "$BUILDKITE_REPO_MIRROR:$BUILDKITE_REPO_MIRROR:ro")
+fi
+
 tty_default='true'
 
 # Set operating system specific defaults

--- a/tests/run.bats
+++ b/tests/run.bats
@@ -857,3 +857,30 @@ export BUILDKITE_JOB_ID=1111
   unstub docker-compose
   unstub buildkite-agent
 }
+
+@test "Run with git-mirrors" {
+  export BUILDKITE_JOB_ID=1111
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RUN=myservice
+  export BUILDKITE_PIPELINE_SLUG=test
+  export BUILDKITE_BUILD_NUMBER=1
+  export BUILDKITE_COMMAND="echo hello world"
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CHECK_LINKED_CONTAINERS=false
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLEANUP=false
+  export BUILDKITE_REPO_MIRROR=/tmp/sample-mirror
+
+  stub docker-compose \
+    "-f docker-compose.yml -p buildkite1111 build --pull myservice : echo built myservice" \
+    "-f docker-compose.yml -p buildkite1111 up -d --scale myservice=0 : echo ran myservice dependencies" \
+    "-f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 -v /tmp/sample-mirror:/tmp/sample-mirror:ro --rm myservice /bin/sh -e -c 'echo hello world' : echo ran myservice"
+
+  stub buildkite-agent \
+    "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 1"
+
+  run $PWD/hooks/command
+
+  assert_success
+  assert_output --partial "built myservice"
+  assert_output --partial "ran myservice"
+  unstub docker-compose
+  unstub buildkite-agent
+}


### PR DESCRIPTION
When `BUILDKITE_GIT_MIRROR_PATH` environment is present, that path is automatically mounted to the same location within the container. This makes repos created with `git clone --reference $BUILDKITE_GIT_MIRROR_PATH` accessible within the docker container.

Until https://github.com/buildkite/agent/pull/1311 the agent does not set `BUILDKITE_GIT_MIRROR_PATH`, ~so this pull request is a draft / RFC~.
This functionality will depend on (upcoming) buildkite-agent >= [v3.24.0](https://github.com/buildkite/agent/releases/tag/v3.24.0).

_Same as https://github.com/buildkite-plugins/docker-buildkite-plugin/pull/167 but this time for docker-compose._