### PR TITLE
Support omitting compose file version

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ The following pipeline will run `test.sh` inside a `app` service container using
 steps:
   - command: test.sh
     plugins:
-      - docker-compose#v3.13.0:
+      - docker-compose#v4.0.0:
           run: app
 ```
 
@@ -28,7 +28,7 @@ through if you need:
 steps:
   - command: test.sh
     plugins:
-      - docker-compose#v3.13.0:
+      - docker-compose#v4.0.0:
           run: app
           config: docker-compose.tests.yml
           env:
@@ -41,7 +41,7 @@ or multiple config files:
 steps:
   - command: test.sh
     plugins:
-      - docker-compose#v3.13.0:
+      - docker-compose#v4.0.0:
           run: app
           config:
             - docker-compose.yml
@@ -56,7 +56,7 @@ env:
 steps:
   - command: test.sh
     plugins:
-      - docker-compose#v3.13.0:
+      - docker-compose#v4.0.0:
           run: app
 ```
 
@@ -65,7 +65,7 @@ If you want to control how your command is passed to docker-compose, you can use
 ```yml
 steps:
   - plugins:
-      - docker-compose#v3.13.0:
+      - docker-compose#v4.0.0:
           run: app
           command: ["custom", "command", "values"]
 ```
@@ -79,7 +79,7 @@ steps:
   - plugins:
       - docker-login#v2.0.1:
           username: xyz
-      - docker-compose#v3.13.0:
+      - docker-compose#v4.0.0:
           build: app
           image-repository: index.docker.io/myorg/myrepo
   - wait
@@ -87,7 +87,7 @@ steps:
     plugins:
       - docker-login#v2.0.1:
           username: xyz
-      - docker-compose#v3.13.0:
+      - docker-compose#v4.0.0:
           run: app
 ```
 
@@ -104,7 +104,7 @@ steps:
   - command: generate-dist.sh
     artifact_paths: "dist/*"
     plugins:
-      - docker-compose#v3.13.0:
+      - docker-compose#v4.0.0:
           run: app
 ```
 
@@ -122,7 +122,7 @@ steps:
   - command: generate-dist.sh
     artifact_paths: "dist/*"
     plugins:
-      - docker-compose#v3.13.0:
+      - docker-compose#v4.0.0:
           run: app
           volumes:
             - "./dist:/app/dist"
@@ -145,7 +145,7 @@ this plugin offers a `environment` block of its own:
 steps:
   - command: generate-dist.sh
     plugins:
-      - docker-compose#v3.13.0:
+      - docker-compose#v4.0.0:
           run: app
           env:
             - BUILDKITE_BUILD_NUMBER
@@ -165,7 +165,7 @@ Alternatively, if you want to set build arguments when pre-building an image, th
 steps:
   - command: generate-dist.sh
     plugins:
-      - docker-compose#v3.13.0:
+      - docker-compose#v4.0.0:
           build: app
           image-repository: index.docker.io/myorg/myrepo
           args:
