### PR TITLE
Add support for exposing service ports on run

### DIFF
--- a/README.md
+++ b/README.md
@@ -606,6 +606,12 @@ The default is `true`.
 
 Sets the `--entrypoint` argument when running `docker-compose`.
 
+### `service-ports` (optional, run only)
+
+If set to true, docker compose will run with the service ports enabled and mapped to the host. Equivalent to `--service-ports` in docker-compose.
+
+The default is `false`.
+
 ### `upload-container-logs` (optional, run only)
 
 Select when to upload container logs.

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ The following pipeline will run `test.sh` inside a `app` service container using
 steps:
   - command: test.sh
     plugins:
-      - docker-compose#v4.6.0:
+      - docker-compose#v4.7.0:
           run: app
 ```
 
@@ -28,7 +28,7 @@ through if you need:
 steps:
   - command: test.sh
     plugins:
-      - docker-compose#v4.6.0:
+      - docker-compose#v4.7.0:
           run: app
           config: docker-compose.tests.yml
           env:
@@ -41,7 +41,7 @@ or multiple config files:
 steps:
   - command: test.sh
     plugins:
-      - docker-compose#v4.6.0:
+      - docker-compose#v4.7.0:
           run: app
           config:
             - docker-compose.yml
@@ -56,7 +56,7 @@ env:
 steps:
   - command: test.sh
     plugins:
-      - docker-compose#v4.6.0:
+      - docker-compose#v4.7.0:
           run: app
 ```
 
@@ -65,7 +65,7 @@ If you want to control how your command is passed to docker-compose, you can use
 ```yml
 steps:
   - plugins:
-      - docker-compose#v4.6.0:
+      - docker-compose#v4.7.0:
           run: app
           command: ["custom", "command", "values"]
 ```
@@ -79,7 +79,7 @@ steps:
   - plugins:
       - docker-login#v2.0.1:
           username: xyz
-      - docker-compose#v4.6.0:
+      - docker-compose#v4.7.0:
           build: app
           image-repository: index.docker.io/myorg/myrepo
   - wait
@@ -87,7 +87,7 @@ steps:
     plugins:
       - docker-login#v2.0.1:
           username: xyz
-      - docker-compose#v4.6.0:
+      - docker-compose#v4.7.0:
           run: app
 ```
 
@@ -104,7 +104,7 @@ steps:
   - command: generate-dist.sh
     artifact_paths: "dist/*"
     plugins:
-      - docker-compose#v4.6.0:
+      - docker-compose#v4.7.0:
           run: app
 ```
 
@@ -122,7 +122,7 @@ steps:
   - command: generate-dist.sh
     artifact_paths: "dist/*"
     plugins:
-      - docker-compose#v4.6.0:
+      - docker-compose#v4.7.0:
           run: app
           volumes:
             - "./dist:/app/dist"
@@ -146,7 +146,7 @@ this plugin offers a `environment` block of its own:
 steps:
   - command: generate-dist.sh
     plugins:
-      - docker-compose#v4.6.0:
+      - docker-compose#v4.7.0:
           run: app
           env:
             - BUILDKITE_BUILD_NUMBER
@@ -164,7 +164,7 @@ Alternatively, you can have the plugin add all environment variables defined for
 steps:
   - command: use-vars.sh
     plugins:
-      - docker-compose#v4.6.0:
+      - docker-compose#v4.7.0:
           run: app
           propagate-environment: true
 ```
@@ -179,7 +179,7 @@ Alternatively, if you want to set build arguments when pre-building an image, th
 steps:
   - command: generate-dist.sh
     plugins:
-      - docker-compose#v4.6.0:
+      - docker-compose#v4.7.0:
           build: app
           image-repository: index.docker.io/myorg/myrepo
           args:
@@ -196,7 +196,7 @@ If you have multiple steps that use the same service/image (such as steps that r
 steps:
   - label: ":docker: Build"
     plugins:
-      - docker-compose#v4.6.0:
+      - docker-compose#v4.7.0:
           build: app
           image-repository: index.docker.io/myorg/myrepo
 
@@ -206,7 +206,7 @@ steps:
     command: test.sh
     parallelism: 25
     plugins:
-      - docker-compose#v4.6.0:
+      - docker-compose#v4.7.0:
           run: app
 ```
 
