### PR TITLE
Introduce quiet-pull to avoid huge amount of junk logs get printed as CI logs  

### DIFF
--- a/README.md
+++ b/README.md
@@ -636,7 +636,8 @@ The default is `false`.
 
 ### `quiet-pull` (optional, run only)
 
-Sets `docker-compose up` to run with `--quiet-pull`. There are other commands that can accept `--quiet-pull` or equivalents. They have not been implemented yet. 
+
+Start up dependencies with `--quiet-pull` to prevent even more logs during that portion of the execution.
 
 The default is `false`.
 

--- a/README.md
+++ b/README.md
@@ -634,6 +634,12 @@ Sets `docker-compose` to run with `--verbose`
 
 The default is `false`.
 
+### `quiet-pull` (optional, run only)
+
+Sets `docker-compose up` to run with `--quiet-pull`. There are other commands that can accept `--quiet-pull` or equivalent. They have not been implemented yet. 
+
+The default is `false`.
+
 ### `rm` (optional, run only)
 
 If set to true, docker compose will remove the primary container after run. Equivalent to `--rm` in docker-compose.

--- a/README.md
+++ b/README.md
@@ -636,7 +636,6 @@ The default is `false`.
 
 ### `quiet-pull` (optional, run only)
 
-
 Start up dependencies with `--quiet-pull` to prevent even more logs during that portion of the execution.
 
 The default is `false`.

--- a/README.md
+++ b/README.md
@@ -636,7 +636,7 @@ The default is `false`.
 
 ### `quiet-pull` (optional, run only)
 
-Sets `docker-compose up` to run with `--quiet-pull`. There are other commands that can accept `--quiet-pull` or equivalent. They have not been implemented yet. 
+Sets `docker-compose up` to run with `--quiet-pull`. There are other commands that can accept `--quiet-pull` or equivalents. They have not been implemented yet. 
 
 The default is `false`.
 

--- a/commands/run.sh
+++ b/commands/run.sh
@@ -293,6 +293,10 @@ if [[ "$(plugin_read_config WAIT "false")" == "true" ]] ; then
   up_params+=("--wait")
 fi
 
+if [[ "$(plugin_read_config QUIET_PULL "false")" == "true" ]] ; then
+  up_params+=("--quiet-pull")
+fi
+
 dependency_exitcode=0
 if [[ "${run_dependencies}" == "true" ]] ; then
   # Start up service dependencies in a different header to keep the main run with less noise

--- a/plugin.yml
+++ b/plugin.yml
@@ -79,6 +79,8 @@ configuration:
       type: integer
     push-retries:
       type: integer
+    quiet-pull:
+      type: boolean
     rm:
       type: boolean
     run-labels:
@@ -140,6 +142,7 @@ configuration:
     propagate-uid-gid: [ run ]
     pull: [ run ]
     push-retries: [ push ]
+    quiet-pull: [ run ]
     service-ports: [ run ]
     skip-pull: [ build, run ]
     secrets: [ buildkit, build ]

--- a/tests/run.bats
+++ b/tests/run.bats
@@ -1556,10 +1556,10 @@ export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CHECK_LINKED_CONTAINERS=false
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_QUIET_PULL=true
 
-  stub docker \
-    "compose -f docker-compose.yml -p buildkite1111 build --pull myservice : echo built myservice" \
-    "compose -f docker-compose.yml -p buildkite1111 up --quiet-pull -d --scale myservice=0 myservice : echo ran myservice dependencies" \
-    "compose -f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 --rm myservice /bin/sh -e -c 'echo hello world' : echo ran myservice"
+  stub docker-compose \
+    "-f docker-compose.yml -p buildkite1111 build --pull myservice : echo built myservice" \
+    "-f docker-compose.yml -p buildkite1111 up --quite-pull -d --scale myservice=0 myservice : echo ran myservice dependencies" \
+    "-f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 --rm myservice /bin/sh -e -c 'echo hello world' : echo ran myservice"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 1"

--- a/tests/run.bats
+++ b/tests/run.bats
@@ -1545,3 +1545,33 @@ export BUILDKITE_JOB_ID=1111
   unstub docker-compose
   unstub buildkite-agent
 }
+
+@test "Run with --quiet-pull" {
+  export BUILDKITE_BUILD_NUMBER=1
+  export BUILDKITE_COMMAND="echo hello world"
+  export BUILDKITE_JOB_ID=1111
+  export BUILDKITE_PIPELINE_SLUG=test
+
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RUN=myservice
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CHECK_LINKED_CONTAINERS=false
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_QUIET_PULL=true
+
+  stub docker \
+    "compose -f docker-compose.yml -p buildkite1111 build --pull myservice : echo built myservice" \
+    "compose -f docker-compose.yml -p buildkite1111 up --quiet-pull -d --scale myservice=0 myservice : echo ran myservice dependencies" \
+    "compose -f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 --rm myservice /bin/sh -e -c 'echo hello world' : echo ran myservice"
+
+  stub buildkite-agent \
+    "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 1"
+
+  run "$PWD"/hooks/command
+
+  assert_success
+  assert_output --partial "built myservice"
+  refute_output --partial "Pulling"
+  assert_output --partial "ran myservice"
+
+  unstub docker
+  unstub buildkite-agent
+}
+

--- a/tests/run.bats
+++ b/tests/run.bats
@@ -1571,6 +1571,6 @@ export BUILDKITE_JOB_ID=1111
   refute_output --partial "Pulling"
   assert_output --partial "ran myservice"
 
-  unstub docker
+  unstub docker-compose
   unstub buildkite-agent
 }

--- a/tests/run.bats
+++ b/tests/run.bats
@@ -1574,4 +1574,3 @@ export BUILDKITE_JOB_ID=1111
   unstub docker
   unstub buildkite-agent
 }
-

--- a/tests/run.bats
+++ b/tests/run.bats
@@ -1558,7 +1558,7 @@ export BUILDKITE_JOB_ID=1111
 
   stub docker-compose \
     "-f docker-compose.yml -p buildkite1111 build --pull myservice : echo built myservice" \
-    "-f docker-compose.yml -p buildkite1111 up --quite-pull -d --scale myservice=0 myservice : echo ran myservice dependencies" \
+    "-f docker-compose.yml -p buildkite1111 up --quiet-pull -d --scale myservice=0 myservice : echo ran myservice dependencies" \
     "-f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 --rm myservice /bin/sh -e -c 'echo hello world' : echo ran myservice"
 
   stub buildkite-agent \

--- a/tests/v2/run.bats
+++ b/tests/v2/run.bats
@@ -1385,7 +1385,7 @@ export BUILDKITE_JOB_ID=1111
 
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RUN=myservice
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CHECK_LINKED_CONTAINERS=false
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_WAIT=true
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_QUIET_PULL=true
 
   stub docker \
     "compose -f docker-compose.yml -p buildkite1111 build --pull myservice : echo built myservice" \


### PR DESCRIPTION
I currently have a buildkite pipeline that generates 30mb to 60mb logs because this plugin prints out everything from docker-compose.


This is actually the first time I am touching this codebase. All I did was pattern matching. Obviously, I don't have a buildkite account that I can freely install plugins on to test my code, so please double-check if I made any mistakes. 

Also, this is just me trying this out and see if I can actually get the logs reduced. If this works, I may come back and implement this for all other possible commands. TBD.