### PR TITLE
cli-version: Fix int/string mismatch.

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ The following pipeline will run `test.sh` inside a `app` service container using
 steps:
   - command: test.sh
     plugins:
-      - docker-compose#v4.10.0:
+      - docker-compose#v4.10.1:
           run: app
 ```
 
@@ -28,7 +28,7 @@ through if you need:
 steps:
   - command: test.sh
     plugins:
-      - docker-compose#v4.10.0:
+      - docker-compose#v4.10.1:
           run: app
           config: docker-compose.tests.yml
           env:
@@ -41,7 +41,7 @@ or multiple config files:
 steps:
   - command: test.sh
     plugins:
-      - docker-compose#v4.10.0:
+      - docker-compose#v4.10.1:
           run: app
           config:
             - docker-compose.yml
@@ -56,7 +56,7 @@ env:
 steps:
   - command: test.sh
     plugins:
-      - docker-compose#v4.10.0:
+      - docker-compose#v4.10.1:
           run: app
 ```
 
@@ -65,7 +65,7 @@ If you want to control how your command is passed to docker-compose, you can use
 ```yml
 steps:
   - plugins:
-      - docker-compose#v4.10.0:
+      - docker-compose#v4.10.1:
           run: app
           command: ["custom", "command", "values"]
 ```
@@ -79,7 +79,7 @@ steps:
   - plugins:
       - docker-login#v2.0.1:
           username: xyz
-      - docker-compose#v4.10.0:
+      - docker-compose#v4.10.1:
           build: app
           image-repository: index.docker.io/myorg/myrepo
   - wait
@@ -87,7 +87,7 @@ steps:
     plugins:
       - docker-login#v2.0.1:
           username: xyz
-      - docker-compose#v4.10.0:
+      - docker-compose#v4.10.1:
           run: app
 ```
 
@@ -104,7 +104,7 @@ steps:
   - command: generate-dist.sh
     artifact_paths: "dist/*"
     plugins:
-      - docker-compose#v4.10.0:
+      - docker-compose#v4.10.1:
           run: app
 ```
 
@@ -122,7 +122,7 @@ steps:
   - command: generate-dist.sh
     artifact_paths: "dist/*"
     plugins:
-      - docker-compose#v4.10.0:
+      - docker-compose#v4.10.1:
           run: app
           volumes:
             - "./dist:/app/dist"
@@ -146,7 +146,7 @@ this plugin offers a `environment` block of its own:
 steps:
   - command: generate-dist.sh
     plugins:
-      - docker-compose#v4.10.0:
+      - docker-compose#v4.10.1:
           run: app
           env:
             - BUILDKITE_BUILD_NUMBER
@@ -164,7 +164,7 @@ Alternatively, you can have the plugin add all environment variables defined for
 steps:
   - command: use-vars.sh
     plugins:
-      - docker-compose#v4.10.0:
+      - docker-compose#v4.10.1:
           run: app
           propagate-environment: true
 ```
@@ -179,7 +179,7 @@ Alternatively, if you want to set build arguments when pre-building an image, th
 steps:
   - command: generate-dist.sh
     plugins:
-      - docker-compose#v4.10.0:
+      - docker-compose#v4.10.1:
           build: app
           image-repository: index.docker.io/myorg/myrepo
           args:
@@ -196,7 +196,7 @@ If you have multiple steps that use the same service/image (such as steps that r
 steps:
   - label: ":docker: Build"
     plugins:
-      - docker-compose#v4.10.0:
+      - docker-compose#v4.10.1:
           build: app
           image-repository: index.docker.io/myorg/myrepo
 
@@ -206,7 +206,7 @@ steps:
     command: test.sh
     parallelism: 25
     plugins:
-      - docker-compose#v4.10.0:
+      - docker-compose#v4.10.1:
           run: app
 ```
 
@@ -222,7 +222,7 @@ steps:
     agents:
       queue: docker-builder
     plugins:
-      - docker-compose#v4.10.0:
+      - docker-compose#v4.10.1:
           build:
             - app
             - tests
@@ -234,7 +234,7 @@ steps:
     command: test.sh
     parallelism: 25
     plugins:
-      - docker-compose#v4.10.0:
+      - docker-compose#v4.10.1:
           run: tests
 ```
 
@@ -246,7 +246,7 @@ If you want to push your Docker images ready for deployment, you can use the `pu
 steps:
   - label: ":docker: Push"
     plugins:
