### PR TITLE
Add clarifications on volume variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ steps:
             - "./dist:/app/dist"
 ```
 
-If you want to use environment variables in the `volumes` element, you will need to activate the (unsafe) option `expand-volume-vars`.
+If you want to use environment variables in the `volumes` element, you will need to activate the (unsafe) option `expand-volume-vars` (and most likely escape it using `$$VARIABLE_NAME`).
 
 ## Environment
 
@@ -547,6 +547,8 @@ Additionally, volumes may be specified via the agent environment variable `BUILD
 When set to true, it will activate interpolation of variables in the elements of the `volumes` configuration array. When turned off (the default), attempting to use variables will fail as the literal `$VARIABLE_NAME` string will be passed to the `-v` option.
 
 :warning: **Important:** this is considered an unsafe option as the most compatible way to achieve this is to run the strings through `eval` which could lead to arbitrary code execution or information leaking if you don't have complete control of the pipeline
+
+Note that rules regarding [environment variable interpolation](https://buildkite.com/docs/pipelines/environment-variables#runtime-variable-interpolation)  apply here. That means that `$VARIABLE_NAME` is resolved at pipeline upload time, whereas `$$VARIABLE_NAME` will be at run time. All things being equal, you likely want to use `$$VARIABLE_NAME` on the variables mentioned in this option.
 
 ### `graceful-shutdown` (optional, run only)
 

--- a/README.md
+++ b/README.md
@@ -548,7 +548,7 @@ When set to true, it will activate interpolation of variables in the elements of
 
 :warning: **Important:** this is considered an unsafe option as the most compatible way to achieve this is to run the strings through `eval` which could lead to arbitrary code execution or information leaking if you don't have complete control of the pipeline
 
-Note that rules regarding [environment variable interpolation](https://buildkite.com/docs/pipelines/environment-variables#runtime-variable-interpolation)  apply here. That means that `$VARIABLE_NAME` is resolved at pipeline upload time, whereas `$$VARIABLE_NAME` will be at run time. All things being equal, you likely want to use `$$VARIABLE_NAME` on the variables mentioned in this option.
+Note that rules regarding [environment variable interpolation](https://buildkite.com/docs/pipelines/environment-variables#runtime-variable-interpolation) apply here. That means that `$VARIABLE_NAME` is resolved at pipeline upload time, whereas `$$VARIABLE_NAME` will be at run time. All things being equal, you likely want to use `$$VARIABLE_NAME` on the variables mentioned in this option.
 
 ### `graceful-shutdown` (optional, run only)
 


### PR DESCRIPTION
This adds a clarification with regards to variable interpolation when using them in volume stanzas.

Same as [PR 235 in the docker plugin](https://github.com/buildkite-plugins/docker-buildkite-plugin/pull/235), by the original author of the [forum post reporting an issue caused by that misunderstanding](https://forum.buildkite.community/t/accessing-ecr-inside-docker-plugin/2558/1).