@@ -222,7 +222,7 @@ steps:
     agents:
       queue: docker-builder
     plugins:
-      - docker-compose#v4.6.0:
+      - docker-compose#v4.7.0:
           build:
             - app
             - tests
@@ -234,7 +234,7 @@ steps:
     command: test.sh
     parallelism: 25
     plugins:
-      - docker-compose#v4.6.0:
+      - docker-compose#v4.7.0:
           run: tests
 ```
 
@@ -246,7 +246,7 @@ If you want to push your Docker images ready for deployment, you can use the `pu
 steps:
   - label: ":docker: Push"
     plugins:
-      - docker-compose#v4.6.0:
+      - docker-compose#v4.7.0:
           push: app
 ```
 
@@ -256,7 +256,7 @@ To push multiple images, you can use a list:
 steps:
   - label: ":docker: Push"
     plugins:
-      - docker-compose#v4.6.0:
+      - docker-compose#v4.7.0:
           push:
             - first-service
             - second-service
@@ -268,7 +268,7 @@ If you want to push to a specific location (that's not defined as the `image` in
 steps:
   - label: ":docker: Push"
     plugins:
-      - docker-compose#v4.6.0:
+      - docker-compose#v4.7.0:
           push:
             - app:index.docker.io/myorg/myrepo/myapp
             - app:index.docker.io/myorg/myrepo/myapp:latest
@@ -282,14 +282,14 @@ A newly spawned agent won't contain any of the docker caches for the first run w
 steps:
   - label: ":docker: Build an image"
     plugins:
-      - docker-compose#v4.6.0:
+      - docker-compose#v4.7.0:
           build: app
           image-repository: index.docker.io/myorg/myrepo
           cache-from: app:index.docker.io/myorg/myrepo/myapp:latest
   - wait
   - label: ":docker: Push to final repository"
     plugins:
-      - docker-compose#v4.6.0:
+      - docker-compose#v4.7.0:
           push:
             - app:index.docker.io/myorg/myrepo/myapp
             - app:index.docker.io/myorg/myrepo/myapp:latest
@@ -303,7 +303,7 @@ This plugin allows for the value of `cache-from` to be a string or a list. If it
 steps:
   - label: ":docker Build an image"
     plugins:
-      - docker-compose#v4.6.0:
+      - docker-compose#v4.7.0:
           build: app
           image-repository: index.docker.io/myorg/myrepo
           cache-from:
@@ -312,7 +312,7 @@ steps:
   - wait
   - label: ":docker: Push to final repository"
     plugins:
-      - docker-compose#v4.6.0:
+      - docker-compose#v4.7.0:
           push:
             - app:index.docker.io/myorg/myrepo/myapp
             - app:index.docker.io/myorg/myrepo/myapp:my-branch
@@ -326,7 +326,7 @@ Adding a grouping tag to the end of a cache-from list item allows this plugin to
 steps:
   - label: ":docker: Build Intermediate Image"
     plugins:
-      - docker-compose#v4.6.0:
+      - docker-compose#v4.7.0:
           build: myservice_intermediate  # docker-compose.yml is the same as myservice but has `target: intermediate`
           image-name: buildkite-build-${BUILDKITE_BUILD_NUMBER}
           image-repository: index.docker.io/myorg/myrepo/myservice_intermediate
@@ -336,7 +336,7 @@ steps:
   - wait
   - label: ":docker: Build Final Image"
     plugins:
-      - docker-compose#v4.6.0:
+      - docker-compose#v4.7.0:
           build: myservice
           image-name: buildkite-build-${BUILDKITE_BUILD_NUMBER}
           image-repository: index.docker.io/myorg/myrepo
@@ -380,7 +380,7 @@ A basic pipeline similar to the following:
 steps:
   - label: ":docker: Run & Push"
     plugins:
-      - docker-compose#v4.6.0:
+      - docker-compose#v4.7.0:
           run: myservice
           push: myservice
 ```
@@ -395,7 +395,7 @@ A basic pipeline similar to the following:
 steps:
   - label: ":docker: Build & Push"
     plugins:
