### PR TITLE
`--wait` when calling `up`

### DIFF
--- a/README.md
+++ b/README.md
@@ -572,6 +572,12 @@ If set to false, doesn't start linked services.
 
 The default is `true`.
 
+### `wait` (optional, run only)
+
+Whether to wait for dependencies to be up (and healthy if possible) when starting them up. It translates to using [`--wait` in the docker-compose up] command.
+
+Defaults to `false`.
+
 ### `ansi` (optional, run only)
 
 If set to false, disables the ansi output from containers.

--- a/commands/run.sh
+++ b/commands/run.sh
@@ -262,16 +262,17 @@ elif [[ ! -f "$override_file" ]]; then
   run_docker_compose build "${build_params[@]}" "$run_service"
 fi
 
+up_params+=("up")  # this ensures that the array has elements to avoid issues with bash 4.3
+
+if [[ "$(plugin_read_config WAIT "false")" == "true" ]] ; then
+  up_params+=("--wait")
+fi
+
 dependency_exitcode=0
 if [[ "$(plugin_read_config DEPENDENCIES "true")" == "true" ]] ; then
-
   # Start up service dependencies in a different header to keep the main run with less noise
   echo "~~~ :docker: Starting dependencies"
-  if [[ ${#up_params[@]} -gt 0 ]] ; then
-    run_docker_compose "${up_params[@]}" up -d --scale "${run_service}=0" "${run_service}" || dependency_exitcode=$?
-  else
-    run_docker_compose up -d --scale "${run_service}=0" "${run_service}" || dependency_exitcode=$?
-  fi
+  run_docker_compose "${up_params[@]}" -d --scale "${run_service}=0" "${run_service}" || dependency_exitcode=$?
 fi
 
 if [[ $dependency_exitcode -ne 0 ]] ; then

--- a/plugin.yml
+++ b/plugin.yml
@@ -128,4 +128,5 @@ configuration:
     use-aliases: [ run ]
     user: [ run ]
     volumes: [ run ]
+    wait: [ run ]
     workdir: [ run ]

--- a/tests/run.bats
+++ b/tests/run.bats
@@ -1356,3 +1356,31 @@ export BUILDKITE_JOB_ID=1111
   unstub docker-compose
   unstub buildkite-agent
 }
+
+@test "Run waiting for dependencies" {
+  export BUILDKITE_BUILD_NUMBER=1
+  export BUILDKITE_COMMAND="echo hello world"
+  export BUILDKITE_JOB_ID=1111
+  export BUILDKITE_PIPELINE_SLUG=test
+
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RUN=myservice
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CHECK_LINKED_CONTAINERS=false
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_WAIT=true
+
+  stub docker-compose \
+    "-f docker-compose.yml -p buildkite1111 build --pull myservice : echo built myservice" \
+    "-f docker-compose.yml -p buildkite1111 up --wait -d --scale myservice=0 : echo ran myservice dependencies" \
+    "-f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 --rm myservice /bin/sh -e -c 'echo hello world' : echo ran myservice"
+
+  stub buildkite-agent \
+    "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 1"
+
+  run "$PWD"/hooks/command
+
+  assert_success
+  assert_output --partial "Starting dependencies"
+  assert_output --partial "ran myservice"
+
+  unstub docker-compose
+  unstub buildkite-agent
+}

--- a/tests/v2/run.bats
+++ b/tests/v2/run.bats
@@ -1232,3 +1232,31 @@ export BUILDKITE_JOB_ID=1111
   unstub docker
   unstub buildkite-agent
 }
+
+@test "Run waiting for dependencies" {
+  export BUILDKITE_BUILD_NUMBER=1
+  export BUILDKITE_COMMAND="echo hello world"
+  export BUILDKITE_JOB_ID=1111
+  export BUILDKITE_PIPELINE_SLUG=test
+
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RUN=myservice
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CHECK_LINKED_CONTAINERS=false
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_WAIT=true
+
+  stub docker \
+    "compose -f docker-compose.yml -p buildkite1111 build --pull myservice : echo built myservice" \
+    "compose -f docker-compose.yml -p buildkite1111 up --wait -d --scale myservice=0 : echo ran myservice dependencies" \
+    "compose -f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 --rm myservice /bin/sh -e -c 'echo hello world' : echo ran myservice"
+
+  stub buildkite-agent \
+    "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 1"
+
+  run "$PWD"/hooks/command
+
+  assert_success
+  assert_output --partial "built myservice"
+  assert_output --partial "ran myservice"
+
+  unstub docker
+  unstub buildkite-agent
+}


### PR DESCRIPTION
Adds a simple option to use `--wait` when starting up dependencies.

Based off #355 