### PR TITLE
Made `--no-ansi` apply to all commands

### DIFF
--- a/commands/run.sh
+++ b/commands/run.sh
@@ -72,14 +72,6 @@ fi
 if [[ ${#pull_services[@]} -gt 0 ]] ; then
   echo "~~~ :docker: Pulling services ${pull_services[0]}"
   retry "$pull_retries" run_docker_compose "${pull_params[@]}"
-
-  # Sometimes docker-compose pull leaves unfinished ansi codes
-  echo
-fi
-
-# Optionally disable ansi output
-if [[ "$(plugin_read_config ANSI "true")" == "false" ]] ; then
-  run_params+=(--no-ansi)
 fi
 
 # We set a predictable container name so we can find it and inspect it later on
@@ -234,9 +226,6 @@ elif [[ ! -f "$override_file" ]]; then
   # for when an image and a build is defined in the docker-compose.ymk file, otherwise we try and
   # pull an image that doesn't exist
   run_docker_compose build "${build_params[@]}" "$run_service"
-
-  # Sometimes docker-compose pull leaves unfinished ansi codes
-  echo
 fi
 
 dependency_exitcode=0
@@ -249,9 +238,6 @@ if [[ "$(plugin_read_config DEPENDENCIES "true")" == "true" ]] ; then
   else
     run_docker_compose up -d --scale "${run_service}=0" "${run_service}" || dependency_exitcode=$?
   fi
-
-  # Sometimes docker-compose leaves unfinished ansi codes
-  echo
 fi
 
 if [[ $dependency_exitcode -ne 0 ]] ; then

--- a/lib/shared.bash
+++ b/lib/shared.bash
@@ -17,8 +17,16 @@ function plugin_prompt() {
 
 # Shows the command being run, and runs it
 function plugin_prompt_and_run() {
+  local exit_code
+
   plugin_prompt "$@"
   "$@"
+  exit_code=$?
+
+  # Sometimes docker-compose pull leaves unfinished ansi codes
+  echo
+
+  return $exit_code
 }
 
 # Shows the command about to be run, and exits if it fails
@@ -186,6 +194,10 @@ function run_docker_compose() {
 
   if [[ "$(plugin_read_config VERBOSE "false")" == "true" ]] ; then
     command+=(--verbose)
+  fi
+
+  if [[ "$(plugin_read_config ANSI "true")" == "false" ]] ; then
+    command+=(--no-ansi)
   fi
 
   for file in $(docker_compose_config_files) ; do

--- a/tests/run.bats
+++ b/tests/run.bats
@@ -482,9 +482,9 @@ export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_ANSI=false
 
   stub docker-compose \
-    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml pull myservice : echo pulled myservice" \
-    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml up -d --scale myservice=0 myservice : echo started dependencies for myservice" \
-    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml --no-ansi run --name buildkite1111_myservice_build_1 --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice without ansi output"
+    "--no-ansi -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml pull myservice : echo pulled myservice" \
+    "--no-ansi -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml up -d --scale myservice=0 myservice : echo started dependencies for myservice" \
+    "--no-ansi -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice without ansi output"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 0" \

--- a/tests/v2/run.bats
+++ b/tests/v2/run.bats
@@ -483,9 +483,9 @@ export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_ANSI=false
 
   stub docker \
-    "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml pull myservice : echo pulled myservice" \
-    "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml up -d --scale myservice=0 myservice : echo started dependencies for myservice" \
-    "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml --no-ansi run --name buildkite1111_myservice_build_1 --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice without ansi output"
+    "compose --no-ansi -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml pull myservice : echo pulled myservice" \
+    "compose --no-ansi -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml up -d --scale myservice=0 myservice : echo started dependencies for myservice" \
+    "compose --no-ansi -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice without ansi output"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 0" \


### PR DESCRIPTION
As reported in #284 when the `no-ansi` option is turned on, all docker compose commands should be executed with the option as it is not specific to one of docker compose's subcommands.

While at it, I also moved the workaround to fix the issues with ansi codes that are not closed correctly sometimes to the general command to avoid having it spread out several times across the codebase.

Closes #284 