### PR TITLE
Avoid pre-running dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -568,9 +568,13 @@ The default is `true` on unix, `false` on windows
 
 ### `dependencies` (optional, run only)
 
-If set to false, doesn't start linked services.
+If set to false, runs with `--no-deps` and doesn't start linked services.
 
 The default is `true`.
+
+### `pre-run-dependencies` (optional, run only)
+
+If `dependencies` are activated (which is the default), you can skip starting them up before the main container by setting this option to `false`. This is useful if you want compose to take care of that on its own at the expense of messier output in the run step.
 
 ### `wait` (optional, run only)
 

--- a/commands/run.sh
+++ b/commands/run.sh
@@ -119,6 +119,7 @@ fi
 tty_default='true'
 workdir_default="/workdir"
 pwd_default="$PWD"
+run_dependencies="true"
 
 # Set operating system specific defaults
 if is_windows ; then
@@ -137,6 +138,9 @@ fi
 # Optionally disable dependencies
 if [[ "$(plugin_read_config DEPENDENCIES "true")" == "false" ]] ; then
   run_params+=(--no-deps)
+  run_dependencies="false"
+elif [[ "$(plugin_read_config PRE_RUN_DEPENDENCIES "true")" == "false" ]]; then
+  run_dependencies="false"
 fi
 
 if [[ -n "$(plugin_read_config WORKDIR)" ]] || [[ "${mount_checkout}" == "true" ]]; then
@@ -274,7 +278,7 @@ if [[ "$(plugin_read_config WAIT "false")" == "true" ]] ; then
 fi
 
 dependency_exitcode=0
-if [[ "$(plugin_read_config DEPENDENCIES "true")" == "true" ]] ; then
+if [[ "${run_dependencies}" == "true" ]] ; then
   # Start up service dependencies in a different header to keep the main run with less noise
   echo "~~~ :docker: Starting dependencies"
   run_docker_compose "${up_params[@]}" -d --scale "${run_service}=0" "${run_service}" || dependency_exitcode=$?

--- a/plugin.yml
+++ b/plugin.yml
@@ -63,6 +63,8 @@ configuration:
       type: [ boolean, string ]
     no-cache:
       type: boolean
+    pre-run-dependencies:
+      type: boolean
     propagate-environment:
       type: boolean
     propagate-uid-gid:
@@ -124,6 +126,7 @@ configuration:
     leave-volumes: [ run ]
     mount-buildkite-agent: [ run ]
     mount-checkout: [ run ]
+    pre-run-dependencies: [ run ]
     propagate-uid-gid: [ run ]
     pull: [ run ]
     push-retries: [ push ]

--- a/tests/run.bats
+++ b/tests/run.bats
@@ -531,6 +531,32 @@ export BUILDKITE_JOB_ID=1111
   unstub buildkite-agent
 }
 
+@test "Run with dependencies but in a single step" {
+  export BUILDKITE_BUILD_NUMBER=1
+  export BUILDKITE_COMMAND=pwd
+  export BUILDKITE_JOB_ID=1111
+  export BUILDKITE_PIPELINE_SLUG=test
+
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RUN=myservice
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLEANUP=false
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_PRE_RUN_DEPENDENCIES=false
+
+  stub docker-compose \
+    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml pull myservice : echo pulled myservice" \
+    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice with dependencies"
+
+  stub buildkite-agent \
+    "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 0" \
+    "meta-data get docker-compose-plugin-built-image-tag-myservice : echo myimage"
+
+  run "$PWD"/hooks/command
+
+  assert_success
+  assert_output --partial "ran myservice with dependencies"
+  unstub docker-compose
+  unstub buildkite-agent
+}
+
 @test "Run without ansi output" {
   export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RUN=myservice

--- a/tests/v2/run.bats
+++ b/tests/v2/run.bats
@@ -532,6 +532,33 @@ export BUILDKITE_JOB_ID=1111
   unstub buildkite-agent
 }
 
+@test "Run with dependencies but in a single step" {
+  export BUILDKITE_BUILD_NUMBER=1
+  export BUILDKITE_COMMAND=pwd
+  export BUILDKITE_JOB_ID=1111
+  export BUILDKITE_PIPELINE_SLUG=test
+
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RUN=myservice
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLEANUP=false
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_PRE_RUN_DEPENDENCIES=false
+
+  stub docker \
+    "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml pull myservice : echo pulled myservice" \
+    "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice with dependencies"
+
+  stub buildkite-agent \
+    "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 0" \
+    "meta-data get docker-compose-plugin-built-image-tag-myservice : echo myimage"
+
+  run "$PWD"/hooks/command
+
+  assert_success
+  assert_output --partial "ran myservice with dependencies"
+
+  unstub docker
+  unstub buildkite-agent
+}
+
 @test "Run without ansi output" {
   export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RUN=myservice


### PR DESCRIPTION
Up to now you either started dependencies before the main `run` container or did not use dependencies whatsoever (skipping that and passing `--no-deps` to the service being run).

This allows for dependencies to be used, but not started before the main service being run. While there are some utilities for this it has the main drawback of mixing up outputs and making them more complicated to follow.

Closes #365 