### PR TITLE
Better signal handling (for Job cancellations)

### DIFF
--- a/commands/run.sh
+++ b/commands/run.sh
@@ -420,7 +420,7 @@ fi
 ensure_stopped() {
   echo '+++ :warning: Signal received, stopping container'
   run_docker_compose stop "${container_name}" || true
-  exitcode=-1
+  exitcode='TRAP'
 }
 
 trap ensure_stopped SIGINT SIGTERM
@@ -435,7 +435,11 @@ set +e
 # Restore -e as an option.
 set -e
 
-if [[ $exitcode -ne 0 ]] ; then
+if [[ $exitcode = "TRAP" ]]; then
+  # command failed due to cancellation signal, prevent printing more messages
+  # mask the exit code
+  exitcode=0
+elif [[ $exitcode -ne 0 ]] ; then
   echo "^^^ +++"
   echo "+++ :warning: Failed to run command, exited with $exitcode, run params:"
   echo "${run_params[@]}"
@@ -449,4 +453,4 @@ if [[ -n "${BUILDKITE_AGENT_ACCESS_TOKEN:-}" ]] ; then
   fi
 fi
 
-return $exitcode
+return "$exitcode"

--- a/commands/run.sh
+++ b/commands/run.sh
@@ -420,6 +420,7 @@ fi
 ensure_stopped() {
   echo ':warning: Signal received, stopping container'
   run_docker_compose stop "${container_name}" || true
+  exitcode=-1
 }
 
 trap ensure_stopped SIGINT SIGTERM

--- a/commands/run.sh
+++ b/commands/run.sh
@@ -429,11 +429,11 @@ trap ensure_stopped SIGINT SIGTERM SIGQUIT
 
 # Disable -e to prevent cancelling step if the command fails for whatever reason
 set +e
-( # subshell is necessary to trap signals (compose v2 fails to stop otherwise)
-  echo "+++ :docker: Running ${display_command[*]:-} in service $run_service" >&2
-  run_docker_compose "${run_params[@]}"
-  exitcode=$?
-)
+
+echo "+++ :docker: Running ${display_command[*]:-} in service $run_service" >&2
+run_docker_compose "${run_params[@]}"
+exitcode=$?
+
 # Restore -e as an option.
 set -e
 

