### PR TITLE
Validate tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ The following pipeline will run `test.sh` inside a `app` service container using
 steps:
   - command: test.sh
     plugins:
-      - docker-compose#v4.0.0:
+      - docker-compose#v4.1.1:
           run: app
 ```
 
@@ -28,7 +28,7 @@ through if you need:
 steps:
   - command: test.sh
     plugins:
-      - docker-compose#v4.0.0:
+      - docker-compose#v4.1.1:
           run: app
           config: docker-compose.tests.yml
           env:
@@ -41,7 +41,7 @@ or multiple config files:
 steps:
   - command: test.sh
     plugins:
-      - docker-compose#v4.0.0:
+      - docker-compose#v4.1.1:
           run: app
           config:
             - docker-compose.yml
@@ -56,7 +56,7 @@ env:
 steps:
   - command: test.sh
     plugins:
-      - docker-compose#v4.0.0:
+      - docker-compose#v4.1.1:
           run: app
 ```
 
@@ -65,7 +65,7 @@ If you want to control how your command is passed to docker-compose, you can use
 ```yml
 steps:
   - plugins:
-      - docker-compose#v4.0.0:
+      - docker-compose#v4.1.1:
           run: app
           command: ["custom", "command", "values"]
 ```
@@ -79,7 +79,7 @@ steps:
   - plugins:
       - docker-login#v2.0.1:
           username: xyz
-      - docker-compose#v4.0.0:
+      - docker-compose#v4.1.1:
           build: app
           image-repository: index.docker.io/myorg/myrepo
   - wait
@@ -87,7 +87,7 @@ steps:
     plugins:
       - docker-login#v2.0.1:
           username: xyz
-      - docker-compose#v4.0.0:
+      - docker-compose#v4.1.1:
           run: app
 ```
 
@@ -104,7 +104,7 @@ steps:
   - command: generate-dist.sh
     artifact_paths: "dist/*"
     plugins:
-      - docker-compose#v4.0.0:
+      - docker-compose#v4.1.1:
           run: app
 ```
 
@@ -122,7 +122,7 @@ steps:
   - command: generate-dist.sh
     artifact_paths: "dist/*"
     plugins:
-      - docker-compose#v4.0.0:
+      - docker-compose#v4.1.1:
           run: app
           volumes:
             - "./dist:/app/dist"
@@ -146,7 +146,7 @@ this plugin offers a `environment` block of its own:
 steps:
   - command: generate-dist.sh
     plugins:
-      - docker-compose#v4.0.0:
+      - docker-compose#v4.1.1:
           run: app
           env:
             - BUILDKITE_BUILD_NUMBER
@@ -164,7 +164,7 @@ Alternatively, you can have the plugin add all environment variables defined for
 steps:
   - command: use-vars.sh
     plugins:
-      - docker-compose#v4.0.0:
+      - docker-compose#v4.1.1:
           run: app
           propagate-environment: true
 ```
@@ -179,7 +179,7 @@ Alternatively, if you want to set build arguments when pre-building an image, th
 steps:
   - command: generate-dist.sh
     plugins:
-      - docker-compose#v4.0.0:
+      - docker-compose#v4.1.1:
           build: app
           image-repository: index.docker.io/myorg/myrepo
           args:
@@ -196,7 +196,7 @@ If you have multiple steps that use the same service/image (such as steps that r
 steps:
   - label: ":docker: Build"
     plugins:
-      - docker-compose#v4.0.0:
+      - docker-compose#v4.1.1:
           build: app
           image-repository: index.docker.io/myorg/myrepo
 
@@ -206,7 +206,7 @@ steps:
     command: test.sh
     parallelism: 25
     plugins:
-      - docker-compose#v4.0.0:
+      - docker-compose#v4.1.1:
           run: app
 ```
 
@@ -222,7 +222,7 @@ steps:
     agents:
       queue: docker-builder
     plugins:
-      - docker-compose#v4.0.0:
+      - docker-compose#v4.1.1:
           build:
             - app
             - tests
