### PR TITLE
Copy docker plugin's mount-ssh-agent feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -371,6 +371,12 @@ Whether to match the user ID and group ID for the container user to the user ID 
 
 Using this option ensures that any files created on shared mounts from within the container will be accessible to the host user. It is otherwise common to accidentally create root-owned files that Buildkite will be unable to remove, since containers by default run as the root user.
 
+### `mount-ssh-agent` (optional, run-only, boolean)
+
+Whether to automatically mount the ssh-agent socket from the host agent machine into the container (at `/ssh-agent`and `/root/.ssh/known_hosts` respectively), allowing git operations to work correctly.
+
+Default: `false`
+
 ### `mount-buildkite-agent` (optional, run-only, boolean)
 
 Whether to automatically mount the `buildkite-agent` binary and associated environment variables from the host agent machine into the container.

--- a/README.md
+++ b/README.md
@@ -377,6 +377,7 @@ Whether to automatically mount the ssh-agent socket from the host agent machine 
 
 Default: `false`
 
+
 ### `mount-buildkite-agent` (optional, run-only, boolean)
 
 Whether to automatically mount the `buildkite-agent` binary and associated environment variables from the host agent machine into the container.

--- a/README.md
+++ b/README.md
@@ -377,7 +377,6 @@ Whether to automatically mount the ssh-agent socket from the host agent machine 
 
 Default: `false`
 
-
 ### `mount-buildkite-agent` (optional, run-only, boolean)
 
 Whether to automatically mount the `buildkite-agent` binary and associated environment variables from the host agent machine into the container.

--- a/commands/run.sh
+++ b/commands/run.sh
@@ -8,6 +8,7 @@ run_service="$(plugin_read_config RUN)"
 container_name="$(docker_compose_project_name)_${run_service}_build_${BUILDKITE_BUILD_NUMBER}"
 override_file="docker-compose.buildkite-${BUILDKITE_BUILD_NUMBER}-override.yml"
 pull_retries="$(plugin_read_config PULL_RETRIES "0")"