--- a/commands/run.sh
+++ b/commands/run.sh
@@ -418,7 +418,7 @@ elif [[ ${#command[@]} -gt 0 ]] ; then
 fi
 
 ensure_stopped() {
-  echo ':warning: Signal received, stopping container'
+  echo '+++ :warning: Signal received, stopping container'
   run_docker_compose stop "${container_name}" || true
   exitcode=-1
 }

--- a/commands/run.sh
+++ b/commands/run.sh
@@ -417,7 +417,12 @@ elif [[ ${#command[@]} -gt 0 ]] ; then
   done
 fi
 
-trap 'run_docker_compose stop ${container_name}' SIGINT SIGTERM
+ensure_stopped() {
+  echo ':warning: Signal received, stopping container'
+  run_docker_compose stop "${container_name}" || true
+}
+
+trap ensure_stopped SIGINT SIGTERM
 
 # Disable -e outside of the subshell; since the subshell returning a failure
 # would exit the parent shell (here) early.

--- a/commands/run.sh
+++ b/commands/run.sh
@@ -424,16 +424,11 @@ ensure_stopped() {
 
 trap ensure_stopped SIGINT SIGTERM
 
-# Disable -e outside of the subshell; since the subshell returning a failure
-# would exit the parent shell (here) early.
+# Disable -e to prevent cancelling step if the command fails for whatever reason
 set +e
 
-(
-  echo "+++ :docker: Running ${display_command[*]:-} in service $run_service" >&2
-
-  run_docker_compose "${run_params[@]}"
-)
-
+echo "+++ :docker: Running ${display_command[*]:-} in service $run_service" >&2
+run_docker_compose "${run_params[@]}"
 exitcode=$?
 
 # Restore -e as an option.

--- a/commands/run.sh
+++ b/commands/run.sh
@@ -422,6 +422,8 @@ fi
 set +e
 
 (
+  trap 'run_docker_compose stop ${container_name}' INT TERM
+
   echo "+++ :docker: Running ${display_command[*]:-} in service $run_service" >&2
   run_docker_compose "${run_params[@]}"
 )

--- a/commands/run.sh
+++ b/commands/run.sh
@@ -422,7 +422,7 @@ fi
 set +e
 
 (
-  trap 'run_docker_compose stop ${container_name}' INT TERM
+  trap 'run_docker_compose stop ${container_name}' SIGINT SIGTERM
 
   echo "+++ :docker: Running ${display_command[*]:-} in service $run_service" >&2
   run_docker_compose "${run_params[@]}"

--- a/commands/run.sh
+++ b/commands/run.sh
@@ -417,14 +417,15 @@ elif [[ ${#command[@]} -gt 0 ]] ; then
   done
 fi
 
+trap 'run_docker_compose stop ${container_name}' SIGINT SIGTERM
+
 # Disable -e outside of the subshell; since the subshell returning a failure
 # would exit the parent shell (here) early.
 set +e
 
 (
-  trap 'run_docker_compose stop ${container_name}' SIGINT SIGTERM
-
   echo "+++ :docker: Running ${display_command[*]:-} in service $run_service" >&2
+
   run_docker_compose "${run_params[@]}"
 )
 

--- a/commands/run.sh
+++ b/commands/run.sh
@@ -423,7 +423,7 @@ ensure_stopped() {
   exitcode='TRAP'
 }
 
-trap ensure_stopped SIGINT SIGTERM
+trap ensure_stopped SIGINT SIGTERM SIGQUIT
 
 # Disable -e to prevent cancelling step if the command fails for whatever reason
 set +e

--- a/commands/run.sh
+++ b/commands/run.sh
@@ -426,11 +426,11 @@ trap ensure_stopped SIGINT SIGTERM
 
 # Disable -e to prevent cancelling step if the command fails for whatever reason
 set +e
-
-echo "+++ :docker: Running ${display_command[*]:-} in service $run_service" >&2
-run_docker_compose "${run_params[@]}"
-exitcode=$?
-
+( # subshell is necessary to trap signals (compose v2 fails to stop otherwise)
+  echo "+++ :docker: Running ${display_command[*]:-} in service $run_service" >&2
+  run_docker_compose "${run_params[@]}"
+  exitcode=$?
+)
 # Restore -e as an option.
 set -e
 

--- a/commands/run.sh
+++ b/commands/run.sh
@@ -422,7 +422,7 @@ ensure_stopped() {
   docker stop "${container_name}" || true
   echo '~~~ Last log lines that may be missing above (if container was not already removed)'
   docker logs "${container_name}" || true
-  exitcode='TRAP'
+  trapped='TRAP'
 }
 
 trap ensure_stopped SIGINT SIGTERM SIGQUIT
@@ -437,8 +437,8 @@ set +e
 # Restore -e as an option.
 set -e
 
-if [[ $exitcode = "TRAP" ]]; then
-  # command failed due to cancellation signal, prevent printing more messages
+if [[ "${trapped:-}" = "TRAP" ]]; then
+  # command failed due to cancellation signal, make sure there is an error but no further output
   exitcode=-1
 elif [[ $exitcode -ne 0 ]] ; then
   echo "^^^ +++"

--- a/commands/run.sh
+++ b/commands/run.sh
@@ -419,7 +419,7 @@ fi
 
 ensure_stopped() {
   echo '+++ :warning: Signal received, stopping container'
-  run_docker_compose stop "${run_service}" || true
+  docker stop "${container_name}" || true
   echo '--- Last log lines that may be missing above (will be empty if container was already removed)'
   docker logs "${container_name}" || true
   exitcode='TRAP'

--- a/commands/run.sh
+++ b/commands/run.sh
@@ -419,7 +419,7 @@ fi
 
 ensure_stopped() {
   echo '+++ :warning: Signal received, stopping container'
-  run_docker_compose stop "${container_name}" || true
+  run_docker_compose stop "${run_service}" || true
   exitcode='TRAP'
 }
 

--- a/commands/run.sh
+++ b/commands/run.sh
@@ -422,7 +422,7 @@ ensure_stopped() {
   docker stop "${container_name}" || true
   echo '~~~ Last log lines that may be missing above (if container was not already removed)'
   docker logs "${container_name}" || true
-  trapped='TRAP'
+  exitcode='TRAP'
 }
 
 trap ensure_stopped SIGINT SIGTERM SIGQUIT
@@ -432,12 +432,13 @@ set +e
 ( # subshell is necessary to trap signals (compose v2 fails to stop otherwise)
   echo "+++ :docker: Running ${display_command[*]:-} in service $run_service" >&2
   run_docker_compose "${run_params[@]}"
-  exitcode=$?
 )
+exitcode=$?
+
 # Restore -e as an option.
 set -e
 
-if [[ "${trapped:-}" = "TRAP" ]]; then
+if [[ $exitcode = "TRAP" ]]; then
   # command failed due to cancellation signal, make sure there is an error but no further output
   exitcode=-1
 elif [[ $exitcode -ne 0 ]] ; then

--- a/commands/run.sh
+++ b/commands/run.sh
@@ -420,8 +420,8 @@ fi
 ensure_stopped() {
   echo '+++ :warning: Signal received, stopping container'
   run_docker_compose stop "${run_service}" || true
-  echo '--- Last log lines (may be missing above)'
-  run_docker_compose logs "${run_service}" || true
+  echo '--- Last log lines that may be missing above (will be empty if container was already removed)'
+  docker logs "${container_name}" || true
   exitcode='TRAP'
 }
 

--- a/commands/run.sh
+++ b/commands/run.sh
@@ -420,7 +420,7 @@ fi
 ensure_stopped() {
   echo '+++ :warning: Signal received, stopping container'
   docker stop "${container_name}" || true
-  echo '--- Last log lines that may be missing above (will be empty if container was already removed)'
+  echo '~~~ Last log lines that may be missing above (if container was not already removed)'
   docker logs "${container_name}" || true
   exitcode='TRAP'
 }
@@ -439,8 +439,7 @@ set -e
 
 if [[ $exitcode = "TRAP" ]]; then
   # command failed due to cancellation signal, prevent printing more messages
-  # mask the exit code
-  exitcode=0
+  exitcode=-1
 elif [[ $exitcode -ne 0 ]] ; then
   echo "^^^ +++"
   echo "+++ :warning: Failed to run command, exited with $exitcode, run params:"

--- a/commands/run.sh
+++ b/commands/run.sh
@@ -429,11 +429,11 @@ trap ensure_stopped SIGINT SIGTERM SIGQUIT
 
 # Disable -e to prevent cancelling step if the command fails for whatever reason
 set +e
-
-echo "+++ :docker: Running ${display_command[*]:-} in service $run_service" >&2
-run_docker_compose "${run_params[@]}"
-exitcode=$?
-
+( # subshell is necessary to trap signals (compose v2 fails to stop otherwise)
+  echo "+++ :docker: Running ${display_command[*]:-} in service $run_service" >&2
+  run_docker_compose "${run_params[@]}"
+  exitcode=$?
+)
 # Restore -e as an option.
 set -e
 

--- a/commands/run.sh
+++ b/commands/run.sh
@@ -420,6 +420,8 @@ fi
 ensure_stopped() {
   echo '+++ :warning: Signal received, stopping container'
   run_docker_compose stop "${run_service}" || true
+  echo '--- Last log lines (may be missing above)'
+  run_docker_compose logs "${run_service}" || true
   exitcode='TRAP'
 }
 


### PR DESCRIPTION
This adds signal handling on `INT`, `TERM` and `QUIT` on the command hook script so that the main container is stopped gracefully. It also gets logs for the container if not removed (though technically only strictly necessary for compose v1 as v2 still shows the output until the container is killed).

I have tested this with the following ruby code:
```ruby
begin
  (1..20).each do |x|
    puts "#{x}\n"
    STDOUT.flush
    sleep 10
  end
rescue SignalException => e
  puts  "\nSignal: #{e.signo} / #{e}"
  sleep 2
  exit e.signo
end
```

Save that file and use docker compose to run the file in a vanilla ruby container. Once it is running, cancel the job.

Without this code, the step cancels immediately, but the main container is still running and (by default) killed during the `pre-exit` hook. Even when using `graceful-termination` so that the container is stopped instead, you are missing the actual container output since the job was cancelled and then removed (which is now guaranteed by #386).

With this code, instead, the container gets sent its corresponding stop signal (as defined in its dockerfile)

Closes #389 