### PR TITLE
Add labels to run container

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,8 @@ These labels can make it easier to query containers on hosts using `docker ps` f
 docker ps --filter "label=com.buildkite.job_label=Run tests"
 ```
 
+This behaviour can be disabled with the `run-labels: false` option.
+
 ## Build Arguments
 
 You can use the [build args key in docker-compose.yml](https://docs.docker.com/compose/compose-file/#args) to set specific build arguments when building an image.
@@ -633,6 +635,12 @@ The default is `false`.
 ### `rm` (optional, run only)
 
 If set to true, docker compose will remove the primary container after run. Equivalent to `--rm` in docker-compose.
+
+The default is `true`.
+
+### `run-labels` (optional, run only)
+
+If set to true, adds useful Docker labels to the primary container. See [Container Labels](#container-labels) for more info.
 
 The default is `true`.
 

--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ steps:
 
 ## Container Labels
 
-When running a command, the plugin will automatically use add the following Docker labels to the container specified in the `run` option:
+When running a command, the plugin will automatically add the following Docker labels to the container specified in the `run` option:
 - `com.buildkite.pipeline_name=${BUILDKITE_PIPELINE_NAME}`
 - `com.buildkite.pipeline_slug=${BUILDKITE_PIPELINE_SLUG}`
 - `com.buildkite.build_number=${BUILDKITE_BUILD_NUMBER}`

--- a/README.md
+++ b/README.md
@@ -181,6 +181,11 @@ When running a command, the plugin will automatically use add the following Dock
 - `com.buildkite.agent_name=${BUILDKITE_AGENT_NAME}`
 - `com.buildkite.agent_id=${BUILDKITE_AGENT_ID}`
 
+These labels can make it easier to query containers on hosts using `docker ps` for example:
+
+```bash
+docker ps --filter "label=com.buildkite.job_label=Run tests"
+```
 
 ## Build Arguments
 

--- a/README.md
+++ b/README.md
@@ -169,6 +169,19 @@ steps:
           propagate-environment: true
 ```
 