@@ -182,7 +182,7 @@ If you have multiple steps that use the same service/image (such as steps that r
 steps:
   - label: ":docker: Build"
     plugins:
-      - docker-compose#v3.13.0:
+      - docker-compose#v4.0.0:
           build: app
           image-repository: index.docker.io/myorg/myrepo
 
@@ -192,7 +192,7 @@ steps:
     command: test.sh
     parallelism: 25
     plugins:
-      - docker-compose#v3.13.0:
+      - docker-compose#v4.0.0:
           run: app
 ```
 
@@ -208,7 +208,7 @@ steps:
     agents:
       queue: docker-builder
     plugins:
-      - docker-compose#v3.13.0:
+      - docker-compose#v4.0.0:
           build:
             - app
             - tests
@@ -220,7 +220,7 @@ steps:
     command: test.sh
     parallelism: 25
     plugins:
-      - docker-compose#v3.13.0:
+      - docker-compose#v4.0.0:
           run: tests
 ```
 
@@ -232,7 +232,7 @@ If you want to push your Docker images ready for deployment, you can use the `pu
 steps:
   - label: ":docker: Push"
     plugins:
-      - docker-compose#v3.13.0:
+      - docker-compose#v4.0.0:
           push: app
 ```
 
@@ -242,7 +242,7 @@ To push multiple images, you can use a list:
 steps:
   - label: ":docker: Push"
     plugins:
-      - docker-compose#v3.13.0:
+      - docker-compose#v4.0.0:
           push:
             - first-service
             - second-service
@@ -254,7 +254,7 @@ If you want to push to a specific location (that's not defined as the `image` in
 steps:
   - label: ":docker: Push"
     plugins:
-      - docker-compose#v3.13.0:
+      - docker-compose#v4.0.0:
           push:
             - app:index.docker.io/myorg/myrepo/myapp
             - app:index.docker.io/myorg/myrepo/myapp:latest
@@ -268,14 +268,14 @@ A newly spawned agent won't contain any of the docker caches for the first run w
 steps:
   - label: ":docker: Build an image"
     plugins:
-      - docker-compose#v3.13.0:
+      - docker-compose#v4.0.0:
           build: app
           image-repository: index.docker.io/myorg/myrepo
           cache-from: app:index.docker.io/myorg/myrepo/myapp:latest
   - wait
   - label: ":docker: Push to final repository"
     plugins:
-      - docker-compose#v3.13.0:
+      - docker-compose#v4.0.0:
           push:
             - app:index.docker.io/myorg/myrepo/myapp
             - app:index.docker.io/myorg/myrepo/myapp:latest
@@ -289,7 +289,7 @@ This plugin allows for the value of `cache-from` to be a string or a list. If it
 steps:
   - label: ":docker Build an image"
     plugins:
-      - docker-compose#v3.13.0:
+      - docker-compose#v4.0.0:
           build: app
           image-repository: index.docker.io/myorg/myrepo
           cache-from:
@@ -298,7 +298,7 @@ steps:
   - wait
   - label: ":docker: Push to final repository"
     plugins:
-      - docker-compose#v3.13.0:
+      - docker-compose#v4.0.0:
           push:
             - app:index.docker.io/myorg/myrepo/myapp
             - app:index.docker.io/myorg/myrepo/myapp:my-branch
@@ -312,7 +312,7 @@ Adding a grouping tag to the end of a cache-from list item allows this plugin to
 steps:
   - label: ":docker: Build Intermediate Image"
     plugins:
-      - docker-compose#v3.13.0:
+      - docker-compose#v4.0.0:
           build: myservice_intermediate  # docker-compose.yml is the same as myservice but has `target: intermediate`
           image-name: buildkite-build-${BUILDKITE_BUILD_NUMBER}
           image-repository: index.docker.io/myorg/myrepo/myservice_intermediate
@@ -322,7 +322,7 @@ steps:
   - wait
   - label: ":docker: Build Final Image"
     plugins:
-      - docker-compose#v3.13.0:
+      - docker-compose#v4.0.0:
           build: myservice
           image-name: buildkite-build-${BUILDKITE_BUILD_NUMBER}
           image-repository: index.docker.io/myorg/myrepo
@@ -366,7 +366,7 @@ A basic pipeline similar to the following:
 steps:
   - label: ":docker: Run & Push"
     plugins:
-      - docker-compose#v3.13.0:
+      - docker-compose#v4.0.0:
           run: myservice
           push: myservice
 ```
@@ -381,7 +381,7 @@ A basic pipeline similar to the following:
 steps:
   - label: ":docker: Build & Push"
     plugins:
-      - docker-compose#v3.13.0:
+      - docker-compose#v4.0.0:
           build: myservice
           push: myservice
 ```

--- a/lib/shared.bash
+++ b/lib/shared.bash
@@ -128,7 +128,7 @@ function build_image_override_file() {
 # Checks that a specific version of docker-compose supports cache_from
 function docker_compose_supports_cache_from() {
   local version="$1"
-  if [[ -z "$version" || "$version" == 1* || "$version" =~ ^(2|3)(\.[01])?$ ]] ; then
+  if [[ "$version" == 1* || "$version" =~ ^(2|3)(\.[01])?$ ]] ; then
     return 1
   fi
 }
@@ -138,14 +138,17 @@ function docker_compose_supports_cache_from() {
 function build_image_override_file_with_version() {
   local version="$1"
 
-  if [[ -z "$version" ]]; then
+  if [[ "$version" == 1* ]] ; then
     echo "The 'build' option can only be used with Compose file versions 2.0 and above."
     echo "For more information on Docker Compose configuration file versions, see:"
     echo "https://docs.docker.com/compose/compose-file/compose-versioning/#versioning"
     exit 1
   fi
 
-  printf "version: '%s'\\n" "$version"
+  if [[ -n "$version" ]]; then
+    printf "version: '%s'\\n" "$version"
+  fi
+
   printf "services:\\n"
 
   shift

--- a/tests/composefiles/docker-compose.no-version.yml
+++ b/tests/composefiles/docker-compose.no-version.yml
@@ -1,0 +1,2 @@
+helloworld:
+  build: .

--- a/tests/composefiles/docker-compose.v1.0.yml
+++ b/tests/composefiles/docker-compose.v1.0.yml
@@ -1,2 +1,3 @@
 helloworld:
   build: .
+version: '1.0'

--- a/tests/docker-compose-config.bats
+++ b/tests/docker-compose-config.bats
@@ -54,7 +54,7 @@ load '../lib/shared'
 
 @test "Whether docker-compose supports cache_from directive" {
   run docker_compose_supports_cache_from ""
-  assert_failure
+  assert_success
 
   run docker_compose_supports_cache_from "1.0"
   assert_failure

--- a/tests/docker-compose-config.bats
+++ b/tests/docker-compose-config.bats
@@ -52,6 +52,13 @@ load '../lib/shared'
   assert_output "2.1"
 }
 
+@test "Read version from docker-compose file with empty version" {
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CONFIG="tests/composefiles/docker-compose.no-version.yml"
+  run docker_compose_config_version
+  assert_success
+  assert_output ""
+}
+
 @test "Whether docker-compose supports cache_from directive" {
   run docker_compose_supports_cache_from ""
   assert_success


### PR DESCRIPTION
As of docker-compose v1.27.0, the compose file version is now optional, defaulting to the [Compose Specification](https://github.com/compose-spec/compose-spec/blob/master/spec.md), rather than v1.0. Here's the exact working from the [specification](https://github.com/compose-spec/compose-spec/blob/master/spec.md#version-top-level-element):

> **Version top-level element**
> Top-level version property is defined by the specification for backward compatibility but is only informative.

and another mention that it's now optional in [their docs](https://docs.docker.com/compose/):

> A docker-compose.yml looks like this:
```
version: "3.9"  # optional since v1.27.0
...
```

To support this change to the specification I've made the following changes to the plugin:
* Allow `version` to be omitted from the compose file. When omitted, `version` is also omitted from the generated override compose file.
* Specifically check for version 1.* when verifying support for `cache_from`

Our main use case for this change is to improve how we manage our docker-compose files for use in integration tests. We typically layer multiple docker-compose files from different repos in the same docker-compose project to integration test a combination of services. When compose file versions are specified they must all be identical which makes it difficult to upgrade compose file versions and adds an unnecessary dependency across repos. Being able to omit them (and only specify a specific version when necessary) will make this easier for us to manage.