### PR TITLE
Remove orphaned containers in cleanup

### DIFF
--- a/lib/run.bash
+++ b/lib/run.bash
@@ -18,9 +18,9 @@ compose_cleanup() {
 
   # Stop and remove all the linked services and network
   if [[ "$(plugin_read_config LEAVE_VOLUMES 'false')" == "false" ]]; then
-    run_docker_compose down --volumes || true
+    run_docker_compose down --remove-orphans --volumes || true
   else
-    run_docker_compose down || true
+    run_docker_compose down --remove-orphans || true
   fi
 }
 
@@ -72,7 +72,7 @@ check_linked_containers_and_save_logs() {
 }
 
 # docker-compose's -v arguments don't do local path expansion like the .yml
-# versions do. So we add very simple support, for the common and basic case.
+# versions do. So we add very simple support for the common and basic case.
 #
 # "./foo:/foo" => "/buildkite/builds/.../foo:/foo"
 expand_relative_volume_path() {

--- a/tests/cleanup.bats
+++ b/tests/cleanup.bats
@@ -19,7 +19,7 @@ load '../lib/run'
   stub docker-compose \
     "-f docker-compose.yml -p buildkite1111 kill : echo killing containers" \
     "-f docker-compose.yml -p buildkite1111 rm --force -v : echo removing stopped containers" \
-    "-f docker-compose.yml -p buildkite1111 down --volumes : echo removing everything"
+    "-f docker-compose.yml -p buildkite1111 down --remove-orphans --volumes : echo removing everything"
 
   run $PWD/hooks/pre-exit
 

--- a/tests/docker-compose-cleanup.bats
+++ b/tests/docker-compose-cleanup.bats
@@ -13,7 +13,7 @@ load '../lib/run'
   assert_success
   assert_equal "${lines[0]}" "kill"
   assert_equal "${lines[1]}" "rm --force -v"
-  assert_equal "${lines[2]}" "down --volumes"
+  assert_equal "${lines[2]}" "down --remove-orphans --volumes"
 }
 
 @test "Possible to gracefully shutdown containers in docker-compose cleanup" {
@@ -26,7 +26,7 @@ load '../lib/run'
   assert_success
   assert_equal "${lines[0]}" "stop"
   assert_equal "${lines[1]}" "rm --force -v"
-  assert_equal "${lines[2]}" "down --volumes"
+  assert_equal "${lines[2]}" "down --remove-orphans --volumes"
 }
 
 @test "Possible to skip volume destruction in docker-compose cleanup" {
@@ -39,5 +39,5 @@ load '../lib/run'
   assert_success
   assert_equal "${lines[0]}" "kill"
   assert_equal "${lines[1]}" "rm --force"
-  assert_equal "${lines[2]}" "down"
+  assert_equal "${lines[2]}" "down --remove-orphans"
 }


### PR DESCRIPTION
When I cancel a job, the main/run container continues running (but the output doesn't show up in the web interface).
See #389.