### PR TITLE
Warnings with step-level array commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ steps:
           run: app
 ```
 
+:warning: Warning: you should not use this plugin with an array of commands at the step level. Execute a script in your repository, a single command separated by `;` or the plugin's [`command` option](#command-optional-run-only-array) instead.
+
 You can also specify a custom Docker Compose config file and what environment to pass
 through if you need:
 

--- a/commands/run.sh
+++ b/commands/run.sh
@@ -339,6 +339,12 @@ if [[ ${#shell[@]} -gt 0 ]] ; then
 fi
 
 if [[ -n "${BUILDKITE_COMMAND}" ]] ; then
+  if [[ $(echo "$BUILDKITE_COMMAND" | wc -l) -gt 1 ]]; then
+    # An array of commands in the step will be a single string with multiple lines
+    # This breaks a lot of things here so we will print a warning for user to be aware
+    echo "⚠️  Warning: The command received has multiple lines."
+    echo "⚠️           The Docker Compose Plugin does not correctly support step-level array commands."
+  fi
   run_params+=("${BUILDKITE_COMMAND}")
   display_command+=("'${BUILDKITE_COMMAND}'")
 elif [[ ${#command[@]} -gt 0 ]] ; then

--- a/tests/run.bats
+++ b/tests/run.bats
@@ -54,6 +54,7 @@ load '../lib/run'
   run $PWD/hooks/command
 
   assert_success
+  refute_output --partial "The Docker Compose Plugin does not correctly support step-level array commands"
   assert_output --partial "built myservice"
   assert_output --partial "ran myservice"
   unstub docker-compose
@@ -135,6 +136,7 @@ cmd3"
   run $PWD/hooks/command
 
   assert_success
+  assert_output --partial "The Docker Compose Plugin does not correctly support step-level array commands"
   assert_output --partial "built myservice"
   assert_output --partial "ran myservice"
   unstub docker-compose
@@ -163,6 +165,7 @@ cmd3"
   run $PWD/hooks/command
 
   assert_success
+  refute_output --partial "The Docker Compose Plugin does not correctly support step-level array commands"
   assert_output --partial "built myservice"
   assert_output --partial "ran myservice"
   unstub docker-compose


### PR DESCRIPTION
Based on previous discussions (#59, #186 and #312), this plugin does not support step-level commands defined as an array. We just receive a multi-line string in the `BUILDKITE_COMMAND` variable but there is no way to identify it is because a single command with newlines (like [we test in the pipeline](https://github.com/buildkite-plugins/docker-compose-buildkite-plugin/blob/2da89a5fcbcb4b8c534d40b978b77d50acdee2c8/.buildkite/pipeline.yml#L44-L47)) or an actual array to be able to manipulate the string and do what we are supposed to do (like what the agent does: creates a script enclosing the whole command and runs that script instead).

So the only possible alternative is to add a warning to the documentation and output for people to be aware of the existing limitation :shrug: 

Closes #312 