### PR TITLE
Collapse logging of run output by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ The following pipeline will run `test.sh` inside a `app` service container using
 steps:
   - command: test.sh
     plugins:
-      - docker-compose#v4.14.0:
+      - docker-compose#v4.15.0:
           run: app
 ```
 
@@ -28,7 +28,7 @@ through if you need:
 steps:
   - command: test.sh
     plugins:
-      - docker-compose#v4.14.0:
+      - docker-compose#v4.15.0:
           run: app
           config: docker-compose.tests.yml
           env:
@@ -41,7 +41,7 @@ or multiple config files:
 steps:
   - command: test.sh
     plugins:
-      - docker-compose#v4.14.0:
+      - docker-compose#v4.15.0:
           run: app
           config:
             - docker-compose.yml
@@ -56,7 +56,7 @@ env:
 steps:
   - command: test.sh
     plugins:
-      - docker-compose#v4.14.0:
+      - docker-compose#v4.15.0:
           run: app
 ```
 
@@ -65,7 +65,7 @@ If you want to control how your command is passed to docker-compose, you can use
 ```yml
 steps:
   - plugins:
-      - docker-compose#v4.14.0:
+      - docker-compose#v4.15.0:
           run: app
           command: ["custom", "command", "values"]
 ```
@@ -79,7 +79,7 @@ steps:
   - plugins:
       - docker-login#v2.0.1:
           username: xyz
-      - docker-compose#v4.14.0:
+      - docker-compose#v4.15.0:
           build: app
           image-repository: index.docker.io/myorg/myrepo
   - wait
@@ -87,7 +87,7 @@ steps:
     plugins:
       - docker-login#v2.0.1:
           username: xyz
-      - docker-compose#v4.14.0:
+      - docker-compose#v4.15.0:
           run: app
 ```
 
@@ -104,7 +104,7 @@ steps:
   - command: generate-dist.sh
     artifact_paths: "dist/*"
     plugins:
-      - docker-compose#v4.14.0:
+      - docker-compose#v4.15.0:
           run: app
 ```
 
@@ -122,7 +122,7 @@ steps:
   - command: generate-dist.sh
     artifact_paths: "dist/*"
     plugins:
-      - docker-compose#v4.14.0:
+      - docker-compose#v4.15.0:
           run: app
           volumes:
             - "./dist:/app/dist"
@@ -146,7 +146,7 @@ this plugin offers a `environment` block of its own:
 steps:
   - command: generate-dist.sh
     plugins:
-      - docker-compose#v4.14.0:
+      - docker-compose#v4.15.0:
           run: app
           env:
             - BUILDKITE_BUILD_NUMBER
@@ -164,7 +164,7 @@ Alternatively, you can have the plugin add all environment variables defined for
 steps:
   - command: use-vars.sh
     plugins:
-      - docker-compose#v4.14.0:
+      - docker-compose#v4.15.0:
           run: app
           propagate-environment: true
 ```
@@ -199,7 +199,7 @@ Alternatively, if you want to set build arguments when pre-building an image, th
 steps:
   - command: generate-dist.sh
     plugins:
-      - docker-compose#v4.14.0:
+      - docker-compose#v4.15.0:
           build: app
           image-repository: index.docker.io/myorg/myrepo
           args:
@@ -216,7 +216,7 @@ If you have multiple steps that use the same service/image (such as steps that r
 steps:
   - label: ":docker: Build"
     plugins:
-      - docker-compose#v4.14.0:
+      - docker-compose#v4.15.0:
           build: app
           image-repository: index.docker.io/myorg/myrepo
 
@@ -226,7 +226,7 @@ steps:
     command: test.sh
     parallelism: 25
     plugins:
-      - docker-compose#v4.14.0:
+      - docker-compose#v4.15.0:
           run: app
 ```
 
@@ -242,7 +242,7 @@ steps:
     agents:
       queue: docker-builder
     plugins:
-      - docker-compose#v4.14.0:
+      - docker-compose#v4.15.0:
           build:
             - app
             - tests
@@ -254,7 +254,7 @@ steps:
     command: test.sh
     parallelism: 25
     plugins:
-      - docker-compose#v4.14.0:
+      - docker-compose#v4.15.0:
           run: tests
 ```
 
@@ -266,7 +266,7 @@ If you want to push your Docker images ready for deployment, you can use the `pu
 steps:
   - label: ":docker: Push"
     plugins:
-      - docker-compose#v4.14.0:
+      - docker-compose#v4.15.0:
           push: app
 ```
 
@@ -276,7 +276,7 @@ To push multiple images, you can use a list:
 steps:
   - label: ":docker: Push"
     plugins:
-      - docker-compose#v4.14.0:
+      - docker-compose#v4.15.0:
           push:
             - first-service
             - second-service
@@ -288,7 +288,7 @@ If you want to push to a specific location (that's not defined as the `image` in
 steps:
   - label: ":docker: Push"
     plugins:
-      - docker-compose#v4.14.0:
+      - docker-compose#v4.15.0:
           push:
             - app:index.docker.io/myorg/myrepo/myapp
             - app:index.docker.io/myorg/myrepo/myapp:latest
@@ -302,14 +302,14 @@ A newly spawned agent won't contain any of the docker caches for the first run w
 steps:
   - label: ":docker: Build an image"
     plugins:
-      - docker-compose#v4.14.0:
+      - docker-compose#v4.15.0:
           build: app
           image-repository: index.docker.io/myorg/myrepo
           cache-from: app:index.docker.io/myorg/myrepo/myapp:latest
   - wait
   - label: ":docker: Push to final repository"
     plugins:
-      - docker-compose#v4.14.0:
+      - docker-compose#v4.15.0:
           push:
             - app:index.docker.io/myorg/myrepo/myapp
             - app:index.docker.io/myorg/myrepo/myapp:latest
@@ -327,7 +327,7 @@ This plugin allows for the value of `cache-from` to be a string or a list. If it
 steps:
   - label: ":docker Build an image"
     plugins:
-      - docker-compose#v4.14.0:
+      - docker-compose#v4.15.0:
           build: app
           image-repository: index.docker.io/myorg/myrepo
           separator-cache-from: "#"
@@ -337,7 +337,7 @@ steps:
   - wait
   - label: ":docker: Push to final repository"
     plugins:
-      - docker-compose#v4.14.0:
+      - docker-compose#v4.15.0:
           push:
             - app:myregistry:port/myrepo/myapp:my-branch
             - app:myregistry:port/myrepo/myapp:latest
@@ -350,7 +350,7 @@ Adding a grouping tag to the end of a cache-from list item allows this plugin to
 steps:
   - label: ":docker: Build Intermediate Image"
     plugins:
-      - docker-compose#v4.14.0:
+      - docker-compose#v4.15.0:
           build: myservice_intermediate  # docker-compose.yml is the same as myservice but has `target: intermediate`
           image-name: buildkite-build-${BUILDKITE_BUILD_NUMBER}
           image-repository: index.docker.io/myorg/myrepo/myservice_intermediate
@@ -360,7 +360,7 @@ steps:
   - wait
   - label: ":docker: Build Final Image"
     plugins:
-      - docker-compose#v4.14.0:
+      - docker-compose#v4.15.0:
           build: myservice
           image-name: buildkite-build-${BUILDKITE_BUILD_NUMBER}
           image-repository: index.docker.io/myorg/myrepo
@@ -404,7 +404,7 @@ A basic pipeline similar to the following:
 steps:
   - label: ":docker: Run & Push"
     plugins:
-      - docker-compose#v4.14.0:
+      - docker-compose#v4.15.0:
           run: myservice
           push: myservice
 ```
@@ -419,7 +419,7 @@ A basic pipeline similar to the following:
 steps:
   - label: ":docker: Build & Push"
     plugins:
-      - docker-compose#v4.14.0:
+      - docker-compose#v4.15.0:
           build: myservice
           push: myservice
 ```

--- a/README.md
+++ b/README.md
@@ -432,11 +432,11 @@ Pull down multiple pre-built images. By default only the service that is being r
 
 ### `collapse-run-log-group` (optional, boolean, run only)
 
-Whether to collapse or expand the log group that is created for the output of `docker-compose run`. When this setting is `true`, the output is collected into a `---` group, when `false` the output is collected into a `+++` group. Setting this to `false` can be useful to highlight your command's output if it does not create its own `+++` group.
+Whether to collapse or expand the log group that is created for the output of `docker-compose run`. When this setting is `true`, the output is collected into a `---` group, when `false` the output is collected into a `+++` group. Setting this to `true` can be useful to de-emphasize plugin output if your command creates its own `+++` group.
 
 For more information see [Managing log output](https://buildkite.com/docs/pipelines/managing-log-output).
 
-Default `true`
+Default `false`
 
 ### `config` (optional)
 

--- a/README.md
+++ b/README.md
@@ -430,6 +430,14 @@ Will cause the image to be pushed twice (once by the build step and another by t
 
 Pull down multiple pre-built images. By default only the service that is being run will be pulled down, but this allows multiple images to be specified to handle prebuilt dependent images. Note that pulling will be skipped if the `skip-pull` option is activated.
 
+### `collapse-run-log-group` (optional, boolean, run only)
+
+Whether to collapse or expand the log group that is created for the output of `docker-compose run`. When this setting is `true`, the output is collected into a `---` group, when `false` the output is collected into a `+++` group. Setting this to `false` can be useful to highlight your command's output if it does not create its own `+++` group.
+
+For more information see [Managing log output](https://buildkite.com/docs/pipelines/managing-log-output).
+
+Default `true`
+
 ### `config` (optional)
 
 The file name of the Docker Compose configuration file to use. Can also be a list of filenames. If `$COMPOSE_FILE` is set, it will be used if `config` is not specified.

--- a/commands/run.sh
+++ b/commands/run.sh
@@ -427,7 +427,7 @@ ensure_stopped() {
 
 trap ensure_stopped SIGINT SIGTERM SIGQUIT
 
-if [[ "${BUILDKITE_PLUGIN_DOCKER_COMPOSE_COLLAPSE_RUN_LOG_GROUP:-true}" = "true" ]]; then
+if [[ "${BUILDKITE_PLUGIN_DOCKER_COMPOSE_COLLAPSE_RUN_LOG_GROUP:-false}" = "true" ]]; then
   group_type="---"
 else
   group_type="+++"

--- a/commands/run.sh
+++ b/commands/run.sh
@@ -427,10 +427,15 @@ ensure_stopped() {
 
 trap ensure_stopped SIGINT SIGTERM SIGQUIT
 
+if [[ "${BUILDKITE_PLUGIN_DOCKER_COMPOSE_COLLAPSE_RUN_LOG_GROUP:-true}" = "true" ]]; then
+  group_type="---"
+else
+  group_type="+++"
+fi
 # Disable -e to prevent cancelling step if the command fails for whatever reason
 set +e
 ( # subshell is necessary to trap signals (compose v2 fails to stop otherwise)
-  echo "+++ :docker: Running ${display_command[*]:-} in service $run_service" >&2
+  echo "${group_type} :docker: Running ${display_command[*]:-} in service $run_service" >&2
   run_docker_compose "${run_params[@]}"
 )
 exitcode=$?

--- a/plugin.yml
+++ b/plugin.yml
@@ -37,6 +37,8 @@ configuration:
           enum: [ 1, 2 ]
     command:
       type: array
+    collapse-run-log-group:
+      type: boolean
     config:
       type: [ string, array ]
       minimum: 1

--- a/tests/run.bats
+++ b/tests/run.bats
@@ -1622,3 +1622,56 @@ export BUILDKITE_JOB_ID=1111
   assert_output --partial "env-propagation-list desired, but LIST_OF_VARS is not defined!"
   unstub buildkite-agent
 }
+
+@test "Run with collapsed run log group by default" {
+  export BUILDKITE_JOB_ID=1111
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RUN=myservice
+  export BUILDKITE_PIPELINE_SLUG=test
+  export BUILDKITE_BUILD_NUMBER=1
+  export BUILDKITE_COMMAND="echo hello world"
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CHECK_LINKED_CONTAINERS=false
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLEANUP=false
+
+  stub docker-compose \
+    "-f docker-compose.yml -p buildkite1111 build --pull myservice : echo built myservice" \
+    "-f docker-compose.yml -p buildkite1111 up -d --scale myservice=0 myservice : echo ran myservice dependencies" \
+    "-f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 --rm myservice /bin/sh -e -c 'echo hello world' : echo ran myservice"
+
+  stub buildkite-agent \
+    "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 1"
+
+  run "$PWD"/hooks/command
+
+  assert_success
+  assert_output --partial "--- :docker: Running /bin/sh -e -c 'echo hello world' in service myservice"
+  unstub docker-compose
+  unstub buildkite-agent
+}
+
+@test "Run with expanded run log group" {
+  export BUILDKITE_JOB_ID=1111
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RUN=myservice
+  export BUILDKITE_PIPELINE_SLUG=test
+  export BUILDKITE_BUILD_NUMBER=1
+  export BUILDKITE_COMMAND="echo hello world"
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CHECK_LINKED_CONTAINERS=false
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLEANUP=false
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_COLLAPSE_RUN_LOG_GROUP=false
+
+  stub docker-compose \
+    "-f docker-compose.yml -p buildkite1111 build --pull myservice : echo built myservice" \
+    "-f docker-compose.yml -p buildkite1111 up -d --scale myservice=0 myservice : echo ran myservice dependencies" \
+    "-f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 --rm myservice /bin/sh -e -c 'echo hello world' : echo ran myservice"
+
+  stub buildkite-agent \
+    "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 1"
+
+  run "$PWD"/hooks/command
+
+  assert_success
+  assert_output --partial "+++ :docker: Running /bin/sh -e -c 'echo hello world' in service myservice"
+  unstub docker-compose
+  unstub buildkite-agent
+
+
+}

--- a/tests/run.bats
+++ b/tests/run.bats
@@ -1623,7 +1623,7 @@ export BUILDKITE_JOB_ID=1111
   unstub buildkite-agent
 }
 
-@test "Run with collapsed run log group by default" {
+@test "Run with expanded run log group by default" {
   export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RUN=myservice
   export BUILDKITE_PIPELINE_SLUG=test
@@ -1631,32 +1631,6 @@ export BUILDKITE_JOB_ID=1111
   export BUILDKITE_COMMAND="echo hello world"
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CHECK_LINKED_CONTAINERS=false
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLEANUP=false
-
-  stub docker-compose \
-    "-f docker-compose.yml -p buildkite1111 build --pull myservice : echo built myservice" \
-    "-f docker-compose.yml -p buildkite1111 up -d --scale myservice=0 myservice : echo ran myservice dependencies" \
-    "-f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 --rm myservice /bin/sh -e -c 'echo hello world' : echo ran myservice"
-
-  stub buildkite-agent \
-    "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 1"
-
-  run "$PWD"/hooks/command
-
-  assert_success
-  assert_output --partial "--- :docker: Running /bin/sh -e -c 'echo hello world' in service myservice"
-  unstub docker-compose
-  unstub buildkite-agent
-}
-
-@test "Run with expanded run log group" {
-  export BUILDKITE_JOB_ID=1111
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RUN=myservice
-  export BUILDKITE_PIPELINE_SLUG=test
-  export BUILDKITE_BUILD_NUMBER=1
-  export BUILDKITE_COMMAND="echo hello world"
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CHECK_LINKED_CONTAINERS=false
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLEANUP=false
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_COLLAPSE_RUN_LOG_GROUP=false
 
   stub docker-compose \
     "-f docker-compose.yml -p buildkite1111 build --pull myservice : echo built myservice" \
@@ -1670,6 +1644,32 @@ export BUILDKITE_JOB_ID=1111
 
   assert_success
   assert_output --partial "+++ :docker: Running /bin/sh -e -c 'echo hello world' in service myservice"
+  unstub docker-compose
+  unstub buildkite-agent
+}
+
+@test "Run with collapsed run log group" {
+  export BUILDKITE_JOB_ID=1111
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RUN=myservice
+  export BUILDKITE_PIPELINE_SLUG=test
+  export BUILDKITE_BUILD_NUMBER=1
+  export BUILDKITE_COMMAND="echo hello world"
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CHECK_LINKED_CONTAINERS=false
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLEANUP=false
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_COLLAPSE_RUN_LOG_GROUP=true
+
+  stub docker-compose \
+    "-f docker-compose.yml -p buildkite1111 build --pull myservice : echo built myservice" \
+    "-f docker-compose.yml -p buildkite1111 up -d --scale myservice=0 myservice : echo ran myservice dependencies" \
+    "-f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 --rm myservice /bin/sh -e -c 'echo hello world' : echo ran myservice"
+
+  stub buildkite-agent \
+    "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 1"
+
+  run "$PWD"/hooks/command
+
+  assert_success
+  assert_output --partial "--- :docker: Running /bin/sh -e -c 'echo hello world' in service myservice"
   unstub docker-compose
   unstub buildkite-agent
 


### PR DESCRIPTION
By default this plugin collects the run output in a `+++` group, while the `docker` plugin collects it in a `---` group (https://github.com/buildkite-plugins/docker-buildkite-plugin/blob/36b85cc317745f868f2f6918a02f9cfb6a0b3069/commands/run.sh#L503). This PR unifies the two plugins by switching to using `---` by default.

The rationale for using `---` by default is that when we're passing lots of environment variables, volumes, etc, the `docker-compose run ...` command gets pretty long and having the log group expanded by default is noisy. Additionally, it's quite likely that the command being run will create a `+++` group of its own, so it's not necessary for the plugin to provide one by default.

For backwards compatibility, the `collapse-run-log-group` option has been added, which will restore the old behaviour.