-      - docker-compose#v4.6.0:
+      - docker-compose#v4.7.0:
           build: myservice
           push: myservice
 ```

--- a/commands/run.sh
+++ b/commands/run.sh
@@ -231,6 +231,11 @@ if [[ -n "${BUILDKITE_AGENT_BINARY_PATH:-}" ]] ; then
   )
 fi
 
+# Optionally expose service ports
+if [[ "$(plugin_read_config SERVICE_PORTS "false")" == "true" ]]; then
+  run_params+=(--service-ports)
+fi
+
 run_params+=("$run_service")
 
 build_params=(--pull)

--- a/plugin.yml
+++ b/plugin.yml
@@ -76,6 +76,8 @@ configuration:
       type: integer
     rm:
       type: boolean
+    service-ports:
+      type: boolean
     skip-checkout:
       type: boolean
     skip-pull:

--- a/plugin.yml
+++ b/plugin.yml
@@ -127,6 +127,7 @@ configuration:
     propagate-uid-gid: [ run ]
     pull: [ run ]
     push-retries: [ push ]
+    service-ports: [ run ]
     skip-pull: [ run ]
     secrets: [ buildkit, build ]
     ssh: [ buildkit ]

--- a/tests/run.bats
+++ b/tests/run.bats
@@ -1384,3 +1384,30 @@ export BUILDKITE_JOB_ID=1111
   unstub docker-compose
   unstub buildkite-agent
 }
+
+@test "Run with --service-ports" {
+  export BUILDKITE_JOB_ID=1111
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RUN=myservice
+  export BUILDKITE_PIPELINE_SLUG=test
+  export BUILDKITE_BUILD_NUMBER=1
+  export BUILDKITE_COMMAND=pwd
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CHECK_LINKED_CONTAINERS=false
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLEANUP=false
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_SERVICE_PORTS=true
+
+  stub docker-compose \
+    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml pull myservice : echo pulled myservice" \
+    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml up -d --scale myservice=0 myservice : echo started dependencies for myservice" \
+    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 --rm --service-ports myservice /bin/sh -e -c $'pwd' : echo ran myservice without tty"
+
+  stub buildkite-agent \
+    "meta-data exists docker-compose-plugin-built-image-tag-myservice : echo myimage" \
+    "meta-data get docker-compose-plugin-built-image-tag-myservice : echo myimage"
+
+  run "$PWD"/hooks/command
+
+  assert_success
+  assert_output --partial "ran myservice without tty"
+  unstub docker-compose
+  unstub buildkite-agent
+}

--- a/tests/v2/run.bats
+++ b/tests/v2/run.bats
@@ -1260,3 +1260,30 @@ export BUILDKITE_JOB_ID=1111
   unstub docker
   unstub buildkite-agent
 }
+
+@test "Run with --service-ports" {
+  export BUILDKITE_JOB_ID=1111
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RUN=myservice
+  export BUILDKITE_PIPELINE_SLUG=test
+  export BUILDKITE_BUILD_NUMBER=1
+  export BUILDKITE_COMMAND=pwd
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CHECK_LINKED_CONTAINERS=false
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLEANUP=false
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_SERVICE_PORTS=true
+
+  stub docker \
+    "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml pull myservice : echo pulled myservice" \
+    "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml up -d --scale myservice=0 myservice : echo started dependencies for myservice" \
+    "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 --rm --service-ports myservice /bin/sh -e -c $'pwd' : echo ran myservice without tty"
+
+  stub buildkite-agent \
+    "meta-data exists docker-compose-plugin-built-image-tag-myservice : echo myimage" \
+    "meta-data get docker-compose-plugin-built-image-tag-myservice : echo myimage"
+
+  run "$PWD"/hooks/command
+
+  assert_success
+  assert_output --partial "ran myservice without tty"
+  unstub docker
+  unstub buildkite-agent
+}


### PR DESCRIPTION
This stems from a need for a step run in a container to have a port exposed that can be connected to from an external testing service whilst it is running.

By default `docker compose run` does not create the service ports so this adds a configuration to optionally to add the `--service-ports` [option](https://docs.docker.com/engine/reference/commandline/compose_run/#options) which enables the service ports and maps them to the host.

The default run configuration is not affected.