### PR TITLE
BuildKit & `ssh` support

### DIFF
--- a/README.md
+++ b/README.md
@@ -612,6 +612,12 @@ To run the tests:
 docker-compose run --rm tests bats tests tests/v2
 ```
 
+### `buildkit` (optional, build only, boolean)
+
+Assuming you have a compatible docker available in the agent, activating this option would setup the environment for the `docker-compose build` call to use BuildKit. Note that if you are using `cli-version` 2, you are already using buildkit by default.
+
+You may want to also add `BUILDKIT_INLINE_CACHE=1` to your build arguments (`args` option in this plugin), but know that [there are known issues with it](https://github.com/moby/buildkit/issues/2274).
+
 ## License
 
 MIT (see [LICENSE](LICENSE))

--- a/README.md
+++ b/README.md
@@ -614,9 +614,13 @@ docker-compose run --rm tests bats tests tests/v2
 
 ### `buildkit` (optional, build only, boolean)
 
-Assuming you have a compatible docker available in the agent, activating this option would setup the environment for the `docker-compose build` call to use BuildKit. Note that if you are using `cli-version` 2, you are already using buildkit by default.
+Assuming you have a compatible docker installation and configuration in the agent, activating this option would setup the environment for the `docker-compose build` call to use BuildKit. Note that if you are using `cli-version` 2, you are already using buildkit by default.
 
 You may want to also add `BUILDKIT_INLINE_CACHE=1` to your build arguments (`args` option in this plugin), but know that [there are known issues with it](https://github.com/moby/buildkit/issues/2274).
+
+### `ssh` (optional, build only, boolean)
+
+When enabled, it will add the `--ssh` option to the build command. Note that it assumes you have a compatible docker installation and configuration in the agent (meaning you are using BuildKit and it is correctly setup).
 
 ## License
 

--- a/commands/build.sh
+++ b/commands/build.sh
@@ -44,6 +44,12 @@ if [[ -z "$image_repository" ]] ; then
   echo "This build step has no image-repository set. Without an image-repository, the Docker image won't be pushed to a repository, and won't be automatically used by any run steps."
 fi
 
+if [[ "$(plugin_read_config BUILDKIT "false")" == "true" ]]; then
+  export DOCKER_BUILDKIT=1
+  export COMPOSE_DOCKER_CLI_BUILD=1
+  export BUILDKIT_PROGRESS=plain
+fi
+
 # Read any cache-from parameters provided and pull down those images first
 # If no-cache is set skip pulling the cache-from images
 if [[ "$(plugin_read_config NO_CACHE "false")" == "false" ]] ; then

--- a/commands/build.sh
+++ b/commands/build.sh
@@ -154,7 +154,7 @@ if [[ "$(plugin_read_config BUILD_PARALLEL "false")" == "true" ]] ; then
 fi
 
 if [[ "$(plugin_read_config SSH "false")" == "true" ]] ; then
-  if [[ "${DOCKER_BUILDKIT}" != "1" ]]; then
+  if [[ "${DOCKER_BUILDKIT:-}" != "1" && "${BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLI_VERSION:-}" != "2" ]]; then
     echo "🚨 You can not use the ssh option if you are not using buildkit"
     exit 1
   fi

--- a/commands/build.sh
+++ b/commands/build.sh
@@ -143,7 +143,7 @@ while read -r line ; do
   [[ -n "$line" ]] && services+=("$line")
 done <<< "$(plugin_read_list BUILD)"
 
-build_params=(--pull)
+build_params=(build --pull)
 
 if [[ "$(plugin_read_config NO_CACHE "false")" == "true" ]] ; then
   build_params+=(--no-cache)
@@ -151,6 +151,14 @@ fi
 
 if [[ "$(plugin_read_config BUILD_PARALLEL "false")" == "true" ]] ; then
   build_params+=(--parallel)
+fi
+
+if [[ "$(plugin_read_config SSH "false")" == "true" ]] ; then
+  if [[ "${DOCKER_BUILDKIT}" != "1" ]]; then
+    echo "🚨 You can not use the ssh option if you are not using buildkit"
+    exit 1
+  fi
+  build_params+=(--ssh)
 fi
 
 target="$(plugin_read_config TARGET "")"
@@ -163,7 +171,7 @@ while read -r arg ; do
 done <<< "$(plugin_read_list ARGS)"
 
 echo "+++ :docker: Building services ${services[*]}"
-run_docker_compose -f "$override_file" build "${build_params[@]}" "${services[@]}"
+run_docker_compose -f "$override_file" "${build_params[@]}" "${services[@]}"
 
 if [[ -n "$image_repository" ]] ; then
   echo "~~~ :docker: Pushing built images to $image_repository"

--- a/plugin.yml
+++ b/plugin.yml
@@ -78,6 +78,8 @@ configuration:
       type: boolean
     skip-pull:
       type: boolean
+    ssh:
+      type: boolean
     target:
       type: string
     tty:
@@ -117,6 +119,7 @@ configuration:
     pull: [ run ]
     push-retries: [ push ]
     skip-pull: [ run ]
+    ssh: [ buildkit ]
     target: [ build ]
     tty: [ run ]
     use-aliases: [ run ]

--- a/plugin.yml
+++ b/plugin.yml
@@ -22,6 +22,8 @@ configuration:
     build-alias:
       type: [ string, array ]
       minimum: 1
+    buildkit:
+      type: boolean
     cache-from:
       type: [ string, array ]
       minimum: 1
@@ -101,6 +103,7 @@ configuration:
   additionalProperties: false
   dependencies:
     ansi: [ run ]
+    buildkit: [ build ]
     cache-from: [ build ]
     dependencies: [ run ]
     env: [ run ]

--- a/tests/v2/build.bats
+++ b/tests/v2/build.bats
@@ -587,3 +587,23 @@ setup_file() {
 
   unstub docker
 }
+
+@test "Build with ssh option" {
+  export BUILDKITE_BUILD_NUMBER=1
+  export BUILDKITE_JOB_ID=1111
+  export BUILDKITE_PIPELINE_SLUG=test
+
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD=myservice
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_SSH=true
+
+  stub docker \
+    "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml build --pull --ssh \* : echo built \${11} with ssh"
+
+  run "$PWD"/hooks/command
+
+  assert_success
+  assert_output --partial "built myservice"
+  assert_output --partial "with ssh"
+
+  unstub docker
+}


### PR DESCRIPTION
Adds two options:
* `buildkit` to automatically setup the environment variables to enable BuildKit support if it is available
* `ssh`, to enable the ability to selectively share the ssh agent environment in a build step (that only works if BuildKit is enabled)