### PR TITLE
`env-propagation-list`: programmatically propagate envvars to the container

### DIFF
--- a/README.md
+++ b/README.md
@@ -468,7 +468,7 @@ If you set this to `VALUE`, and `VALUE` is an environment variable containing a 
 
 Whether or not to automatically propagate all pipeline environment variables into the run container. Avoiding the need to be specified with environment.
 
-\* Caveat: only environment variables listed in $BUILDKITE_ENV_FILE will be propagated. This does not include e.g. variables that you exported in an `environment` hook. If you wish for those to be propagated, try `env-propagation-list`.
+**Important**: only pipeline environment variables will be propagated (what you see in the BuildKite UI, those listed in `$BUILDKITE_ENV_FILE`). This does not include variables exported in preceeding `environment` hooks. If you wish for those to be propagated you will need to list them specifically or use `env-propagation-list`.
 
 ### `command` (optional, run only, array)
 

--- a/README.md
+++ b/README.md
@@ -460,11 +460,15 @@ A list of KEY=VALUE that are passed through as build arguments when image is bei
 
 A list of either KEY or KEY=VALUE that are passed through as environment variables to the container.
 
+### `env-propagation-list` (optional, string)
+
+If you set this to `VALUE`, and `VALUE` is an environment variable containing a space-separated list of environment variables such as `A B C D`, then A, B, C, and D will all be propagated to the container. This is helpful when you've set up an `environment` hook to export secrets as environment variables, and you'd also like to programmatically ensure that secrets get propagated to containers, instead of listing them all out.
+
 ### `propagate-environment` (optional, boolean)
 
 Whether or not to automatically propagate all pipeline environment variables into the run container. Avoiding the need to be specified with environment.
 
-**Important**: only pipeline variables will automatically be propagated (what you see in the Buildkite UI). Variables set in proceeding hook scripts will not be propagated to the container.
+\* Caveat: only environment variables listed in $BUILDKITE_ENV_FILE will be propagated. This does not include e.g. variables that you exported in an `environment` hook. If you wish for those to be propagated, try `env-propagation-list`.
 
 ### `command` (optional, run only, array)
 

--- a/commands/run.sh
+++ b/commands/run.sh
@@ -112,6 +112,19 @@ if [[ "$(plugin_read_config PROPAGATE_ENVIRONMENT "false")" =~ ^(true|on|1)$ ]] 
   fi
 fi
 
+# If requested, propagate a set of env vars as listed in a given env var to the
+# container.
+if [[ -n "$(plugin_read_config ENV_PROPAGATION_LIST)" ]]; then
+  env_propagation_list_var="$(plugin_read_config ENV_PROPAGATION_LIST)"
+  if [[ -z "${!env_propagation_list_var:-}" ]]; then
+    echo -n "env-propagation-list desired, but ${env_propagation_list_var} is not defined!"
+    exit 1
+  fi
+  for var in ${!env_propagation_list_var}; do
+    run_params+=("-e" "$var")
+  done
+fi
+
 while IFS=$'\n' read -r vol ; do
   [[ -n "${vol:-}" ]] && run_params+=("-v" "$(expand_relative_volume_path "$vol")")
 done <<< "$(plugin_read_list VOLUMES)"

--- a/plugin.yml
+++ b/plugin.yml
@@ -50,6 +50,8 @@ configuration:
     environment:
       type: [ string, array ]
       minimum: 1
+    env-propagation-list:
+      type: string
     expand-volume-vars:
       type: boolean
     image-repository:

--- a/tests/run.bats
+++ b/tests/run.bats
@@ -1545,3 +1545,51 @@ export BUILDKITE_JOB_ID=1111
   unstub docker-compose
   unstub buildkite-agent
 }
