### PR TITLE
Add entrypoint property to plugin.yml

### DIFF
--- a/plugin.yml
+++ b/plugin.yml
@@ -74,6 +74,8 @@ configuration:
       type: boolean
     mount-buildkite-agent:
       type: boolean
+    entrypoint:
+      type: [ string, array ]
   oneOf:
     - required:
       - run

--- a/plugin.yml
+++ b/plugin.yml
@@ -75,7 +75,7 @@ configuration:
     mount-buildkite-agent:
       type: boolean
     entrypoint:
-      type: [ string, array ]
+      type: string
   oneOf:
     - required:
       - run


### PR DESCRIPTION
Fixes https://github.com/buildkite-plugins/docker-compose-buildkite-plugin/issues/299

This works for something like:

```yaml
steps:
  - label: "test"
    plugins:
      - evandam/docker-compose#9faddab:
          run: test-app
          entrypoint: "echo"
          command: ["hello entrypoint"]
```