### PR TITLE
Mount checkout path

### DIFF
--- a/README.md
+++ b/README.md
@@ -468,7 +468,7 @@ Completely avoid running any `pull` command. Images being used will need to be p
 
 ### `workdir` (optional, run only)
 
-Specify the container working directory via `docker-compose run --workdir`. This option is also used by [`mount-checkout`](#mount-checkout-optional-run-only-boolean) to determine where to mount the checkout in the container.
+Specify the container working directory via `docker-compose run --workdir`. This option is also used by [`mount-checkout`](#mount-checkout-optional-run-only-boolean) if it doesn't specify where to mount the checkout in the container.
 
 Example: `/app`
 
@@ -494,9 +494,11 @@ Whether to automatically mount the `buildkite-agent` binary and associated envir
 
 Default: `false`
 
-### `mount-checkout` (optional, run-only, boolean)
+### `mount-checkout` (optional, run-only, string or boolean)
 
-Whether to automatically mount the current working directory which contains your checked out codebase. Mounts onto `/workdir`, unless `workdir` is set, in which case that will be used.
+The absolute path where to mount the current working directory which contains your checked out codebase.
+
+If set to `true` it will mount onto `/workdir`, unless `workdir` is set, in which case that will be used.
 
 Default: `false`
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ The following pipeline will run `test.sh` inside a `app` service container using
 steps:
   - command: test.sh
     plugins:
-      - docker-compose#v4.3.0:
+      - docker-compose#v4.5.0:
           run: app
 ```
 
@@ -28,7 +28,7 @@ through if you need:
 steps:
   - command: test.sh
     plugins:
-      - docker-compose#v4.3.0:
+      - docker-compose#v4.5.0:
           run: app
           config: docker-compose.tests.yml
           env:
@@ -41,7 +41,7 @@ or multiple config files:
 steps:
   - command: test.sh
     plugins:
-      - docker-compose#v4.3.0:
+      - docker-compose#v4.5.0:
           run: app
           config:
             - docker-compose.yml
@@ -56,7 +56,7 @@ env:
 steps:
   - command: test.sh
     plugins:
-      - docker-compose#v4.3.0:
+      - docker-compose#v4.5.0:
           run: app
 ```
 
@@ -65,7 +65,7 @@ If you want to control how your command is passed to docker-compose, you can use
 ```yml
 steps:
   - plugins:
-      - docker-compose#v4.3.0:
+      - docker-compose#v4.5.0:
           run: app
           command: ["custom", "command", "values"]
 ```
@@ -79,7 +79,7 @@ steps:
   - plugins:
       - docker-login#v2.0.1:
           username: xyz
-      - docker-compose#v4.3.0:
+      - docker-compose#v4.5.0:
           build: app
           image-repository: index.docker.io/myorg/myrepo
   - wait
@@ -87,7 +87,7 @@ steps:
     plugins:
       - docker-login#v2.0.1:
           username: xyz
-      - docker-compose#v4.3.0:
+      - docker-compose#v4.5.0:
           run: app
 ```
 
@@ -104,7 +104,7 @@ steps:
   - command: generate-dist.sh
     artifact_paths: "dist/*"
     plugins:
-      - docker-compose#v4.3.0:
+      - docker-compose#v4.5.0:
           run: app
 ```
 
@@ -122,7 +122,7 @@ steps:
   - command: generate-dist.sh
     artifact_paths: "dist/*"
     plugins:
-      - docker-compose#v4.3.0:
+      - docker-compose#v4.5.0:
           run: app
           volumes:
             - "./dist:/app/dist"
@@ -146,7 +146,7 @@ this plugin offers a `environment` block of its own:
 steps:
   - command: generate-dist.sh
     plugins:
-      - docker-compose#v4.3.0:
+      - docker-compose#v4.5.0:
           run: app
           env:
             - BUILDKITE_BUILD_NUMBER
@@ -164,7 +164,7 @@ Alternatively, you can have the plugin add all environment variables defined for
 steps:
   - command: use-vars.sh
     plugins:
-      - docker-compose#v4.3.0:
+      - docker-compose#v4.5.0:
           run: app
           propagate-environment: true
 ```
@@ -179,7 +179,7 @@ Alternatively, if you want to set build arguments when pre-building an image, th
 steps:
   - command: generate-dist.sh
     plugins:
-      - docker-compose#v4.3.0:
+      - docker-compose#v4.5.0:
           build: app
           image-repository: index.docker.io/myorg/myrepo
           args:
@@ -196,7 +196,7 @@ If you have multiple steps that use the same service/image (such as steps that r
 steps:
   - label: ":docker: Build"
     plugins:
-      - docker-compose#v4.3.0:
+      - docker-compose#v4.5.0:
           build: app
           image-repository: index.docker.io/myorg/myrepo
 
@@ -206,7 +206,7 @@ steps:
     command: test.sh
     parallelism: 25
     plugins:
-      - docker-compose#v4.3.0:
+      - docker-compose#v4.5.0:
           run: app
 ```
 
@@ -222,7 +222,7 @@ steps:
     agents:
       queue: docker-builder
     plugins:
-      - docker-compose#v4.3.0:
+      - docker-compose#v4.5.0:
           build:
             - app
             - tests
@@ -234,7 +234,7 @@ steps:
     command: test.sh
     parallelism: 25
     plugins:
-      - docker-compose#v4.3.0:
+      - docker-compose#v4.5.0:
           run: tests
 ```
 
@@ -246,7 +246,7 @@ If you want to push your Docker images ready for deployment, you can use the `pu
 steps:
   - label: ":docker: Push"
     plugins:
-      - docker-compose#v4.3.0:
+      - docker-compose#v4.5.0:
           push: app
 ```
 
@@ -256,7 +256,7 @@ To push multiple images, you can use a list:
 steps:
   - label: ":docker: Push"
     plugins:
-      - docker-compose#v4.3.0:
+      - docker-compose#v4.5.0:
           push:
             - first-service
             - second-service
@@ -268,7 +268,7 @@ If you want to push to a specific location (that's not defined as the `image` in
 steps:
   - label: ":docker: Push"
     plugins:
-      - docker-compose#v4.3.0:
+      - docker-compose#v4.5.0:
           push:
             - app:index.docker.io/myorg/myrepo/myapp
             - app:index.docker.io/myorg/myrepo/myapp:latest
@@ -282,14 +282,14 @@ A newly spawned agent won't contain any of the docker caches for the first run w
 steps:
   - label: ":docker: Build an image"
     plugins:
-      - docker-compose#v4.3.0:
+      - docker-compose#v4.5.0:
           build: app
           image-repository: index.docker.io/myorg/myrepo
           cache-from: app:index.docker.io/myorg/myrepo/myapp:latest
   - wait
   - label: ":docker: Push to final repository"
     plugins:
-      - docker-compose#v4.3.0:
+      - docker-compose#v4.5.0:
           push:
             - app:index.docker.io/myorg/myrepo/myapp
             - app:index.docker.io/myorg/myrepo/myapp:latest
@@ -303,7 +303,7 @@ This plugin allows for the value of `cache-from` to be a string or a list. If it
 steps:
   - label: ":docker Build an image"
     plugins:
-      - docker-compose#v4.3.0:
+      - docker-compose#v4.5.0:
           build: app
           image-repository: index.docker.io/myorg/myrepo
           cache-from:
@@ -312,7 +312,7 @@ steps:
   - wait
   - label: ":docker: Push to final repository"
     plugins:
-      - docker-compose#v4.3.0:
+      - docker-compose#v4.5.0:
           push:
             - app:index.docker.io/myorg/myrepo/myapp
             - app:index.docker.io/myorg/myrepo/myapp:my-branch
@@ -326,7 +326,7 @@ Adding a grouping tag to the end of a cache-from list item allows this plugin to
 steps:
   - label: ":docker: Build Intermediate Image"
     plugins:
-      - docker-compose#v4.3.0:
+      - docker-compose#v4.5.0:
           build: myservice_intermediate  # docker-compose.yml is the same as myservice but has `target: intermediate`
           image-name: buildkite-build-${BUILDKITE_BUILD_NUMBER}
           image-repository: index.docker.io/myorg/myrepo/myservice_intermediate
@@ -336,7 +336,7 @@ steps:
   - wait
   - label: ":docker: Build Final Image"
     plugins:
-      - docker-compose#v4.3.0:
+      - docker-compose#v4.5.0:
           build: myservice
           image-name: buildkite-build-${BUILDKITE_BUILD_NUMBER}
           image-repository: index.docker.io/myorg/myrepo
@@ -380,7 +380,7 @@ A basic pipeline similar to the following:
 steps:
   - label: ":docker: Run & Push"
     plugins:
-      - docker-compose#v4.3.0:
+      - docker-compose#v4.5.0:
           run: myservice
           push: myservice
 ```
@@ -395,7 +395,7 @@ A basic pipeline similar to the following:
 steps:
   - label: ":docker: Build & Push"
     plugins:
-      - docker-compose#v4.3.0:
+      - docker-compose#v4.5.0:
           build: myservice
           push: myservice
 ```

--- a/commands/run.sh
+++ b/commands/run.sh
@@ -143,6 +143,10 @@ if [[ -n "$(plugin_read_config WORKDIR)" ]] || [[ "${mount_checkout}" == "true" 
   workdir="$(plugin_read_config WORKDIR "$workdir_default")"
 fi
 
+if [[ -n "${workdir}" ]] ; then
+  run_params+=("--workdir=${workdir}")
+fi
+
 if [[ "${mount_checkout}" == "true" ]]; then
   run_params+=("-v" "${pwd_default}:${workdir}")
 elif [[ "${mount_checkout}" =~ ^/.*$ ]]; then
@@ -151,11 +155,6 @@ elif [[ "${mount_checkout}" != "false" ]]; then
   echo -n "🚨 mount-checkout should be either true or an absolute path to use as a mountpoint"
   exit 1
 fi
-
-if [[ -n "${workdir}" ]] ; then
-  run_params+=("--workdir=${workdir}")
-fi
-
 
 # Can't set both user and propagate-uid-gid
 if [[ -n "$(plugin_read_config USER)" ]] && [[ -n "$(plugin_read_config PROPAGATE_UID_GID)" ]]; then

--- a/commands/run.sh
+++ b/commands/run.sh
@@ -145,7 +145,7 @@ fi
 
 if [[ "${mount_checkout}" == "true" ]]; then
   run_params+=("-v" "${pwd_default}:${workdir}")
-elif [[ "${mount_checkout}" ~= ^/.*$ ]]; then
+elif [[ "${mount_checkout}" =~ ^/.*$ ]]; then
   run_params+=("-v" "${pwd_default}:${mount_checkout}")
 elif [[ "${mount_checkout}" != "false" ]]; then
   echo -n "🚨 mount-checkout should be either true or an absolute path to use as a mountpoint"

--- a/commands/run.sh
+++ b/commands/run.sh
@@ -10,6 +10,7 @@ override_file="docker-compose.buildkite-${BUILDKITE_BUILD_NUMBER}-override.yml"
 pull_retries="$(plugin_read_config PULL_RETRIES "0")"
 mount_ssh_agent=''
 mount_checkout="$(plugin_read_config MOUNT_CHECKOUT "false")"
+workdir=''
 
 expand_headers_on_error() {
   echo "^^^ +++"
@@ -138,20 +139,23 @@ if [[ "$(plugin_read_config DEPENDENCIES "true")" == "false" ]] ; then
   run_params+=(--no-deps)
 fi
 
-workdir=''
-
 if [[ -n "$(plugin_read_config WORKDIR)" ]] || [[ "${mount_checkout}" == "true" ]]; then
   workdir="$(plugin_read_config WORKDIR "$workdir_default")"
+fi
+
+if [[ "${mount_checkout}" == "true" ]]; then
+  run_params+=("-v" "${pwd_default}:${workdir}")
+elif [[ "${mount_checkout}" ~= ^/.*$ ]]; then
+  run_params+=("-v" "${pwd_default}:${mount_checkout}")
+elif [[ "${mount_checkout}" != "false" ]]; then
+  echo -n "🚨 mount-checkout should be either true or an absolute path to use as a mountpoint"
+  exit 1
 fi
 
 if [[ -n "${workdir}" ]] ; then
   run_params+=("--workdir=${workdir}")
 fi
 
-# By default, mount $PWD onto $WORKDIR
-if [[ "${mount_checkout}" == "true" ]] ; then
-  run_params+=("-v" "${pwd_default}:${workdir}")
-fi
 
 # Can't set both user and propagate-uid-gid
 if [[ -n "$(plugin_read_config USER)" ]] && [[ -n "$(plugin_read_config PROPAGATE_UID_GID)" ]]; then

--- a/plugin.yml
+++ b/plugin.yml
@@ -60,7 +60,7 @@ configuration:
     mount-ssh-agent:
       type: boolean
     mount-checkout:
-      type: boolean
+      type: [ boolean, string ]
     no-cache:
       type: boolean
     propagate-environment:

--- a/tests/v2/run.bats
+++ b/tests/v2/run.bats
@@ -29,7 +29,7 @@ setup_file() {
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 1"
 
-  run $PWD/hooks/command
+  run "$PWD"/hooks/command
 
   assert_success
   assert_output --partial "built myservice"
@@ -55,7 +55,7 @@ setup_file() {
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 1"
 
-  run $PWD/hooks/command
+  run "$PWD"/hooks/command
 
   assert_success
   assert_output --partial "built myservice"
@@ -82,7 +82,7 @@ setup_file() {
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 1"
 
-  run $PWD/hooks/command
+  run "$PWD"/hooks/command
 
   assert_success
   assert_output --partial "built myservice"
@@ -108,7 +108,7 @@ setup_file() {
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 1"
 
-  run $PWD/hooks/command
+  run "$PWD"/hooks/command
 
   assert_success
   assert_output --partial "built myservice"
@@ -136,7 +136,7 @@ cmd3"
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 1"
 
-  run $PWD/hooks/command
+  run "$PWD"/hooks/command
 
   assert_success
   assert_output --partial "built myservice"
@@ -164,7 +164,7 @@ cmd3"
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 1"
 
-  run $PWD/hooks/command
+  run "$PWD"/hooks/command
 
   assert_success
   assert_output --partial "built myservice"
@@ -195,7 +195,7 @@ cmd3"
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 1"
 
-  run $PWD/hooks/command
+  run "$PWD"/hooks/command
 
   assert_success
   assert_output --partial "ran myservice"
@@ -221,7 +221,7 @@ cmd3"
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 1"
 
-  run $PWD/hooks/command
+  run "$PWD"/hooks/command
 
   assert_success
   assert_output --partial "built myservice"
@@ -249,7 +249,7 @@ cmd3"
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 1"
 
-  run $PWD/hooks/command
+  run "$PWD"/hooks/command
 
   assert_success
   assert_output --partial "built myservice"
@@ -336,7 +336,7 @@ cmd3"
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 0" \
     "meta-data get docker-compose-plugin-built-image-tag-myservice : echo myimage"
 
-  run $PWD/hooks/command
+  run "$PWD"/hooks/command
 
   assert_success
   assert_output --partial "ran myservice"
@@ -363,7 +363,7 @@ cmd3"
     "meta-data exists docker-compose-plugin-built-image-tag-myservice-tests/composefiles/docker-compose.v2.0.yml : exit 0" \
     "meta-data get docker-compose-plugin-built-image-tag-myservice-tests/composefiles/docker-compose.v2.0.yml : echo myimage"
 
-  run $PWD/hooks/command
+  run "$PWD"/hooks/command
 
   assert_success
   assert_output --partial "ran myservice"
@@ -391,7 +391,7 @@ export BUILDKITE_JOB_ID=1111
     "meta-data exists docker-compose-plugin-built-image-tag-myservice-tests/composefiles/docker-compose.v2.0.yml-tests/composefiles/docker-compose.v2.1.yml : exit 0" \
     "meta-data get docker-compose-plugin-built-image-tag-myservice-tests/composefiles/docker-compose.v2.0.yml-tests/composefiles/docker-compose.v2.1.yml : echo myimage"
 
-  run $PWD/hooks/command
+  run "$PWD"/hooks/command
 
   assert_success
   assert_output --partial "ran myservice"
@@ -418,7 +418,7 @@ export BUILDKITE_JOB_ID=1111
     "meta-data exists docker-compose-plugin-built-image-tag-myservice-tests/composefiles/docker-compose.v2.0.yml : exit 0" \
     "meta-data get docker-compose-plugin-built-image-tag-myservice-tests/composefiles/docker-compose.v2.0.yml : echo myimage"
 
-  run $PWD/hooks/command
+  run "$PWD"/hooks/command
 
   assert_success
   assert_output --partial "ran myservice"
@@ -442,7 +442,7 @@ export BUILDKITE_JOB_ID=1111
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 0" \
     "meta-data get docker-compose-plugin-built-image-tag-myservice : echo myimage"
 
-  run $PWD/hooks/command
+  run "$PWD"/hooks/command
 
   assert_failure
   assert_output --partial "Exited with 2"
@@ -470,7 +470,7 @@ export BUILDKITE_JOB_ID=1111
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 0" \
     "meta-data get docker-compose-plugin-built-image-tag-myservice : echo myimage"
 
-  run $PWD/hooks/command
+  run "$PWD"/hooks/command
 
   assert_success
   assert_output --partial "pulled myservice"
@@ -498,7 +498,7 @@ export BUILDKITE_JOB_ID=1111
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 0" \
     "meta-data get docker-compose-plugin-built-image-tag-myservice : echo myimage"
 
-  run $PWD/hooks/command
+  run "$PWD"/hooks/command
 
   assert_success
   assert_output --partial "ran myservice without tty"
@@ -524,7 +524,7 @@ export BUILDKITE_JOB_ID=1111
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 0" \
     "meta-data get docker-compose-plugin-built-image-tag-myservice : echo myimage"
 
-  run $PWD/hooks/command
+  run "$PWD"/hooks/command
 
   assert_success
   assert_output --partial "ran myservice without dependencies"
@@ -551,7 +551,7 @@ export BUILDKITE_JOB_ID=1111
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 0" \
     "meta-data get docker-compose-plugin-built-image-tag-myservice : echo myimage"
 
-  run $PWD/hooks/command
+  run "$PWD"/hooks/command
 
   assert_success
   assert_output --partial "ran myservice without ansi output"
@@ -578,7 +578,7 @@ export BUILDKITE_JOB_ID=1111
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 0" \
     "meta-data get docker-compose-plugin-built-image-tag-myservice : echo myimage"
 
-  run $PWD/hooks/command
+  run "$PWD"/hooks/command
 
   assert_success
   assert_output --partial "ran myservice with use aliases output"
@@ -606,7 +606,7 @@ export BUILDKITE_JOB_ID=1111
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 0" \
     "meta-data get docker-compose-plugin-built-image-tag-myservice : echo myimage"
 
-  run $PWD/hooks/command
+  run "$PWD"/hooks/command
 
   assert_success
   assert_output --partial "ran myservice with volumes"
@@ -633,7 +633,7 @@ export BUILDKITE_JOB_ID=1111
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 0" \
     "meta-data get docker-compose-plugin-built-image-tag-myservice : echo myimage"
 
-  run $PWD/hooks/command
+  run "$PWD"/hooks/command
 
   assert_success
   assert_output --partial "ran myservice with volumes"
@@ -663,7 +663,7 @@ export BUILDKITE_JOB_ID=1111
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 0" \
     "meta-data get docker-compose-plugin-built-image-tag-myservice : echo myimage"
 
-  run $PWD/hooks/command
+  run "$PWD"/hooks/command
 
   assert_success
   assert_output --partial "ran myservice with volumes"
@@ -690,7 +690,7 @@ export BUILDKITE_JOB_ID=1111
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 0" \
     "meta-data get docker-compose-plugin-built-image-tag-myservice : echo myimage"
 
-  run $PWD/hooks/command
+  run "$PWD"/hooks/command
 
   assert_success
   assert_output --partial "ran myservice with volumes"
@@ -718,7 +718,7 @@ export BUILDKITE_JOB_ID=1111
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice-llamas1.yml-llamas2.yml-llamas3.yml : exit 1"
 
-  run $PWD/hooks/command
+  run "$PWD"/hooks/command
 
   assert_success
   assert_output --partial "built myservice"
@@ -744,7 +744,7 @@ export BUILDKITE_JOB_ID=1111
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 1"
 
-  run $PWD/hooks/command
+  run "$PWD"/hooks/command
 
   assert_failure
   assert_output --partial "^^^ +++"
@@ -775,7 +775,7 @@ export BUILDKITE_JOB_ID=1111
     "meta-data exists docker-compose-plugin-built-image-tag-myservice2 : exit 0" \
     "meta-data get docker-compose-plugin-built-image-tag-myservice2 : echo myimage2"
 
-  run $PWD/hooks/command
+  run "$PWD"/hooks/command
 
   assert_success
   assert_output --partial "pulled myservice1 and myservice2"
@@ -802,7 +802,7 @@ export BUILDKITE_JOB_ID=1111
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 1"
 
-  run $PWD/hooks/command
+  run "$PWD"/hooks/command
 
   assert_success
   assert_output --partial "built myservice"
@@ -829,7 +829,7 @@ export BUILDKITE_JOB_ID=1111
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 1"
 
-  run $PWD/hooks/command
+  run "$PWD"/hooks/command
 
   assert_success
   assert_output --partial "built myservice"
@@ -852,7 +852,7 @@ export BUILDKITE_JOB_ID=1111
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 1"
 
-  run $PWD/hooks/command
+  run "$PWD"/hooks/command
 
   assert_failure
   assert_output --partial "Error"
@@ -880,7 +880,7 @@ export BUILDKITE_JOB_ID=1111
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : echo myimage" \
     "meta-data get docker-compose-plugin-built-image-tag-myservice : echo myimage"
 
-  run $PWD/hooks/command
+  run "$PWD"/hooks/command
 
   assert_success
   assert_output --partial "ran myservice without tty"
@@ -898,8 +898,6 @@ export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLEANUP=false
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_ENTRYPOINT="my custom entrypoint"
 
-  ENTRYPOINT='--entrypoint\ \"my\ custom\ entrypoint\"'
-
   stub docker \
     "compose -f docker-compose.yml -p buildkite1111 build --pull myservice : echo built myservice" \
     "compose -f docker-compose.yml -p buildkite1111 up -d --scale myservice=0 : echo ran myservice dependencies" \
@@ -908,7 +906,7 @@ export BUILDKITE_JOB_ID=1111
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 1"
 
-  run $PWD/hooks/command
+  run "$PWD"/hooks/command
 
   assert_success
   assert_output --partial "built myservice"
@@ -935,7 +933,7 @@ export BUILDKITE_JOB_ID=1111
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 1"
 
-  run $PWD/hooks/command
+  run "$PWD"/hooks/command
 
   assert_success
   assert_output --partial "built myservice"
@@ -963,7 +961,7 @@ export BUILDKITE_JOB_ID=1111
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 1"
 
-  run $PWD/hooks/command
+  run "$PWD"/hooks/command
 
   assert_success
   assert_output --partial "built myservice"
@@ -990,7 +988,7 @@ export BUILDKITE_JOB_ID=1111
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 1"
 
-  run $PWD/hooks/command
+  run "$PWD"/hooks/command
 
   assert_success
   assert_output --partial "built myservice"
@@ -1021,7 +1019,7 @@ export BUILDKITE_JOB_ID=1111
   apk add netcat-openbsd
   nc -lkvU $SSH_AUTH_SOCK &
 
-  run $PWD/hooks/command
+  run "$PWD"/hooks/command
 
   kill %1
 

--- a/tests/v2/run.bats
+++ b/tests/v2/run.bats
@@ -1029,3 +1029,206 @@ export BUILDKITE_JOB_ID=1111
   unstub docker
   unstub buildkite-agent
 }
+
+@test "Run without mount-checkout doesn't set volume" {
+  export BUILDKITE_BUILD_NUMBER=1
+  export BUILDKITE_JOB_ID=1111
+  export BUILDKITE_PIPELINE_SLUG=test
+  export BUILDKITE_COMMAND=pwd
+
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RUN=myservice
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CHECK_LINKED_CONTAINERS=false
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLEANUP=false
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_MOUNT_CHECKOUT=false
+
+  stub docker \
+    "compose -f docker-compose.yml -p buildkite1111 -f \* pull myservice : echo pulled myservice" \
+    "compose -f docker-compose.yml -p buildkite1111 -f \* up -d --scale myservice=0 myservice : echo started dependencies for myservice" \
+    "compose -f docker-compose.yml -p buildkite1111 -f \* run --name buildkite1111_myservice_build_1 --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice without mount-checkout"
+
+  stub buildkite-agent \
+    "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 0" \
+    "meta-data get docker-compose-plugin-built-image-tag-myservice : echo myimage"
+
+  run "$PWD"/hooks/command
+
+  assert_success
+  assert_output --partial "ran myservice without mount-checkout"
+
+  unstub docker
+  unstub buildkite-agent
+}
+
+@test "Run with mount-checkout set to true" {
+  export BUILDKITE_BUILD_NUMBER=1
+  export BUILDKITE_JOB_ID=1111
+  export BUILDKITE_PIPELINE_SLUG=test
+  export BUILDKITE_COMMAND=pwd
+
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RUN=myservice
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CHECK_LINKED_CONTAINERS=false
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLEANUP=false
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_MOUNT_CHECKOUT=true
+
+  stub docker \
+    "compose -f docker-compose.yml -p buildkite1111 -f \* pull myservice : echo pulled myservice" \
+    "compose -f docker-compose.yml -p buildkite1111 -f \* up -d --scale myservice=0 myservice : echo started dependencies for myservice" \
+    "compose -f docker-compose.yml -p buildkite1111 -f \* run --name buildkite1111_myservice_build_1 --workdir=/workdir -v /plugin:/workdir --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice with mount-checkout"
+
+  stub buildkite-agent \
+    "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 0" \
+    "meta-data get docker-compose-plugin-built-image-tag-myservice : echo myimage"
+
+  run "$PWD"/hooks/command
+
+  assert_success
+  assert_output --partial "ran myservice with mount-checkout"
+
+  unstub docker
+  unstub buildkite-agent
+}
+
+@test "Run with mount-checkout set to true with custom workdir" {
+  export BUILDKITE_BUILD_NUMBER=1
+  export BUILDKITE_JOB_ID=1111
+  export BUILDKITE_PIPELINE_SLUG=test
+  export BUILDKITE_COMMAND=pwd
+
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RUN=myservice
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CHECK_LINKED_CONTAINERS=false
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLEANUP=false
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_MOUNT_CHECKOUT=true
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_WORKDIR="/custom_workdir"
+
+  stub docker \
+    "compose -f docker-compose.yml -p buildkite1111 -f \* pull myservice : echo pulled myservice" \
+    "compose -f docker-compose.yml -p buildkite1111 -f \* up -d --scale myservice=0 myservice : echo started dependencies for myservice" \
+    "compose -f docker-compose.yml -p buildkite1111 -f \* run --name buildkite1111_myservice_build_1 \* -v \* --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice with mount-checkout on \${13}"
+
+  stub buildkite-agent \
+    "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 0" \
+    "meta-data get docker-compose-plugin-built-image-tag-myservice : echo myimage"
+
+  run "$PWD"/hooks/command
+
+  assert_success
+  assert_output --partial "ran myservice with mount-checkout on /plugin:/custom_workdir"
+
+  unstub docker
+  unstub buildkite-agent
+}
+
+@test "Run with mount-checkout set to specific path" {
+  export BUILDKITE_BUILD_NUMBER=1
+  export BUILDKITE_JOB_ID=1111
+  export BUILDKITE_PIPELINE_SLUG=test
+  export BUILDKITE_COMMAND=pwd
+
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RUN=myservice
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CHECK_LINKED_CONTAINERS=false
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLEANUP=false
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_MOUNT_CHECKOUT="/special"
+
+  stub docker \
+    "compose -f docker-compose.yml -p buildkite1111 -f \* pull myservice : echo pulled myservice" \
+    "compose -f docker-compose.yml -p buildkite1111 -f \* up -d --scale myservice=0 myservice : echo started dependencies for myservice" \
+    "compose -f docker-compose.yml -p buildkite1111 -f \* run --name buildkite1111_myservice_build_1 -v \* --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice with mount-checkout on \${12}"
+
+  stub buildkite-agent \
+    "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 0" \
+    "meta-data get docker-compose-plugin-built-image-tag-myservice : echo myimage"
+
+  run "$PWD"/hooks/command
+
+  assert_success
+  assert_output --partial "ran myservice with mount-checkout on /plugin:/special"
+
+  unstub docker
+  unstub buildkite-agent
+}
+
+@test "Run with mount-checkout set to specific path and workdir set" {
+  export BUILDKITE_BUILD_NUMBER=1
+  export BUILDKITE_JOB_ID=1111
+  export BUILDKITE_PIPELINE_SLUG=test
+  export BUILDKITE_COMMAND=pwd
+
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RUN=myservice
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CHECK_LINKED_CONTAINERS=false
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLEANUP=false
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_MOUNT_CHECKOUT="/special"
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_WORKDIR="/custom_workdir"
+
+  stub docker \
+    "compose -f docker-compose.yml -p buildkite1111 -f \* pull myservice : echo pulled myservice" \
+    "compose -f docker-compose.yml -p buildkite1111 -f \* up -d --scale myservice=0 myservice : echo started dependencies for myservice" \
+    "compose -f docker-compose.yml -p buildkite1111 -f \* run --name buildkite1111_myservice_build_1 \* -v \* --rm myservice /bin/sh -e -c 'pwd' : echo echo ran myservice with mount-checkout on \${13}"
+
+  stub buildkite-agent \
+    "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 0" \
+    "meta-data get docker-compose-plugin-built-image-tag-myservice : echo myimage"
+
+  run "$PWD"/hooks/command
+
+  assert_success
+  assert_output --partial "ran myservice with mount-checkout on /plugin:/special"
+  assert_output --partial "--workdir=/custom_workdir"
+
+  unstub docker
+  unstub buildkite-agent
+}
+
+@test "Run with mount-checkout set something else" {
+  export BUILDKITE_BUILD_NUMBER=1
+  export BUILDKITE_JOB_ID=1111
+  export BUILDKITE_PIPELINE_SLUG=test
+  export BUILDKITE_COMMAND=pwd
+
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RUN=myservice
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CHECK_LINKED_CONTAINERS=false
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLEANUP=false
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_MOUNT_CHECKOUT="not_absolute"
+
+  stub docker \
+    "compose -f docker-compose.yml -p buildkite1111 -f \* pull myservice : echo pulled myservice"
+
+  stub buildkite-agent \
+    "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 0" \
+    "meta-data get docker-compose-plugin-built-image-tag-myservice : echo myimage"
+
+  run "$PWD"/hooks/command
+
+  assert_failure
+  assert_output --partial "mount-checkout should be either true or an absolute path to use as a mountpoint"
+
+  unstub docker
+  unstub buildkite-agent
+}
+
+@test "Run with mount-checkout set something else and workdir set" {
+  export BUILDKITE_BUILD_NUMBER=1
+  export BUILDKITE_JOB_ID=1111
+  export BUILDKITE_PIPELINE_SLUG=test
+  export BUILDKITE_COMMAND=pwd
+
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RUN=myservice
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CHECK_LINKED_CONTAINERS=false
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLEANUP=false
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_MOUNT_CHECKOUT="not-absolute"
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_WORKDIR="/custom_workdir"
+
+  stub docker \
+    "compose -f docker-compose.yml -p buildkite1111 -f \* pull myservice : echo pulled myservice"
+
+  stub buildkite-agent \
+    "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 0" \
+    "meta-data get docker-compose-plugin-built-image-tag-myservice : echo myimage"
+
+  run "$PWD"/hooks/command
+
+  assert_failure
+  assert_output --partial "mount-checkout should be either true or an absolute path to use as a mountpoint"
+
+  unstub docker
+  unstub buildkite-agent
+}


### PR DESCRIPTION
Changes the behaviour of the recently-added `mount-checkout` option so that, in addition to a boolean that uses `workdir` to mount, you can specify an absolute path to use as a mount-point.

This was necessary based on [some feedback in the original issue](https://github.com/buildkite-plugins/docker-compose-buildkite-plugin/pull/348#issuecomment-1287528010)