### PR TITLE
Add skip-pull support to build phase

### DIFF
--- a/README.md
+++ b/README.md
@@ -486,7 +486,7 @@ Whether to skip the repository checkout phase. This is useful for steps that use
 
 **Important**: as the code repository will not be available in the step, you need to ensure that the docker compose file(s) are present in some way (like using artifacts)
 
-### `skip-pull` (optional, run only)
+### `skip-pull` (optional, build and run only)
 
 Completely avoid running any `pull` command. Images being used will need to be present in the machine from before or have been built in the same step. Could be useful to avoid hitting rate limits when you can be sure the operation is unnecessary. Note that it is possible other commands run in the plugin's lifecycle will trigger a pull of necessary images.
 

--- a/commands/build.sh
+++ b/commands/build.sh
@@ -148,7 +148,11 @@ while read -r line ; do
   [[ -n "$line" ]] && services+=("$line")
 done <<< "$(plugin_read_list BUILD)"
 
-build_params=(build --pull)
+build_params=(build)
+
+if [[ ! "$(plugin_read_config SKIP_PULL "false")" == "true" ]] ; then
+  build_params+=(--pull)
+fi
 
 if [[ "$(plugin_read_config NO_CACHE "false")" == "true" ]] ; then
   build_params+=(--no-cache)

--- a/plugin.yml
+++ b/plugin.yml
@@ -141,7 +141,7 @@ configuration:
     pull: [ run ]
     push-retries: [ push ]
     service-ports: [ run ]
-    skip-pull: [ run ]
+    skip-pull: [ build, run ]
     secrets: [ buildkit, build ]
     ssh: [ buildkit ]
     target: [ build ]

--- a/tests/build.bats
+++ b/tests/build.bats
@@ -882,3 +882,20 @@ load '../lib/shared'
 
   unstub docker-compose
 }
+
+@test "Build without pull" {
+  export BUILDKITE_JOB_ID=1111
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD=myservice
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_SKIP_PULL=true
+  export BUILDKITE_PIPELINE_SLUG=test
+  export BUILDKITE_BUILD_NUMBER=1
+
+  stub docker-compose \
+    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml build myservice : echo built myservice"
+
+  run "$PWD"/hooks/command
+
+  assert_success
+  assert_output --partial "built myservice"
+  unstub docker-compose
+}

--- a/tests/v2/build.bats
+++ b/tests/v2/build.bats
@@ -674,3 +674,20 @@ setup_file() {
 
   unstub docker
 }
+
+@test "Build without pull" {
+  export BUILDKITE_JOB_ID=1111
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD=myservice
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_SKIP_PULL=true
+  export BUILDKITE_PIPELINE_SLUG=test
+  export BUILDKITE_BUILD_NUMBER=1
+
+  stub docker \
+    "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml build myservice : echo built myservice"
+
+  run "$PWD"/hooks/command
+
+  assert_success
+  assert_output --partial "built myservice"
+  unstub docker
+}


### PR DESCRIPTION
Reuses the existing `skip-pull` option to conditionally remove the `--pull` flag from the generated docker compose command.

I have a use case where I am pre-building images outside the docker-compose plugin and wanted to use those images in the `FROM` tag of a `Dockerfile` to be built via the plugin. With the `--pull` flag docker compose tries to fetch from docker hub and fails. This change puts the flag behind the same `SKIP_PULL` conditional currently used by
the run phase.

I verified that this works as expected for my own pipelines but those are very simple at the moment and not exercising much of the plugin's surface area. If there are explicit reasons why this was unsupported previously I'm happy to revisit this approach or come up with another workaround.
