### PR TITLE
Default tty to false to minimise build output

### DIFF
--- a/README.md
+++ b/README.md
@@ -600,9 +600,9 @@ The default is `false`.
 
 ### `tty` (optional, run only)
 
-If set to false, doesn't allocate a TTY. This is useful in some situations where TTY's aren't supported, for instance windows.
+If set to true, allocates a TTY. This is useful in some situations TTYs are required.
 
-The default is `true` on unix, `false` on windows
+The default is `false`.
 
 ### `dependencies` (optional, run only)
 

--- a/commands/run.sh
+++ b/commands/run.sh
@@ -142,14 +142,13 @@ if [[ -n "${BUILDKITE_REPO_MIRROR:-}" ]]; then
   run_params+=("-v" "$BUILDKITE_REPO_MIRROR:$BUILDKITE_REPO_MIRROR:ro")
 fi
 
-tty_default='true'
+tty_default='false'
 workdir_default="/workdir"
 pwd_default="$PWD"
 run_dependencies="true"
 
 # Set operating system specific defaults
 if is_windows ; then
-  tty_default='false'
   workdir_default="C:\\workdir"
   # escaping /C is a necessary workaround for an issue with Git for Windows 2.24.1.2
   # https://github.com/git-for-windows/git/issues/2442


### PR DESCRIPTION
This PR changes the default of `tty` to `false`.

Unless there's a scenario I'm not considering, it doesn't seem to make sense to have this on by default, as CI is traditionally a non-interactive environment anyway. Most command line tools change their output behaviour to be more "interactive" when a TTY is detected, but this drastically increases build output, causing build log truncation warnings.

For a single step in our pipeline, the build output size difference is staggering!

* `tty: true` - 2.1MB
* `tty: false` - 752KB (35% of above output, ~65% reduction)