@@ -234,7 +234,7 @@ steps:
     command: test.sh
     parallelism: 25
     plugins:
-      - docker-compose#v4.0.0:
+      - docker-compose#v4.1.1:
           run: tests
 ```
 
@@ -246,7 +246,7 @@ If you want to push your Docker images ready for deployment, you can use the `pu
 steps:
   - label: ":docker: Push"
     plugins:
-      - docker-compose#v4.0.0:
+      - docker-compose#v4.1.1:
           push: app
 ```
 
@@ -256,7 +256,7 @@ To push multiple images, you can use a list:
 steps:
   - label: ":docker: Push"
     plugins:
-      - docker-compose#v4.0.0:
+      - docker-compose#v4.1.1:
           push:
             - first-service
             - second-service
@@ -268,7 +268,7 @@ If you want to push to a specific location (that's not defined as the `image` in
 steps:
   - label: ":docker: Push"
     plugins:
-      - docker-compose#v4.0.0:
+      - docker-compose#v4.1.1:
           push:
             - app:index.docker.io/myorg/myrepo/myapp
             - app:index.docker.io/myorg/myrepo/myapp:latest
@@ -282,14 +282,14 @@ A newly spawned agent won't contain any of the docker caches for the first run w
 steps:
   - label: ":docker: Build an image"
     plugins:
-      - docker-compose#v4.0.0:
+      - docker-compose#v4.1.1:
           build: app
           image-repository: index.docker.io/myorg/myrepo
           cache-from: app:index.docker.io/myorg/myrepo/myapp:latest
   - wait
   - label: ":docker: Push to final repository"
     plugins:
-      - docker-compose#v4.0.0:
+      - docker-compose#v4.1.1:
           push:
             - app:index.docker.io/myorg/myrepo/myapp
             - app:index.docker.io/myorg/myrepo/myapp:latest
@@ -303,7 +303,7 @@ This plugin allows for the value of `cache-from` to be a string or a list. If it
 steps:
   - label: ":docker Build an image"
     plugins:
-      - docker-compose#v4.0.0:
+      - docker-compose#v4.1.1:
           build: app
           image-repository: index.docker.io/myorg/myrepo
           cache-from:
@@ -312,7 +312,7 @@ steps:
   - wait
   - label: ":docker: Push to final repository"
     plugins:
-      - docker-compose#v4.0.0:
+      - docker-compose#v4.1.1:
           push:
             - app:index.docker.io/myorg/myrepo/myapp
             - app:index.docker.io/myorg/myrepo/myapp:my-branch
@@ -326,7 +326,7 @@ Adding a grouping tag to the end of a cache-from list item allows this plugin to
 steps:
   - label: ":docker: Build Intermediate Image"
     plugins:
-      - docker-compose#v4.0.0:
+      - docker-compose#v4.1.1:
           build: myservice_intermediate  # docker-compose.yml is the same as myservice but has `target: intermediate`
           image-name: buildkite-build-${BUILDKITE_BUILD_NUMBER}
           image-repository: index.docker.io/myorg/myrepo/myservice_intermediate
@@ -336,7 +336,7 @@ steps:
   - wait
   - label: ":docker: Build Final Image"
     plugins:
-      - docker-compose#v4.0.0:
+      - docker-compose#v4.1.1:
           build: myservice
           image-name: buildkite-build-${BUILDKITE_BUILD_NUMBER}
           image-repository: index.docker.io/myorg/myrepo
@@ -380,7 +380,7 @@ A basic pipeline similar to the following:
 steps:
   - label: ":docker: Run & Push"
     plugins:
-      - docker-compose#v4.0.0:
+      - docker-compose#v4.1.1:
           run: myservice
           push: myservice
 ```
@@ -395,7 +395,7 @@ A basic pipeline similar to the following:
 steps:
   - label: ":docker: Build & Push"
     plugins:
