### PR TITLE
Deactivate renovate dependency dashboard

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,7 @@
 {
   "extends": [
-    "config:base"
+    "config:base",
+    ":disableDependencyDashboard"
   ],
   "docker-compose": {
     "digest": {


### PR DESCRIPTION
Does what is described in the title. The PRs renovates opens are enough for the time being :)

Closes #308 