-      - docker-compose#v4.10.0:
+      - docker-compose#v4.10.1:
           push: app
 ```
 
@@ -256,7 +256,7 @@ To push multiple images, you can use a list:
 steps:
   - label: ":docker: Push"
     plugins:
-      - docker-compose#v4.10.0:
+      - docker-compose#v4.10.1:
           push:
             - first-service
             - second-service
@@ -268,7 +268,7 @@ If you want to push to a specific location (that's not defined as the `image` in
 steps:
   - label: ":docker: Push"
     plugins:
-      - docker-compose#v4.10.0:
+      - docker-compose#v4.10.1:
           push:
             - app:index.docker.io/myorg/myrepo/myapp
             - app:index.docker.io/myorg/myrepo/myapp:latest
@@ -282,14 +282,14 @@ A newly spawned agent won't contain any of the docker caches for the first run w
 steps:
   - label: ":docker: Build an image"
     plugins:
-      - docker-compose#v4.10.0:
+      - docker-compose#v4.10.1:
           build: app
           image-repository: index.docker.io/myorg/myrepo
           cache-from: app:index.docker.io/myorg/myrepo/myapp:latest
   - wait
   - label: ":docker: Push to final repository"
     plugins:
-      - docker-compose#v4.10.0:
+      - docker-compose#v4.10.1:
           push:
             - app:index.docker.io/myorg/myrepo/myapp
             - app:index.docker.io/myorg/myrepo/myapp:latest
@@ -307,7 +307,7 @@ This plugin allows for the value of `cache-from` to be a string or a list. If it
 steps:
   - label: ":docker Build an image"
     plugins:
-      - docker-compose#v4.10.0:
+      - docker-compose#v4.10.1:
           build: app
           image-repository: index.docker.io/myorg/myrepo
           separator-cache-from: "#"
@@ -317,7 +317,7 @@ steps:
   - wait
   - label: ":docker: Push to final repository"
     plugins:
-      - docker-compose#v4.10.0:
+      - docker-compose#v4.10.1:
           push:
             - app:myregistry:port/myrepo/myapp:my-branch
             - app:myregistry:port/myrepo/myapp:latest
@@ -330,7 +330,7 @@ Adding a grouping tag to the end of a cache-from list item allows this plugin to
 steps:
   - label: ":docker: Build Intermediate Image"
     plugins:
-      - docker-compose#v4.10.0:
+      - docker-compose#v4.10.1:
           build: myservice_intermediate  # docker-compose.yml is the same as myservice but has `target: intermediate`
           image-name: buildkite-build-${BUILDKITE_BUILD_NUMBER}
           image-repository: index.docker.io/myorg/myrepo/myservice_intermediate
@@ -340,7 +340,7 @@ steps:
   - wait
   - label: ":docker: Build Final Image"
     plugins:
-      - docker-compose#v4.10.0:
+      - docker-compose#v4.10.1:
           build: myservice
           image-name: buildkite-build-${BUILDKITE_BUILD_NUMBER}
           image-repository: index.docker.io/myorg/myrepo
@@ -384,7 +384,7 @@ A basic pipeline similar to the following:
 steps:
   - label: ":docker: Run & Push"
     plugins:
-      - docker-compose#v4.10.0:
+      - docker-compose#v4.10.1:
           run: myservice
           push: myservice
 ```
@@ -399,7 +399,7 @@ A basic pipeline similar to the following:
 steps:
   - label: ":docker: Build & Push"
     plugins:
-      - docker-compose#v4.10.0:
+      - docker-compose#v4.10.1:
           build: myservice
           push: myservice
 ```

--- a/README.md
+++ b/README.md
@@ -464,7 +464,7 @@ Example: `[ "powershell", "-Command" ]`
 
 Whether to skip the repository checkout phase. This is useful for steps that use a pre-built image and will fail if there is no pre-built image.
 
-**Important**: as the code repository will not be available in the step, you need to ensure that the docker compose file(s) are present in some way (like using artifacts) 
+**Important**: as the code repository will not be available in the step, you need to ensure that the docker compose file(s) are present in some way (like using artifacts)
 
 ### `skip-pull` (optional, run only)
 

--- a/README.md
+++ b/README.md
@@ -650,9 +650,9 @@ Select when to upload container logs.
 
 The default is `on-error`.
 
-### `cli-version` (optional)
+### `cli-version` (optional, string or integer)
 
-If set to `2`, plugin will use `docker compose` to execute commands; otherwise it will default to version `1` using `docker-compose` instead.
+If set to `2`, plugin will use `docker compose` to execute commands; otherwise it will default to version `1`, using `docker-compose` instead.
 
 ### `buildkit` (optional, build only, boolean)
 

--- a/plugin.yml
+++ b/plugin.yml
@@ -30,10 +30,11 @@ configuration:
     compatibility:
       type: boolean
     cli-version:
-      type: string
-      enum:
-        - 1
-        - 2
+      oneOf:
+        - type: string
+          enum: [ "1", "2" ]
+        - type: integer
+          enum: [ 1, 2 ]
     command:
       type: array
     config:


### PR DESCRIPTION
Over in https://github.com/buildkite-plugins/docker-compose-buildkite-plugin/pull/334, support was added for using Docker CLI v2.

However, i found it impossible to actually select!  Here's the pipeline yaml i tried:

```yaml
steps:
  - name: Build ecs-upload-task Docker
    plugins:
    - docker-compose#v4.9.0:
        cli-version: 2
        config: ecs-upload-task/docker-compose.yaml
        push: ecs-upload-task
```

The problem is though, the `plugin.yml` file specifies an "impossible schema".  Note how the field is defined as requiring a string, but the only two enum options are YAML integers!  My small change made it possible to actually use the plugin as intended and unblocked me.

https://github.com/buildkite-plugins/docker-compose-buildkite-plugin/blob/fe3522acb645f4471014f4218fa7d884024f0b29/plugin.yml#L32-L36

Here's what i saw when i originally set `cli-version: 2` or `cli-version: "2"`.

![image](https://user-images.githubusercontent.com/423357/220009176-750145a0-a59b-4230-8d7e-33e14e91a97f.png)
![image](https://user-images.githubusercontent.com/423357/220009200-e9fbf0fc-aa61-41d2-8793-438a58b00351.png)


