### PR TITLE
Fix `ssh` option in builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -688,9 +688,9 @@ Assuming you have a compatible docker installation and configuration in the agen
 
 You may want to also add `BUILDKIT_INLINE_CACHE=1` to your build arguments (`args` option in this plugin), but know that [there are known issues with it](https://github.com/moby/buildkit/issues/2274).
 
-### `ssh` (optional, build only, boolean)
+### `ssh` (optional, build only, boolean or string)
 
-When enabled, it will add the `--ssh` option to the build command. Note that it assumes you have a compatible docker installation and configuration in the agent (meaning you are using BuildKit and it is correctly setup).
+It will add the `--ssh` option to the build command with the passed value (if `true` it will use `default`). Note that it assumes you have a compatible docker installation and configuration in the agent (meaning you are using BuildKit and it is correctly setup).
 
 ### `secrets` (optional, build only, array of strings)
 

--- a/commands/build.sh
+++ b/commands/build.sh
@@ -163,12 +163,18 @@ while read -r line ; do
   [[ -n "$line" ]] && build_params+=("--secret" "$line")
 done <<< "$(plugin_read_list SECRETS)"
 
-if [[ "$(plugin_read_config SSH "false")" == "true" ]] ; then
+if [[ "$(plugin_read_config SSH "false")" != "false" ]] ; then
   if [[ "${DOCKER_BUILDKIT:-}" != "1" && "${BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLI_VERSION:-}" != "2" ]]; then
     echo "🚨 You can not use the ssh option if you are not using buildkit"
     exit 1
   fi
-  build_params+=(--ssh)
+
+  SSH_CONTEXT="$(plugin_read_config SSH)"
+  if [[ "${SSH_CONTEXT}" == "true" ]]; then
+    # ssh option was a boolean
+    SSH_CONTEXT='default'
+  fi
+  build_params+=(--ssh "${SSH_CONTEXT}")
 fi
 
 target="$(plugin_read_config TARGET "")"

--- a/plugin.yml
+++ b/plugin.yml
@@ -94,7 +94,7 @@ configuration:
     skip-pull:
       type: boolean
     ssh:
-      type: boolean
+      type: [ boolean, string ]
     secrets:
       type: array
       items:

--- a/tests/build.bats
+++ b/tests/build.bats
@@ -841,7 +841,7 @@ load '../lib/shared'
   refute_output --partial "built myservice"
 }
 
-@test "Build with ssh option and buildkit" {
+@test "Build with ssh option as true and buildkit" {
   export BUILDKITE_BUILD_NUMBER=1
   export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PIPELINE_SLUG=test
@@ -851,7 +851,28 @@ load '../lib/shared'
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_SSH=true
 
   stub docker-compose \
-    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml build --pull --ssh \* : echo built \${10} with ssh"
+    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml build --pull --ssh default \* : echo built \${11} with ssh"
+
+  run "$PWD"/hooks/command
+
+  assert_success
+  assert_output --partial "built myservice"
+  assert_output --partial "with ssh"
+
+  unstub docker-compose
+}
+
+@test "Build with ssh option as string and buildkit" {
+  export BUILDKITE_BUILD_NUMBER=1
+  export BUILDKITE_JOB_ID=1111
+  export BUILDKITE_PIPELINE_SLUG=test
+
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD=myservice
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILDKIT=true
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_SSH=context
+
+  stub docker-compose \
+    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml build --pull --ssh context \* : echo built \${11} with ssh"
 
   run "$PWD"/hooks/command
 

--- a/tests/v2/build.bats
+++ b/tests/v2/build.bats
@@ -633,7 +633,7 @@ setup_file() {
   unstub docker
 }
 
-@test "Build with ssh option" {
+@test "Build with ssh option as boolean" {
   export BUILDKITE_BUILD_NUMBER=1
   export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PIPELINE_SLUG=test
@@ -642,7 +642,7 @@ setup_file() {
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_SSH=true
 
   stub docker \
-    "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml build --pull --ssh \* : echo built \${11} with ssh"
+    "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml build --pull --ssh default \* : echo built \${11} with ssh"
 
   run "$PWD"/hooks/command
 
@@ -653,6 +653,25 @@ setup_file() {
   unstub docker
 }
 
+@test "Build with ssh option as string" {
+  export BUILDKITE_BUILD_NUMBER=1
+  export BUILDKITE_JOB_ID=1111
+  export BUILDKITE_PIPELINE_SLUG=test
+
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD=myservice
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_SSH=context
+
+  stub docker \
+    "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml build --pull --ssh context \* : echo built \${11} with ssh"
+
+  run "$PWD"/hooks/command
+
+  assert_success
+  assert_output --partial "built myservice"
+  assert_output --partial "with ssh"
+
+  unstub docker
+}
 
 @test "Build with secrets" {
   export BUILDKITE_BUILD_NUMBER=1

--- a/tests/v2/build.bats
+++ b/tests/v2/build.bats
@@ -642,7 +642,7 @@ setup_file() {
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_SSH=true
 
   stub docker \
-    "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml build --pull --ssh default \* : echo built \${11} with ssh"
+    "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml build --pull --ssh default \* : echo built \${12} with ssh"
 
   run "$PWD"/hooks/command
 
@@ -662,7 +662,7 @@ setup_file() {
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_SSH=context
 
   stub docker \
-    "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml build --pull --ssh context \* : echo built \${11} with ssh"
+    "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml build --pull --ssh context \* : echo built \${12} with ssh"
 
   run "$PWD"/hooks/command
 


### PR DESCRIPTION
Corrects the misuse of the `ssh` option allowing it to be specified as a string and use `default` if set to `true`

Closes #382 