### PR TITLE
Add use-prior-image to completely skip repetitive builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -336,6 +336,22 @@ steps:
 In the example above, the `myservice_intermediate:buildkite-build-${BUILDKITE_BUILD_NUMBER}` is one group named "intermediate", and `myservice:${BUILDKITE_BRANCH}` and `myservice:latest`
 are another (with a default name). The first successfully downloaded image in each group will be used as a cache.
 
+## Reusing previously built images
+
+If an build image has already been built previously, you can skip it if it
+already exists on the repository.
+
+```yaml
+steps:
+  - label: ":docker: Build an image"
+    plugins:
+      - docker-compose#v3.8.0:
+          build: app
+          image-repository: index.docker.io/myorg/myrepo
+          cache-from: app:index.docker.io/myorg/myrepo/myapp:123
+          use-prior-image: true
+```
+
 ## Configuration
 
 ### Main Commands
@@ -481,6 +497,11 @@ This option can also be configured on the agent machine using the environment va
 ### `cache-from` (optional, build only)
 
 A list of images to pull caches from in the format `service:index.docker.io/myorg/myrepo/myapp:tag` before building, ignoring any failures. If multiple images are listed for a service, the first one to successfully pull will be used. Requires docker-compose file version `3.2+`.
+
+### `use-prior-image` (optional, build only)
+
+When true, the build step will be skipped if the `cache-from` image exists on
+the remote repository. The run will use the existing image in later steps.
 
 ### `volumes` (optional, run only)
 

--- a/commands/build.sh
+++ b/commands/build.sh
@@ -55,6 +55,16 @@ if [[ "$(plugin_read_config NO_CACHE "false")" == "false" ]] ; then
       fi
     fi
 
+    if [[ "$(plugin_read_config USE_PRIOR_IMAGE "false")" == "true" ]] ; then
+      if docker manifest inspect "$service_image" > /dev/null; then
+        echo "Found matching image $cache_image_name, marking and skipping build"
+
+        set_prebuilt_image "$service_name" "$service_image"
+
+        exit 0;
+      fi
+    fi
+
     echo "~~~ :docker: Pulling cache image for $service_name (group ${cache_from_group_name})"
     if retry "$pull_retries" plugin_prompt_and_run docker pull "$service_image" ; then
       if [[ -z "${!cache_image_name+x}" ]]; then

--- a/plugin.yml
+++ b/plugin.yml
@@ -78,6 +78,8 @@ configuration:
       type: boolean
     mount-buildkite-agent:
       type: boolean
+    use-prior-image:
+      type: boolean
     entrypoint:
       type: string
     cli-version:
@@ -112,3 +114,4 @@ configuration:
     user: [ run ]
     propagate-uid-gid: [ run ]
     mount-buildkite-agent: [ run ]
+    use-prior-image: [ build ]

--- a/tests/build.bats
+++ b/tests/build.bats
@@ -549,6 +549,60 @@ load '../lib/shared'
   unstub docker-compose
 }
 
+@test "Build with use-prior-image and a previously-built image" {
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CONFIG="tests/composefiles/docker-compose.v3.2.yml"
+  export BUILDKITE_JOB_ID=1111
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD_0=helloworld
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CACHE_FROM_0=helloworld:my.repository/myservice_cache:latest
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_IMAGE_REPOSITORY=my.repository/llamas
+  export BUILDKITE_PIPELINE_SLUG=test
+  export BUILDKITE_BUILD_NUMBER=1
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_USE_PRIOR_IMAGE=true
+
+  stub docker \
+    "manifest inspect my.repository/myservice_cache:latest : exit 0"
+
+  stub buildkite-agent \
+    "meta-data set docker-compose-plugin-built-image-tag-helloworld-tests/composefiles/docker-compose.v3.2.yml my.repository/myservice_cache:latest : echo set image metadata for myservice"
+
+  run $PWD/hooks/command
+
+  assert_success
+  assert_output --partial "Found matching image cache_from__helloworld, marking and skipping build"
+  refute_output --partial "pulled cache image"
+  unstub docker
+  unstub buildkite-agent
+}
+
+@test "Build with use-prior-image and no previously-built image found" {
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CONFIG="tests/composefiles/docker-compose.v3.2.yml"
+  export BUILDKITE_JOB_ID=1111
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD_0=helloworld
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CACHE_FROM_0=helloworld:my.repository/myservice_cache:latest
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_IMAGE_REPOSITORY=my.repository/llamas
+  export BUILDKITE_PIPELINE_SLUG=test
+  export BUILDKITE_BUILD_NUMBER=1
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_USE_PRIOR_IMAGE=true
+
+  stub docker \
+    "manifest inspect my.repository/myservice_cache:latest : exit 1" \
+    "pull my.repository/myservice_cache:latest : exit 1"
+  stub buildkite-agent \
+    "meta-data set docker-compose-plugin-built-image-tag-helloworld-tests/composefiles/docker-compose.v3.2.yml my.repository/llamas:test-helloworld-build-1"
+  stub docker-compose \
+    "-f tests/composefiles/docker-compose.v3.2.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml build --pull helloworld" \
+    "-f tests/composefiles/docker-compose.v3.2.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml push helloworld : echo pushed helloworld"
+
+  run $PWD/hooks/command
+
+  assert_success
+  refute_output --partial "Found matching image cache_from__helloworld, marking and skipping build"
+  assert_output --partial "pushed helloworld"
+  unstub docker
+  unstub buildkite-agent
+  unstub docker-compose
+}
+
 @test "Build with a custom image-name" {
   export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD=myservice


### PR DESCRIPTION
This change adds a new plugin build option, `use-prior-image`. When set
to `true`, we'll check to see if a plugin with the expected image name
(the name specified by the cache-from parameter) exists on the
repository with `docker manifest inspect`. If it exists, we'll tag the
build metadata with the image name for the service and skip any further
pulling or building activity.

For builds where dependencies are built in a service, this can allow for
significant time shaved off of a blocking early build step.