### PR TITLE
Support multiple `version` keys in docker-compose config

### DIFF
--- a/lib/shared.bash
+++ b/lib/shared.bash
@@ -115,7 +115,7 @@ function docker_compose_config_files() {
 # Returns the version from the output of docker_compose_config
 function docker_compose_config_version() {
   IFS=$'\n' read -r -a config <<< "$(docker_compose_config_files)"
-  awk '/^\s*version:/ { print $2; }' < "${config[0]}" | sed "s/[\"']//g"
+  awk '/^\s*version:/ { print $2; exit; }' < "${config[0]}" | sed "s/[\"']//g"
 }
 
 # Build an docker-compose file that overrides the image for a set of

--- a/tests/composefiles/docker-compose.v3.2.with-version-arg.yml
+++ b/tests/composefiles/docker-compose.v3.2.with-version-arg.yml
@@ -1,0 +1,8 @@
+version: "3.2"
+
+services:
+  helloworld:
+    build:
+      context: .
+      args:
+        version: 73.976.3

--- a/tests/docker-compose-config.bats
+++ b/tests/docker-compose-config.bats
@@ -60,6 +60,13 @@ load '../lib/shared'
   assert_output "2.1"
 }
 
+@test "Read version given docker-compose file with argument named version" {
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CONFIG_0="tests/composefiles/docker-compose.v3.2.with-version-arg.yml"
+  run docker_compose_config_version
+  assert_success
+  assert_output "3.2"
+}
+
 @test "Whether docker-compose supports cache_from directive" {
   run docker_compose_supports_cache_from ""
   assert_failure

--- a/tests/docker-compose-config.bats
+++ b/tests/docker-compose-config.bats
@@ -52,6 +52,14 @@ load '../lib/shared'
   assert_output "2.1"
 }
 
+@test "Read version from first of two docker-compose files configured" {
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CONFIG_0="tests/composefiles/docker-compose.v2.1.yml"
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CONFIG_1="tests/composefiles/docker-compose.v3.2.yml"
+  run docker_compose_config_version
+  assert_success
+  assert_output "2.1"
+}
+
 @test "Whether docker-compose supports cache_from directive" {
   run docker_compose_supports_cache_from ""
   assert_failure


### PR DESCRIPTION
### Context

The plugin has trouble working with `docker-compose.yml` files where there are multiple `version` entries. See #315.

### Change

Alter the file parsing to consider only the first `version` entry it finds. Fixes #315.