### PR TITLE
Fix v1 incompatibility

### DIFF
--- a/commands/run.sh
+++ b/commands/run.sh
@@ -146,9 +146,9 @@ fi
 # Mount buildkite-agent if we have a path for it
 if [[ -n "${BUILDKITE_AGENT_BINARY_PATH:-}" ]] ; then
   run_params+=(
-    "--env" "BUILDKITE_JOB_ID"
-    "--env" "BUILDKITE_BUILD_ID"
-    "--env" "BUILDKITE_AGENT_ACCESS_TOKEN"
+    "-e" "BUILDKITE_JOB_ID"
+    "-e" "BUILDKITE_BUILD_ID"
+    "-e" "BUILDKITE_AGENT_ACCESS_TOKEN"
     "--volume" "$BUILDKITE_AGENT_BINARY_PATH:/usr/bin/buildkite-agent"
   )
 fi


### PR DESCRIPTION
`--env` works for docker-composer-v2, but not for v1, which silently fails (e.g. returncode=0) when passed invalid args such as `--env`. 

* Tested this change in our internal setup and seems to have worked. 
* `-e` should be forward compatible with v2 as well. 