+
+@test "Run with a list of propagated env vars" {
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_ENV_PROPAGATION_LIST="LIST_OF_VARS"
+  export LIST_OF_VARS="VAR_A VAR_B VAR_C"
+  export BUILDKITE_JOB_ID=1111
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RUN=myservice
+  export BUILDKITE_PIPELINE_SLUG=test
+  export BUILDKITE_BUILD_NUMBER=1
+  export BUILDKITE_COMMAND="echo hello world"
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CHECK_LINKED_CONTAINERS=false
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLEANUP=false
+
+  stub docker-compose \
+    "-f docker-compose.yml -p buildkite1111 build --pull myservice : echo built myservice" \
+    "-f docker-compose.yml -p buildkite1111 up -d --scale myservice=0 myservice : echo ran myservice dependencies" \
+    "-f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 -e VAR_A -e VAR_B -e VAR_C --rm myservice /bin/sh -e -c 'echo hello world' : echo ran myservice"
+
+  stub buildkite-agent \
+    "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 1"
+
+  run "$PWD"/hooks/command
+
+  assert_success
+  assert_output --partial "built myservice"
+  assert_output --partial "ran myservice"
+  unstub docker-compose
+  unstub buildkite-agent
+}
+
+@test "Run with a list of propagated env vars - unless you forgot to define the variable" {
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_ENV_PROPAGATION_LIST="LIST_OF_VARS"
+  export BUILDKITE_JOB_ID=1111
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RUN=myservice
+  export BUILDKITE_PIPELINE_SLUG=test
+  export BUILDKITE_BUILD_NUMBER=1
+  export BUILDKITE_COMMAND="echo hello world"
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CHECK_LINKED_CONTAINERS=false
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLEANUP=false
+
+  stub buildkite-agent \
+    "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 1"
+
+  run "$PWD"/hooks/command
+
+  assert_failure
+  assert_output --partial "env-propagation-list desired, but LIST_OF_VARS is not defined!"
+  unstub buildkite-agent
+}

--- a/tests/v2/run.bats
+++ b/tests/v2/run.bats
@@ -1405,3 +1405,51 @@ export BUILDKITE_JOB_ID=1111
   unstub docker
   unstub buildkite-agent
 }
+
+@test "Run with a list of propagated env vars" {
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_ENV_PROPAGATION_LIST="LIST_OF_VARS"
+  export LIST_OF_VARS="VAR_A VAR_B VAR_C"
+  export BUILDKITE_JOB_ID=1111
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RUN=myservice
+  export BUILDKITE_PIPELINE_SLUG=test
+  export BUILDKITE_BUILD_NUMBER=1
+  export BUILDKITE_COMMAND="echo hello world"
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CHECK_LINKED_CONTAINERS=false
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLEANUP=false
+
+  stub docker \
+    "compose -f docker-compose.yml -p buildkite1111 build --pull myservice : echo built myservice" \
+    "compose -f docker-compose.yml -p buildkite1111 up -d --scale myservice=0 myservice : echo ran myservice dependencies" \
+    "compose -f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 -e VAR_A -e VAR_B -e VAR_C --rm myservice /bin/sh -e -c 'echo hello world' : echo ran myservice"
+
+  stub buildkite-agent \
+    "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 1"
+
+  run "$PWD"/hooks/command
+
+  assert_success
+  assert_output --partial "built myservice"
+  assert_output --partial "ran myservice"
+  unstub docker
+  unstub buildkite-agent
+}
+
+@test "Run with a list of propagated env vars - unless you forgot to define the variable" {
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_ENV_PROPAGATION_LIST="LIST_OF_VARS"
+  export BUILDKITE_JOB_ID=1111
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RUN=myservice
+  export BUILDKITE_PIPELINE_SLUG=test
+  export BUILDKITE_BUILD_NUMBER=1
+  export BUILDKITE_COMMAND="echo hello world"
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CHECK_LINKED_CONTAINERS=false
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLEANUP=false
+
+  stub buildkite-agent \
+    "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 1"
+
+  run "$PWD"/hooks/command
+
+  assert_failure
+  assert_output --partial "env-propagation-list desired, but LIST_OF_VARS is not defined!"
+  unstub buildkite-agent
+}


### PR DESCRIPTION
Implements the same feature as https://github.com/buildkite-plugins/docker-buildkite-plugin/pull/238, which is also useful for docker-compose use case. See the linked PR for rationale / use cases.