-      - docker-compose#v4.0.0:
+      - docker-compose#v4.1.1:
           build: myservice
           push: myservice
 ```

--- a/commands/build.sh
+++ b/commands/build.sh
@@ -53,7 +53,7 @@ if [[ "$(plugin_read_config NO_CACHE "false")" == "false" ]] ; then
     service_image=$(IFS=':'; echo "${tokens[*]:1:2}")
     service_tag=${tokens[2]}
 
-    if ! [[ "$service_tag" =~ ^[A-Za-z0-9_][A-Za-z0-9_.-]{0,127}$ ]]; then
+    if ! validate_tag "$service_tag"; then
       echo "🚨 cache-from ${service_image} has an invalid tag so it will be ignored"
       continue
     fi
@@ -98,7 +98,7 @@ service_idx=0
 for service_name in $(plugin_read_list BUILD) ; do
   image_name=$(build_image_name "${service_name}" "${service_idx}")
 
-  if ! [[ "$image_name" =~ ^[A-Za-z0-9_][A-Za-z0-9_.-]{0,127}$ ]]; then
+  if ! validate_tag "$image_name"; then
     echo "🚨 ${image_name} is not a valid tag name"
     exit 1
   fi

--- a/commands/build.sh
+++ b/commands/build.sh
@@ -90,6 +90,12 @@ fi
 service_idx=0
 for service_name in $(plugin_read_list BUILD) ; do
   image_name=$(build_image_name "${service_name}" "${service_idx}")
+
+  if ! [[ "$image_name" =~ ^[A-Za-z0-9_][A-Za-z0-9_.-]{0,127}$ ]]; then
+    echo "🚨 ${image_name} is not a valid tag name"
+    exit 1
+  fi
+
   service_idx=$((service_idx+1))
 
   if [[ -n "$image_repository" ]] ; then

--- a/commands/build.sh
+++ b/commands/build.sh
@@ -51,6 +51,13 @@ if [[ "$(plugin_read_config NO_CACHE "false")" == "false" ]] ; then
     IFS=':' read -r -a tokens <<< "$line"
     service_name=${tokens[0]}
     service_image=$(IFS=':'; echo "${tokens[*]:1:2}")
+    service_tag=${tokens[2]}
+
+    if ! [[ "$service_tag" =~ ^[A-Za-z0-9_][A-Za-z0-9_.-]{0,127}$ ]]; then
+      echo "🚨 cache-from ${service_image} has an invalid tag so it will be ignored"
+      continue
+    fi
+
     cache_from_group_name=$(IFS=':'; echo "${tokens[*]:3}")
     if [[ -z "$cache_from_group_name" ]]; then
       cache_from_group_name=":default:"

--- a/commands/push.sh
+++ b/commands/push.sh
@@ -21,6 +21,14 @@ for line in $(plugin_read_list PUSH) ; do
   service_name=${tokens[0]}
   service_image=$(compose_image_for_service "$service_name")
 
+  # push in the form of service:repo:tag
+  if [[ ${#tokens[@]} -gt 2 ]]; then 
+    if ! validate_tag "${tokens[2]}"; then
+      echo "🚨 specified image to push ${line} has an invalid tag so it will be ignored"
+      continue
+    fi
+  fi
+
   # Pull down prebuilt image if one exists
   if prebuilt_image=$(get_prebuilt_image "$service_name") ; then
 

--- a/lib/shared.bash
+++ b/lib/shared.bash
@@ -258,3 +258,13 @@ function is_windows() {
 function is_macos() {
   [[ "$OSTYPE" =~ ^(darwin) ]]
 }
+
+function validate_tag {
+  local tag=$1
+
+  if [[ "$tag" =~ ^[A-Za-z0-9_][A-Za-z0-9_.-]{0,127}$ ]]; then
+    return 0
+  else
+    return 1
+  fi
+}

--- a/plugin.yml
+++ b/plugin.yml
@@ -35,7 +35,7 @@ configuration:
     image-repository:
       type: string
     image-name:
-      type: string
+      type: [ string, array ]
     pull-retries:
       type: integer
     push-retries:

--- a/tests/build.bats
+++ b/tests/build.bats
@@ -309,6 +309,27 @@ load '../lib/shared'
   unstub docker-compose
 }
 
+@test "Build with an invalid cache-from tag" {
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CONFIG="tests/composefiles/docker-compose.v3.2.yml"
+  export BUILDKITE_JOB_ID=1111
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD_0=helloworld
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CACHE_FROM_0=helloworld:my.repository/myservice_cache:-latest
+  export BUILDKITE_PIPELINE_SLUG=test
+  export BUILDKITE_BUILD_NUMBER=1
+
+  stub docker-compose \
+    "-f tests/composefiles/docker-compose.v3.2.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml build --pull helloworld : echo built helloworld"
+
+  run "$PWD"/hooks/command
+
+  assert_success
+  refute_output --partial "pulled cache image"
+  refute_output --partial "- my.repository/myservice_cache:-latest"
+  assert_output --partial "invalid tag so it will be ignored"
+  assert_output --partial "built helloworld"
+  unstub docker-compose
+}
+
 @test "Build with several cache-from images for one service" {
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CONFIG="tests/composefiles/docker-compose.v3.2.yml"
   export BUILDKITE_JOB_ID=1111

--- a/tests/build.bats
+++ b/tests/build.bats
@@ -599,6 +599,46 @@ load '../lib/shared'
   unstub buildkite-agent
 }
 
+@test "Build with an invalid image-name (start with hyphen) " {
+  export BUILDKITE_JOB_ID=1111
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD=myservice
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_IMAGE_NAME=-llamas-image
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_IMAGE_REPOSITORY=my.repository/llamas
+  export BUILDKITE_BUILD_NUMBER=1
+
+  run "$PWD"/hooks/command
+
+  assert_failure
+  assert_output --partial "-llamas-image is not a valid tag name"
+}
+
+@test "Build with an invalid image-name (start with period) " {
+  export BUILDKITE_JOB_ID=1111
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD=myservice
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_IMAGE_NAME=.llamas-image
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_IMAGE_REPOSITORY=my.repository/llamas
+  export BUILDKITE_BUILD_NUMBER=1
+
+  run "$PWD"/hooks/command
+
+  assert_failure
+  assert_output --partial ".llamas-image is not a valid tag name"
+}
+
+@test "Build with an invalid image-name (too long) " {
+  export BUILDKITE_JOB_ID=1111
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD=myservice
+  # numbers from 1 to 69 result in 129 characters
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_IMAGE_NAME="$(seq 69 | tr -d "\n")"
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_IMAGE_REPOSITORY=my.repository/llamas
+  export BUILDKITE_BUILD_NUMBER=1
+
+  run "$PWD"/hooks/command
+
+  assert_failure
+  assert_output --partial "is not a valid tag name"
+}
+
 @test "Build with a custom image-name and a config" {
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CONFIG="tests/composefiles/docker-compose.v3.2.yml"
   export BUILDKITE_JOB_ID=1111

--- a/tests/push.bats
+++ b/tests/push.bats
@@ -101,6 +101,24 @@ load '../lib/shared'
   unstub buildkite-agent
 }
 
+@test "Push a prebuilt image with an invalid tag" {
+  export BUILDKITE_JOB_ID=1111
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_PUSH=myservice:my.repository/myservice:-llamas
+  export BUILDKITE_PIPELINE_SLUG=test
+  export BUILDKITE_BUILD_NUMBER=1
+
+  stub docker-compose \
+    "-f docker-compose.yml -p buildkite1111 config : echo blah"
+
+  run $PWD/hooks/command
+
+  assert_success
+  refute_output --partial "pulled prebuilt image"
+  refute_output --partial "tagged image"
+  assert_output --partial "invalid tag"
+  unstub docker-compose
+}
+
 @test "Push a prebuilt image to multiple tags" {
   export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_PUSH_0=myservice:my.repository/myservice:llamas

--- a/tests/v2/build.bats
+++ b/tests/v2/build.bats
@@ -272,6 +272,27 @@ setup_file() {
   unstub docker
 }
 
+@test "Build with an invalid cache-from tag" {
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CONFIG="tests/composefiles/docker-compose.v3.2.yml"
+  export BUILDKITE_JOB_ID=1111
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD_0=helloworld
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CACHE_FROM_0=helloworld:my.repository/myservice_cache:-latest
+  export BUILDKITE_PIPELINE_SLUG=test
+  export BUILDKITE_BUILD_NUMBER=1
+
+  stub docker \
+    "compose -f tests/composefiles/docker-compose.v3.2.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml build --pull helloworld : echo built helloworld"
+
+  run "$PWD"/hooks/command
+
+  assert_success
+  refute_output --partial "pulled cache image"
+  refute_output --partial "- my.repository/myservice_cache:-latest"
+  assert_output --partial "invalid tag so it will be ignored"
+  assert_output --partial "built helloworld"
+  unstub docker
+}
+
 @test "Build with a cache-from image with no-cache also set" {
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CONFIG="tests/composefiles/docker-compose.v3.2.yml"
   export BUILDKITE_JOB_ID=1111

--- a/tests/v2/build.bats
+++ b/tests/v2/build.bats
@@ -452,6 +452,46 @@ setup_file() {
   unstub buildkite-agent
 }
 
+@test "Build with an invalid image-name (start with hyphen) " {
+  export BUILDKITE_JOB_ID=1111
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD=myservice
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_IMAGE_NAME=-llamas-image
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_IMAGE_REPOSITORY=my.repository/llamas
+  export BUILDKITE_BUILD_NUMBER=1
+
+  run "$PWD"/hooks/command
+
+  assert_failure
+  assert_output --partial "-llamas-image is not a valid tag name"
+}
+
+@test "Build with an invalid image-name (start with period) " {
+  export BUILDKITE_JOB_ID=1111
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD=myservice
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_IMAGE_NAME=.llamas-image
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_IMAGE_REPOSITORY=my.repository/llamas
+  export BUILDKITE_BUILD_NUMBER=1
+
+  run "$PWD"/hooks/command
+
+  assert_failure
+  assert_output --partial ".llamas-image is not a valid tag name"
+}
+
+@test "Build with an invalid image-name (too long) " {
+  export BUILDKITE_JOB_ID=1111
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD=myservice
+  # numbers from 1 to 69 result in 129 characters
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_IMAGE_NAME="$(seq 69 | tr -d "\n")"
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_IMAGE_REPOSITORY=my.repository/llamas
+  export BUILDKITE_BUILD_NUMBER=1
+
+  run "$PWD"/hooks/command
+
+  assert_failure
+  assert_output --partial "is not a valid tag name"
+}
+
 @test "Build with a custom image-name and a config" {
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CONFIG="tests/composefiles/docker-compose.v3.2.yml"
   export BUILDKITE_JOB_ID=1111

--- a/tests/v2/push.bats
+++ b/tests/v2/push.bats
@@ -96,6 +96,24 @@ setup_file() {
   unstub buildkite-agent
 }
 
+@test "Push a prebuilt image with an invalid tag" {
+  export BUILDKITE_JOB_ID=1111
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_PUSH=myservice:my.repository/myservice:-llamas
+  export BUILDKITE_PIPELINE_SLUG=test
+  export BUILDKITE_BUILD_NUMBER=1
+
+  stub docker \
+    "compose -f docker-compose.yml -p buildkite1111 config : echo blah"
+
+  run $PWD/hooks/command
+
+  assert_success
+  refute_output --partial "pulled prebuilt image"
+  refute_output --partial "tagged image"
+  assert_output --partial "invalid tag"
+  unstub docker
+}
+
 @test "Push a prebuilt image to multiple tags" {
   export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_PUSH_0=myservice:my.repository/myservice:llamas


### PR DESCRIPTION
Adds validation tags in the parameters `image-name`, `cache-from` and `push` so that the error is actually helpful trying to be as backwards-compatible as possible.

According to [docker's documentation](https://docs.docker.com/engine/reference/commandline/tag/#description):

> A tag name must be valid ASCII and may contain lowercase and uppercase letters, digits, underscores, periods and dashes. A tag name may not start with a period or a dash and may contain a maximum of 128 characters.

Closes #233
Closes #265 