+## Container Labels
+
+When running a command, the plugin will automatically use add the following Docker labels to the container specified in the `run` option:
+- `com.buildkite.pipeline_name=${BUILDKITE_PIPELINE_NAME}`
+- `com.buildkite.pipeline_slug=${BUILDKITE_PIPELINE_SLUG}`
+- `com.buildkite.build_number=${BUILDKITE_BUILD_NUMBER}`
+- `com.buildkite.job_id=${BUILDKITE_JOB_ID}`
+- `com.buildkite.job_label=${BUILDKITE_LABEL}`
+- `com.buildkite.step_key=${BUILDKITE_STEP_KEY}`
+- `com.buildkite.agent_name=${BUILDKITE_AGENT_NAME}`
+- `com.buildkite.agent_id=${BUILDKITE_AGENT_ID}`
+
+
 ## Build Arguments
 
 You can use the [build args key in docker-compose.yml](https://docs.docker.com/compose/compose-file/#args) to set specific build arguments when building an image.

--- a/commands/run.sh
+++ b/commands/run.sh
@@ -78,6 +78,18 @@ fi
 # We set a predictable container name so we can find it and inspect it later on
 run_params+=("run" "--name" "$container_name")
 
+# Add useful labels to run container
+run_params+=(
+  "--label" "com.buildkite.pipeline_name=${BUILDKITE_PIPELINE_NAME}"
+  "--label" "com.buildkite.pipeline_slug=${BUILDKITE_PIPELINE_SLUG}"
+  "--label" "com.buildkite.build_number=${BUILDKITE_BUILD_NUMBER}"
+  "--label" "com.buildkite.job_id=${BUILDKITE_JOB_ID}"
+  "--label" "com.buildkite.job_label=${BUILDKITE_LABEL}"
+  "--label" "com.buildkite.step_key=${BUILDKITE_STEP_KEY}"
+  "--label" "com.buildkite.agent_name=${BUILDKITE_AGENT_NAME}"
+  "--label" "com.buildkite.agent_id=${BUILDKITE_AGENT_ID}"
+)
+
 # append env vars provided in ENV or ENVIRONMENT, these are newline delimited
 while IFS=$'\n' read -r env ; do
   [[ -n "${env:-}" ]] && run_params+=("-e" "${env}")

--- a/commands/run.sh
+++ b/commands/run.sh
@@ -78,17 +78,19 @@ fi
 # We set a predictable container name so we can find it and inspect it later on
 run_params+=("run" "--name" "$container_name")
 
-# Add useful labels to run container
-run_params+=(
-  "--label" "com.buildkite.pipeline_name=${BUILDKITE_PIPELINE_NAME}"
-  "--label" "com.buildkite.pipeline_slug=${BUILDKITE_PIPELINE_SLUG}"
-  "--label" "com.buildkite.build_number=${BUILDKITE_BUILD_NUMBER}"
-  "--label" "com.buildkite.job_id=${BUILDKITE_JOB_ID}"
-  "--label" "com.buildkite.job_label=${BUILDKITE_LABEL}"
-  "--label" "com.buildkite.step_key=${BUILDKITE_STEP_KEY}"
-  "--label" "com.buildkite.agent_name=${BUILDKITE_AGENT_NAME}"
-  "--label" "com.buildkite.agent_id=${BUILDKITE_AGENT_ID}"
-)
+if [[ "$(plugin_read_config RUN_LABELS "true")" =~ ^(true|on|1)$ ]]; then
+  # Add useful labels to run container
+  run_params+=(
+    "--label" "com.buildkite.pipeline_name=${BUILDKITE_PIPELINE_NAME}"
+    "--label" "com.buildkite.pipeline_slug=${BUILDKITE_PIPELINE_SLUG}"
+    "--label" "com.buildkite.build_number=${BUILDKITE_BUILD_NUMBER}"
+    "--label" "com.buildkite.job_id=${BUILDKITE_JOB_ID}"
+    "--label" "com.buildkite.job_label=${BUILDKITE_LABEL}"
+    "--label" "com.buildkite.step_key=${BUILDKITE_STEP_KEY}"
+    "--label" "com.buildkite.agent_name=${BUILDKITE_AGENT_NAME}"
+    "--label" "com.buildkite.agent_id=${BUILDKITE_AGENT_ID}"
+  )
+fi
 
 # append env vars provided in ENV or ENVIRONMENT, these are newline delimited
 while IFS=$'\n' read -r env ; do

--- a/plugin.yml
+++ b/plugin.yml
@@ -81,6 +81,8 @@ configuration:
       type: integer
     rm:
       type: boolean
+    run-labels:
+      type: boolean
     separator-cache-from:
       type: string
       minLength: 1

--- a/tests/multiple-commands.bats
+++ b/tests/multiple-commands.bats
@@ -8,12 +8,14 @@ load '../lib/metadata'
 # export BUILDKITE_AGENT_STUB_DEBUG=/dev/tty
 # export BATS_MOCK_TMPDIR=$PWD
 
-# General pipeline variables
-export BUILDKITE_BUILD_NUMBER=1
-export BUILDKITE_COMMAND="pwd"
-export BUILDKITE_JOB_ID=12
-export BUILDKITE_PIPELINE_SLUG=test
-
+setup_file() {
+  # General pipeline variables
+  export BUILDKITE_BUILD_NUMBER=1
+  export BUILDKITE_COMMAND="pwd"
+  export BUILDKITE_JOB_ID=12
+  export BUILDKITE_PIPELINE_SLUG=test
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RUN_LABELS="false"
+}
 
 @test "Build and run" {
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RUN=myservice

--- a/tests/output.bats
+++ b/tests/output.bats
@@ -9,6 +9,9 @@ load '../lib/run'
 # export DOCKER_STUB_DEBUG=/dev/tty
 # export BATS_MOCK_TMPDIR=$PWD
 
+setup_file() {
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RUN_LABELS="false"
+}
 
 @test "Logs: Detect some containers KO" {
   export BUILDKITE_AGENT_ACCESS_TOKEN="123123"

--- a/tests/push.bats
+++ b/tests/push.bats
@@ -8,10 +8,6 @@ load '../lib/shared'
 # export BUILDKITE_AGENT_STUB_DEBUG=/dev/tty
 # export BATS_MOCK_TMPDIR=$PWD
 
-setup_file() {
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RUN_LABELS="false"
-}
-
 @test "Push a single service with an image in it's config" {
   export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_PUSH=app

--- a/tests/push.bats
+++ b/tests/push.bats
@@ -8,6 +8,10 @@ load '../lib/shared'
 # export BUILDKITE_AGENT_STUB_DEBUG=/dev/tty
 # export BATS_MOCK_TMPDIR=$PWD
 
+setup_file() {
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RUN_LABELS="false"
+}
+
 @test "Push a single service with an image in it's config" {
   export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_PUSH=app

--- a/tests/run.bats
+++ b/tests/run.bats
@@ -8,6 +8,10 @@ load '../lib/run'
 # export BUILDKITE_AGENT_STUB_DEBUG=/dev/tty
 # export BATS_MOCK_TMPDIR=$PWD
 
+setup_file() {
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RUN_LABELS="false"
+}
+
 @test "Run without a prebuilt image" {
   export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RUN=myservice

--- a/tests/run.bats
+++ b/tests/run.bats
@@ -1505,17 +1505,20 @@ export BUILDKITE_JOB_ID=1111
 }
 
 @test "Run with Docker labels" {
-  export BUILDKITE_JOB_ID=1111
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RUN=myservice
-  export BUILDKITE_PIPELINE_SLUG=test
+  # Pipeline vars
+  export BUILDKITE_AGENT_ID="1234"
+  export BUILDKITE_AGENT_NAME="agent"
   export BUILDKITE_BUILD_NUMBER=1
   export BUILDKITE_COMMAND=pwd
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RUN_LABELS="true"
-  export BUILDKITE_PIPELINE_NAME="label-test"
+  export BUILDKITE_JOB_ID=1111
   export BUILDKITE_LABEL="Testjob"
+  export BUILDKITE_PIPELINE_NAME="label-test"
+  export BUILDKITE_PIPELINE_SLUG=test
   export BUILDKITE_STEP_KEY="test-job"
-  export BUILDKITE_AGENT_NAME="agent"
-  export BUILDKITE_AGENT_ID="1234"
+
+  # Plugin config
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RUN=myservice
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RUN_LABELS="true"
 
   stub docker-compose \
     "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml pull myservice : echo pulled myservice" \

--- a/tests/v2/run.bats
+++ b/tests/v2/run.bats
@@ -10,6 +10,7 @@ load '../../lib/run'
 
 setup_file() {
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLI_VERSION=2
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RUN_LABELS="false"
 }
 
 @test "Run without a prebuilt image" {


### PR DESCRIPTION
Adds labels that can be useful for finding the containers spawned on a host by this plugin. This can also enable automated tools to associate these docker-compose containers with the agent that started them.

Tested on our infra:
![image](https://user-images.githubusercontent.com/3876970/221652849-021b0c74-9dd7-452b-a4c1-c9e75c255751.png)

Question for maintainers: should this be behind a plugin config? I don't think so since it doesn't affect the behaviour of the container itself, but I'm happy to make it conditional if needed.