### PR TITLE
POC Run docker compose cp

### DIFF
--- a/commands/run.sh
+++ b/commands/run.sh
@@ -253,8 +253,13 @@ if [[ "$(plugin_read_config DEPENDENCIES "true")" == "true" ]] ; then
 fi
 
 # TODO: Customize which files are copied to the container
-echo "--- Copying . into ${run_service}:/vydia/"
-docker cp . "${run_service}:/vydia/"
+echo "--- :docker: Copying . into ${run_service}:/vydia/"
+echo "docker ps"
+docker ps
+container_id="$(run_docker_compose ps -q "${run_service}")"
+echo "docker container_id: ${container_id}"
+echo "docker cp"
+docker cp . "${container_id}:/vydia/"
 echo "Done cp"
 
 shell=()

--- a/commands/run.sh
+++ b/commands/run.sh
@@ -254,7 +254,7 @@ fi
 
 # TODO: Customize which files are copied to the container
 echo "--- Copying . into ${run_service}:/vydia/"
-run_docker_compose cp . "${run_service}:/vydia/"
+docker cp . "${run_service}:/vydia/"
 echo "Done cp"
 
 shell=()

--- a/commands/run.sh
+++ b/commands/run.sh
@@ -252,6 +252,11 @@ if [[ "$(plugin_read_config DEPENDENCIES "true")" == "true" ]] ; then
   echo
 fi
 
+# TODO: Customize which files are copied to the container
+echo "--- Copying . into ${run_service}:/vydia/"
+run_docker_compose cp . "${run_service}:/vydia/"
+echo "Done cp"
+
 shell=()
 shell_disabled=1
 result=()

--- a/commands/run.sh
+++ b/commands/run.sh
@@ -252,16 +252,6 @@ if [[ "$(plugin_read_config DEPENDENCIES "true")" == "true" ]] ; then
   echo
 fi
 
-# TODO: Customize which files are copied to the container
-echo "--- :docker: Copying . into ${run_service}:/vydia/"
-echo "docker ps"
-docker ps
-container_id="$(run_docker_compose ps -q "${run_service}")"
-echo "docker container_id: ${container_id}"
-echo "docker cp"
-docker cp . "${container_id}:/vydia/"
-echo "Done cp"
-
 shell=()
 shell_disabled=1
 result=()
@@ -341,6 +331,8 @@ elif [[ ${#command[@]} -gt 0 ]] ; then
     display_command+=("${command_arg}")
   done
 fi
+
+. "$DIR/../commands/run_on_host_when_container_ready.sh" &
 
 # Disable -e outside of the subshell; since the subshell returning a failure
 # would exit the parent shell (here) early.

--- a/commands/run_on_host_when_container_ready.sh
+++ b/commands/run_on_host_when_container_ready.sh
@@ -5,7 +5,7 @@ set -ueo pipefail
 echo "--- :docker: Waiting for the container to start before copying . into ${run_service}:/vydia/"
 
 # Wait until the container is ready
-while [ -z "$(docker-compose ps -q ${run_service})" ]; do
+while [ -z "$(run_docker_compose ps -q ${run_service})" ]; do
   printf "."
   sleep 1
 done

--- a/commands/run_on_host_when_container_ready.sh
+++ b/commands/run_on_host_when_container_ready.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+set -ueo pipefail
+
+# TODO: Customize which files are copied to the container
+echo "--- :docker: Waiting for the container to start before copying . into ${run_service}:/vydia/"
+
+# Wait until the container is ready
+while [ -z "$(docker-compose ps -q ${run_service})" ]; do
+  printf "."
+  sleep 1
+done
+
+echo "docker ps"
+docker ps
+container_id="$(run_docker_compose ps -q "${run_service}")"
+echo "docker container_id: ${container_id}"
+echo "docker cp"
+docker cp . "${container_id}:/vydia/"
+echo "Done cp"

--- a/lib/shared.bash
+++ b/lib/shared.bash
@@ -173,7 +173,7 @@ function build_image_override_file_with_version() {
 
 # Runs the docker-compose command, scoped to the project, with the given arguments
 function run_docker_compose() {
-  local command=(docker-compose)
+  local command=(docker compose)
 
   if [[ "$(plugin_read_config VERBOSE "false")" == "true" ]] ; then
     command+=(--verbose)

--- a/lib/shared.bash
+++ b/lib/shared.bash
@@ -173,7 +173,7 @@ function build_image_override_file_with_version() {
 
 # Runs the docker-compose command, scoped to the project, with the given arguments
 function run_docker_compose() {
-  local command=(docker compose)
+  local command=(docker-compose)
 
   if [[ "$(plugin_read_config VERBOSE "false")" == "true" ]] ; then
     command+=(--verbose)


### PR DESCRIPTION
Hi, this does a `docker cp` command to get project files into a docker compose container.

# Why?

Docker volumes have been a huge perf issue for us so I want to avoid volumes.

And doing a `COPY .` directive in the dockerfile adds a ton of extra size to the docker image, and seems incredibly redundant since the files are **already on disk from the git checkout build step.**

# How?

Simply `cp` the files into the container after the container boots

In my project's pipeline.yml, wait until the file exists before running the `command` script

```
command: ['/bin/sh', '-c', 'until [ -f ./scripts/ci_smartlink_cypress_test.sh ]; do sleep 1; done; ./scripts/ci_smartlink_cypress_test.sh']
```

---

This PR needs some cleanup and adding some config options to specify which files to copy, and removing some of the hardcoded values.

If maintainers think this is something that could be merged I can work on cleaning it up. Let me know