### PR TITLE
Backport buildkite-agent-mount option

### DIFF
--- a/plugin.yml
+++ b/plugin.yml
@@ -66,6 +66,8 @@ configuration:
       type: boolean
     workdir:
       type: string
+    mount-buildkite-agent:
+      type: boolean
   oneOf:
     - required:
       - run
@@ -92,3 +94,4 @@ configuration:
     tty: [ run ]
     workdir: [ run ]
     user: [ run ]
+    mount-buildkite-agent: [ run ]


### PR DESCRIPTION
Cherry-pick the commit that adds the buildkite-agent-mount capability so it is available without moving the rest of the branch forward. 