+mount_ssh_agent=''
 
 expand_headers_on_error() {
   echo "^^^ +++"
@@ -159,6 +160,27 @@ fi
 if [[ -n "$(plugin_read_config ENTRYPOINT)" ]] ; then
   run_params+=(--entrypoint)
   run_params+=("$(plugin_read_config ENTRYPOINT)")
+fi
+
+# Mount ssh-agent socket and known_hosts
+if [[ "${BUILDKITE_PLUGIN_DOCKER_COMPOSE_MOUNT_SSH_AGENT:-$mount_ssh_agent}" =~ ^(true|on|1)$ ]] ; then
+  if [[ -z "${SSH_AUTH_SOCK:-}" ]] ; then
+    echo "+++ 🚨 \$SSH_AUTH_SOCK isn't set, has ssh-agent started?"
+    exit 1
+  fi
+  if [[ ! -S "${SSH_AUTH_SOCK}" ]] ; then
+    echo "+++ 🚨 There isn't any file at ${SSH_AUTH_SOCK}, has ssh-agent started?"
+    exit 1
+  fi
+  if [[ ! -S "${SSH_AUTH_SOCK}" ]] ; then
+    echo "+++ 🚨 The file at ${SSH_AUTH_SOCK} isn't a socket, has ssh-agent started?"
+    exit 1
+  fi
+  run_params+=(
+    "--env" "SSH_AUTH_SOCK=/ssh-agent"
+    "--volume" "${SSH_AUTH_SOCK}:/ssh-agent"
+    "--volume" "${HOME}/.ssh/known_hosts:/root/.ssh/known_hosts"
+  )
 fi
 
 # Optionally handle the mount-buildkite-agent option

--- a/commands/run.sh
+++ b/commands/run.sh
@@ -177,9 +177,9 @@ if [[ "${BUILDKITE_PLUGIN_DOCKER_COMPOSE_MOUNT_SSH_AGENT:-$mount_ssh_agent}" =~ 
     exit 1
   fi
   run_params+=(
-    "--env" "SSH_AUTH_SOCK=/ssh-agent"
-    "--volume" "${SSH_AUTH_SOCK}:/ssh-agent"
-    "--volume" "${HOME}/.ssh/known_hosts:/root/.ssh/known_hosts"
+    "-e" "SSH_AUTH_SOCK=/ssh-agent"
+    "-v" "${SSH_AUTH_SOCK}:/ssh-agent"
+    "-v" "${HOME}/.ssh/known_hosts:/root/.ssh/known_hosts"
   )
 fi
 

--- a/plugin.yml
+++ b/plugin.yml
@@ -72,6 +72,8 @@ configuration:
       type: string
     propagate-uid-gid:
       type: boolean
+    mount-ssh-agent:
+      type: boolean
     mount-buildkite-agent:
       type: boolean
     entrypoint:

--- a/tests/run.bats
+++ b/tests/run.bats
@@ -911,3 +911,36 @@ export BUILDKITE_JOB_ID=1111
   unstub docker-compose
   unstub buildkite-agent
 }
+
+@test "Run with mount-ssh-agent" {
+  export SSH_AUTH_SOCK=/tmp/ssh_auth_sock
+  export BUILDKITE_JOB_ID=1111
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RUN=myservice
+  export BUILDKITE_PIPELINE_SLUG=test
+  export BUILDKITE_BUILD_NUMBER=1
+  export BUILDKITE_COMMAND="echo hello world"
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CHECK_LINKED_CONTAINERS=false
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLEANUP=false
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_MOUNT_SSH_AGENT=true
+
+  stub docker-compose \
+    "-f docker-compose.yml -p buildkite1111 build --pull myservice : echo built myservice" \
+    "-f docker-compose.yml -p buildkite1111 up -d --scale myservice=0 : echo ran myservice dependencies" \
+    "-f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 --rm --env SSH_AUTH_SOCK=/ssh-agent --volume /tmp/ssh_auth_sock:/ssh-agent --volume /root/.ssh/known_hosts:/root/.ssh/known_hosts myservice /bin/sh -e -c 'echo hello world' : echo ran myservice"
+
+  stub buildkite-agent \
+    "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 1"
+
+  apk add netcat-openbsd
+  nc -lkvU $SSH_AUTH_SOCK &
+
+  run $PWD/hooks/command
+
+  kill %1
+
+  assert_success
+  assert_output --partial "built myservice"
+  assert_output --partial "ran myservice"
+  unstub docker-compose
+  unstub buildkite-agent
+}

--- a/tests/run.bats
+++ b/tests/run.bats
@@ -926,7 +926,7 @@ export BUILDKITE_JOB_ID=1111
   stub docker-compose \
     "-f docker-compose.yml -p buildkite1111 build --pull myservice : echo built myservice" \
     "-f docker-compose.yml -p buildkite1111 up -d --scale myservice=0 : echo ran myservice dependencies" \
-    "-f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 --rm --env SSH_AUTH_SOCK=/ssh-agent --volume /tmp/ssh_auth_sock:/ssh-agent --volume /root/.ssh/known_hosts:/root/.ssh/known_hosts myservice /bin/sh -e -c 'echo hello world' : echo ran myservice"
+    "-f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 --rm -e SSH_AUTH_SOCK=/ssh-agent -v /tmp/ssh_auth_sock:/ssh-agent -v /root/.ssh/known_hosts:/root/.ssh/known_hosts myservice /bin/sh -e -c 'echo hello world' : echo ran myservice"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 1"


### PR DESCRIPTION
Hi, love your work,

That `mount-ssh-agent` feature in the `docker` plugin means we can `bundle install` our Rails apps that have git/github references in their `Gemfile`s. It's very handy! However, some of our repos *also* need databases, redis, or other services to run their test suites, so they have to run with `docker-compose` to spin them up. However, `docker-compose` "run" is mysteriously lacking `mount-ssh-agent`, so I copied it over and now it works swimmingly for us.

Not sure how you feel about merging this in, but I thought I'd open the PR and offer it up anyways.

Take care!
