### PR TITLE
Build simplification

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -61,7 +61,7 @@ steps:
     plugins:
       ${BUILDKITE_PULL_REQUEST_REPO:-$BUILDKITE_REPO}#${BUILDKITE_COMMIT}:
         build: helloworld
-        image-repository: "$IMAGE_REPO"
+        push: "helloworld:${IMAGE_REPO}"
         config: tests/composefiles/docker-compose.v2.0.yml
 
   - label: run after build with v2.0
@@ -83,7 +83,7 @@ steps:
     plugins:
       ${BUILDKITE_PULL_REQUEST_REPO:-$BUILDKITE_REPO}#${BUILDKITE_COMMIT}:
         build: helloworld
-        image-repository: "$IMAGE_REPO"
+        push: "helloworld:${IMAGE_REPO}"
         config: tests/composefiles/docker-compose.v2.1.yml
 
   - label: run with default command
@@ -95,42 +95,19 @@ steps:
         run: helloworld
         config: tests/composefiles/docker-compose.v2.1.yml
 
-  - label: prebuild, where service has build and image-repo
-    key: prebuild-2-1-build-image-repo
-    env:
-      PERSIST_REGISTRY: true
-    plugins:
-      ${BUILDKITE_PULL_REQUEST_REPO:-$BUILDKITE_REPO}#${BUILDKITE_COMMIT}:
-        build: helloworldimage
-        image-repository: "$IMAGE_REPO"
-        config: tests/composefiles/docker-compose.v2.1.yml
-        commmand: ["/hello"]
-
-  - label: run after prebuild
-    depends_on: prebuild-2-1-build-image-repo
-    env:
-      RESTORE_REGISTRY_FROM: prebuild-2-1-build-image-repo
-    plugins:
-      ${BUILDKITE_PULL_REQUEST_REPO:-$BUILDKITE_REPO}#${BUILDKITE_COMMIT}:
-        run: helloworldimage
-        require-prebuild: true
-        config: tests/composefiles/docker-compose.v2.1.yml
-        commmand: ["/hello"]
-
   - wait: ~
 
-  - label: prebuild with custom image-name
+  - label: prebuild with custom tag
     key: prebuild-custom-image-name
     env:
       PERSIST_REGISTRY: true
     plugins:
       ${BUILDKITE_PULL_REQUEST_REPO:-$BUILDKITE_REPO}#${BUILDKITE_COMMIT}:
         build: helloworld
-        image-repository: "$IMAGE_REPO"
-        image-name: llamas-build-${BUILDKITE_BUILD_NUMBER}
+        push: "helloworld:${IMAGE_REPO}:llamas-build-${BUILDKITE_BUILD_NUMBER}"
         config: tests/composefiles/docker-compose.v2.1.yml
 
-  - label: run after prebuild with custom image-name
+  - label: run after prebuild with custom tag
     depends_on: prebuild-custom-image-name
     env:
       RESTORE_REGISTRY_FROM: prebuild-custom-image-name
@@ -141,12 +118,11 @@ steps:
         config: tests/composefiles/docker-compose.v2.1.yml
         commmand: ["/hello"]
 
-  - label: push after build with custom image-name
+  - label: push after build with custom tag
     depends_on: prebuild-custom-image-name
     env:
       RESTORE_REGISTRY_FROM: prebuild-custom-image-name
     plugins:
       ${BUILDKITE_PULL_REQUEST_REPO:-$BUILDKITE_REPO}#${BUILDKITE_COMMIT}:
-        push: helloworld
-        image-name: llamas-build-${BUILDKITE_BUILD_NUMBER}
+        push: helloworld:${IMAGE_REPO}:llamas-build-${BUILDKITE_BUILD_NUMBER}-push
         config: tests/composefiles/docker-compose.v2.1.yml

--- a/README.md
+++ b/README.md
@@ -444,21 +444,11 @@ The file name of the Docker Compose configuration file to use. Can also be a lis
 
 Default: `docker-compose.yml`
 
-### `image-repository` (optional, build only)
-
-The repository for pushing and pulling pre-built images, same as the repository location you would use for a `docker push`, for example `"index.docker.io/myorg/myrepo"`. Each image is tagged to the specific build so you can safely share the same image repository for any number of projects and builds.
-
-The default is `""` which only builds images on the local Docker host doing the build.
-
-This option can also be configured on the agent machine using the environment variable `BUILDKITE_PLUGIN_DOCKER_COMPOSE_IMAGE_REPOSITORY`.
-
-### `image-name` (optional, build only)
-
-The name to use when tagging pre-built images. If multiple images are built in the build phase, you must provide an array of image names.
-
 ### `build-alias` (optional, build only)
 
-Other docker-compose services that should be aliased to the main service that was built. This is for when different docker-compose services share the same prebuilt image.
+Other docker-compose services that should be aliased to the service that was built. This is to have a pre-built image set for different services based off a single definitio.
+
+Important: this only works when building a single service, an error will be generated otherwise
 
 ### `args` (optional, build and run only)
 

--- a/commands/build.sh
+++ b/commands/build.sh
@@ -1,9 +1,7 @@
 #!/bin/bash
 set -ueo pipefail
 
-image_repository="$(plugin_read_config IMAGE_REPOSITORY)"
 pull_retries="$(plugin_read_config PULL_RETRIES "0")"
-push_retries="$(plugin_read_config PUSH_RETRIES "0")"
 separator="$(plugin_read_config SEPARATOR_CACHE_FROM ":")"
 override_file="docker-compose.buildkite-${BUILDKITE_BUILD_NUMBER}-override.yml"
 build_images=()
@@ -45,11 +43,6 @@ named_array_values() {
   local copy=( "${!tmp}" )
   echo "${copy[@]}"
 }
-
-if [[ -z "$image_repository" ]] ; then
-  echo "+++ ⚠️ Build step missing image-repository setting"
-  echo "This build step has no image-repository set. Without an image-repository, the Docker image won't be pushed to a repository, and won't be automatically used by any run steps."
-fi
 
 if [[ "$(plugin_read_config BUILDKIT "false")" == "true" ]]; then
   export DOCKER_BUILDKIT=1
@@ -113,32 +106,23 @@ fi
 # write into a docker-compose override file
 service_idx=0
 for service_name in $(plugin_read_list BUILD) ; do
-  image_name=$(build_image_name "${service_name}" "${service_idx}")
-
-  if ! validate_tag "$image_name"; then
-    echo "🚨 ${image_name} is not a valid tag name"
-    exit 1
-  fi
-
   service_idx=$((service_idx+1))
-
-  if [[ -n "$image_repository" ]] ; then
-    image_name="${image_repository}:${image_name}"
-  fi
-
-  build_images+=("$service_name" "$image_name")
+  image_name="" # no longer used here
 
   cache_from_var="$(service_name_cache_from_var "${service_name}")"
   if [[ -n "${!cache_from_var-}" ]]; then
     cache_from_length="$(count_of_named_array "${cache_from_var}")"
-    build_images+=("${cache_from_length}")
+  else
+    cache_from_length=0
+  fi
+
+  if [[ "${cache_from_length:-0}" -gt 0 ]]; then
+    build_images+=("$service_name" "${image_name}" "${cache_from_length}")
 
     for i in $(seq 0 "$((cache_from_length-1))"); do
       cache_from_group_var="$(service_name_group_name_cache_from_var "$service_name" "$i")"
       build_images+=("${!cache_from_group_var}")
     done
-  else
-    build_images+=(0)
   fi
 done
 
@@ -197,23 +181,4 @@ while read -r arg ; do
 done <<< "$(plugin_read_list ARGS)"
 
 echo "${group_type} :docker: Building services ${services[*]}"
-run_docker_compose -f "$override_file" "${build_params[@]}" "${services[@]}"
-
-if [[ -n "$image_repository" ]] ; then
-  echo "~~~ :docker: Pushing built images to $image_repository"
-  retry "$push_retries" run_docker_compose -f "$override_file" push "${services[@]}"
-
-  # iterate over build images
-  while [[ ${#build_images[@]} -gt 0 ]] ; do
-    set_prebuilt_image "${build_images[0]}" "${build_images[1]}"
-
-    # set aliases
-    for service_alias in $(plugin_read_list BUILD_ALIAS) ; do
-      set_prebuilt_image "$service_alias" "${build_images[1]}"
-    done
-
-    # pop-off the last build image
-    # 3 for service, image, num_cache_from; plus num_cache_from
-    build_images=("${build_images[@]:(3 + ${build_images[2]})}")
-  done
-fi
+run_docker_compose "${build_params[@]}" "${services[@]}"

--- a/commands/build.sh
+++ b/commands/build.sh
@@ -51,11 +51,6 @@ if [[ "$(plugin_read_config BUILDKIT "false")" == "true" ]]; then
   export BUILDKIT_PROGRESS=plain
 fi
 
-if [[ -n "$(plugin_read_config TARGET "")" ]] && [[ -z "$(plugin_read_config BUILD "")" ]]; then
-  echo "+++ 🚨 You can not use target if you are not building a single service"
-  exit 1
-fi
-
 # Read any cache-from parameters provided and pull down those images first
 # If no-cache is set skip pulling the cache-from images
 if [[ "$(plugin_read_config NO_CACHE "false")" == "false" ]] ; then

--- a/commands/push.sh
+++ b/commands/push.sh
@@ -36,12 +36,7 @@ for line in $(plugin_read_list PUSH) ; do
     echo "~~~ :docker: Service has an image configuration: ${service_image}"
   elif in_array "${service_name}" "${build_services[@]}"; then
     echo "~~~ :docker: Service was built in this step, using that image"
-    service_image="$(default_compose_image_for_service)"
-    if ! docker_image_exists "${service_image}"; then
-      echo '+++ 🚨 Could not find service image for service to push'
-      echo 'If you are using Docker Compose CLI v1, please ensure it is not a wrapper for v2'
-      exit 1
-    fi
+    service_image="$(default_compose_image_for_service "${service_name}")"
   elif prebuilt_image="$(get_prebuilt_image "$service_name")"; then
     echo "~~~ :docker: Using pre-built image ${prebuilt_image}"
 
@@ -55,6 +50,12 @@ for line in $(plugin_read_list PUSH) ; do
     service_image="${prebuilt_image}"
   else
     echo "+++ 🚨 No prebuilt-image nor built image found for service to push"
+    exit 1
+  fi
+
+  if ! docker_image_exists "${service_image}"; then
+    echo "+++ 🚨 Could not find image for service to push: ${service_image}"
+    echo 'If you are using Docker Compose CLI v1, please ensure it is not a wrapper for v2'
     exit 1
   fi
 

--- a/commands/push.sh
+++ b/commands/push.sh
@@ -27,7 +27,9 @@ for line in $(plugin_read_list PUSH) ; do
   service_name=${tokens[0]}
   service_image=$(compose_image_for_service "$service_name")
 
-  if prebuilt_image="$(get_prebuilt_image "$service_name")"; then
+  if docker_image_exists "${service_image}"; then
+    echo "~~~ :docker: Using service image ${service_image} from Docker Compose config"
+  elif prebuilt_image="$(get_prebuilt_image "$service_name")"; then
     echo "~~~ :docker: Using pre-built image ${prebuilt_image}"
 
     # Only pull it down once
@@ -38,8 +40,6 @@ for line in $(plugin_read_list PUSH) ; do
     fi
 
     service_image="${prebuilt_image}"
-  elif docker_image_exists "${service_image}"; then
-    echo "~~~ :docker: Using service image ${service_image} from Docker Compose config"
   else
     echo "+++ 🚨 No prebuilt-image nor service image found for service to push"
     exit 1

--- a/commands/push.sh
+++ b/commands/push.sh
@@ -47,9 +47,10 @@ for line in $(plugin_read_list PUSH) ; do
 
   # push: "service-name"
   if [[ ${#tokens[@]} -eq 1 ]] ; then
-    echo "~~~ :docker: Pushing images for ${service_name}" >&2;
+    echo "${group_type} :docker: Pushing images for ${service_name}" >&2;
     retry "$push_retries" run_docker_compose push "${service_name}"
     set_prebuilt_image "${service_name}" "${service_image}"
+    target_image="${service_image}" # necessary for build-alias
   # push: "service-name:repo:tag"
   else
     target_image="$(IFS=:; echo "${tokens[*]:1}")"
@@ -62,8 +63,8 @@ done
 
 # single image build
 for service_alias in $(plugin_read_list BUILD_ALIAS) ; do
-  if [ -n "${BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD}" ]; then
-    echo "+++ 🚨 You can not use build-alias if you are not building a single service"
+  if [ -z "${BUILDKITE_PLUGIN_DOCKER_COMPOSE_PUSH}" ]; then
+    echo "+++ 🚨 You can not use build-alias if you are not pushing a single service"
     exit 1
   fi
 

--- a/commands/push.sh
+++ b/commands/push.sh
@@ -27,15 +27,6 @@ for line in $(plugin_read_list PUSH) ; do
   service_name=${tokens[0]}
   service_image=$(compose_image_for_service "$service_name")
 
-  # push in the form of service:repo:tag
-  # if the registry contains a port this means that the tag is mandatory
-  if [[ ${#tokens[@]} -gt 2 ]]; then 
-    if ! validate_tag "${tokens[-1]}"; then
-      echo "🚨 specified image to push ${line} has an invalid tag so it will be ignored"
-      continue
-    fi
-  fi
-
   if prebuilt_image="$(get_prebuilt_image "$service_name")"; then
     echo "~~~ :docker: Using pre-built image ${prebuilt_image}"
 

--- a/commands/run.sh
+++ b/commands/run.sh
@@ -43,7 +43,7 @@ prebuilt_services=()
 for service_name in "${prebuilt_candidates[@]}" ; do
   if prebuilt_image=$(get_prebuilt_image "$service_name") ; then
     echo "~~~ :docker: Found a pre-built image for $service_name"
-    prebuilt_service_overrides+=("$service_name" "$prebuilt_image" 0)
+    prebuilt_service_overrides+=("$service_name" "$prebuilt_image" "" 0)
     prebuilt_services+=("$service_name")
 
     # If it's prebuilt, we need to pull it down

--- a/hooks/pre-exit
+++ b/hooks/pre-exit
@@ -8,6 +8,9 @@ DIR="$(cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd)"
 # shellcheck source=lib/metadata.bash
 . "$DIR/../lib/metadata.bash"
 
+# remove build override files
+rm -f "docker-compose.buildkite-${BUILDKITE_BUILD_NUMBER}-override.yml"
+
 # clean up resources after a run command. we do this here so that it will
 # run after a job is cancelled
 if [[ -n "$(plugin_read_list RUN)" ]] && [[ "$(plugin_read_config CLEANUP "true")" == "true" ]] ; then

--- a/lib/push.bash
+++ b/lib/push.bash
@@ -10,11 +10,6 @@ compose_image_for_service() {
     | grep -oE '  image: (.+)' \
     | awk '{print $2}')
 
-  if [[ -z "$image" ]] ; then
-    default_compose_image_for_service "$service"
-    return
-  fi
-
   echo "$image"
 }
 

--- a/lib/shared.bash
+++ b/lib/shared.bash
@@ -161,10 +161,32 @@ function build_image_override_file_with_version() {
 
   shift
   while test ${#} -gt 0 ; do
-    printf "  %s:\\n" "$1"
-    printf "    image: %s\\n" "$2"
+    service_name=$1
+    image_name=$2
+    target=$3
+    cache_from_amt=$4
+    shift 4
 
-    if [[ "$3" -gt 0 ]] ; then
+    if [[ -z "$image_name" ]] && [[ -z "$target" ]] && [[ "$cache_from_amt" -eq 0 ]]; then
+      # should not print out an empty service
+      continue
+    fi
+
+    printf "  %s:\\n" "$service_name"
+
+    if [[ -n "$image_name" ]]; then
+      printf "    image: %s\\n" "$image_name"
+    fi
+
+    if [[ "$cache_from_amt" -gt 0 ]] || [[ -n "$target" ]]; then
+      printf "    build:\\n"
+    fi
+
+    if [[ -n "$target" ]]; then
+      printf "      target: %s\\n" "$target"
+    fi
+
+    if [[ "$cache_from_amt" -gt 0 ]] ; then
       if ! docker_compose_supports_cache_from "$version" ; then
         echo "Unsupported Docker Compose config file version: $version"
         echo "The 'cache_from' option can only be used with Compose file versions 2.2 or 3.2 and above."
@@ -173,15 +195,12 @@ function build_image_override_file_with_version() {
         exit 1
       fi
 
-      printf "    build:\\n"
       printf "      cache_from:\\n"
-      for cache_from_i in $(seq 4 "$((3 + $3))"); do
+      for cache_from_i in $(seq 1 "$cache_from_amt"); do
         printf "        - %s\\n" "${!cache_from_i}"
       done
-      shift "$3"
+      shift "$cache_from_amt"
     fi
-
-    shift 3
   done
 }
 

--- a/lib/shared.bash
+++ b/lib/shared.bash
@@ -214,20 +214,6 @@ function run_docker_compose() {
   plugin_prompt_and_run "${command[@]}" "$@"
 }
 
-# Create an image name that is used to tag custom images
-function build_image_name() {
-  local service_name="$1"
-  local service_idx="$2"
-  local image_names=()
-
-  while read -r name ; do
-    image_names+=("$name")
-  done <<< "$(plugin_read_list IMAGE_NAME)"
-
-  # Either look in custom image_name values, or use our default
-  echo "${image_names[$service_idx]:-${BUILDKITE_PIPELINE_SLUG}-${service_name}-build-${BUILDKITE_BUILD_NUMBER}}"
-}
-
 function in_array() {
   local e
   for e in "${@:2}"; do [[ "$e" == "$1" ]] && return 0; done

--- a/plugin.yml
+++ b/plugin.yml
@@ -56,10 +56,6 @@ configuration:
       type: string
     expand-volume-vars:
       type: boolean
-    image-repository:
-      type: string
-    image-name:
-      type: [ string, array ]
     leave-volumes:
       type: boolean
     mount-buildkite-agent:

--- a/tests/build.bats
+++ b/tests/build.bats
@@ -8,7 +8,7 @@ load '../lib/shared'
 
 teardown() {
   # some test failures may leave this file around
-  rm -f docker-compose.buildkite-1-override.yml
+  rm -f docker-compose.buildkite*-override.yml
 }
 
 @test "Build without a repository" {

--- a/tests/build.bats
+++ b/tests/build.bats
@@ -4,8 +4,12 @@ load "${BATS_PLUGIN_PATH}/load.bash"
 load '../lib/shared'
 
 # export DOCKER_COMPOSE_STUB_DEBUG=/dev/stdout
-# export BUILDKITE_AGENT_STUB_DEBUG=/dev/stdout
 # export BATS_MOCK_TMPDIR=$PWD
+
+teardown() {
+  # some test failures may leave this file around
+  rm -f docker-compose.buildkite-1-override.yml
+}
 
 @test "Build without a repository" {
   export BUILDKITE_JOB_ID=1111
@@ -95,107 +99,73 @@ load '../lib/shared'
 @test "Build with a repository" {
   export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD=myservice
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_IMAGE_REPOSITORY=my.repository/llamas
   export BUILDKITE_PIPELINE_SLUG=test
   export BUILDKITE_BUILD_NUMBER=1
 
   stub docker-compose \
-    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml build --pull myservice : echo built myservice" \
-    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml push myservice : echo pushed myservice" \
-
-  stub buildkite-agent \
-    "meta-data set docker-compose-plugin-built-image-tag-myservice my.repository/llamas:test-myservice-build-1 : echo set image metadata for myservice"
+    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml build --pull myservice : echo built myservice"
 
   run "$PWD"/hooks/command
 
   assert_success
   assert_output --partial "built myservice"
-  assert_output --partial "pushed myservice"
-  assert_output --partial "set image metadata for myservice"
+
   unstub docker-compose
-  unstub buildkite-agent
 }
 
 @test "Build with a repository and multiple build aliases" {
   export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD=myservice
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_IMAGE_REPOSITORY=my.repository/llamas
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD_ALIAS_0=myservice-1
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD_ALIAS_1=myservice-2
   export BUILDKITE_PIPELINE_SLUG=test
   export BUILDKITE_BUILD_NUMBER=1
 
   stub docker-compose \
-    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml build --pull myservice : echo built myservice" \
-    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml push myservice : echo pushed myservice" \
-
-  stub buildkite-agent \
-    "meta-data set docker-compose-plugin-built-image-tag-myservice my.repository/llamas:test-myservice-build-1 : echo set image metadata for myservice" \
-    "meta-data set docker-compose-plugin-built-image-tag-myservice-1 my.repository/llamas:test-myservice-build-1 : echo set image metadata for myservice-1" \
-    "meta-data set docker-compose-plugin-built-image-tag-myservice-2 my.repository/llamas:test-myservice-build-1 : echo set image metadata for myservice-2"
+    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml build --pull myservice : echo built myservice"
 
   run "$PWD"/hooks/command
 
   assert_success
   assert_output --partial "built myservice"
-  assert_output --partial "pushed myservice"
-  assert_output --partial "set image metadata for myservice"
-  assert_output --partial "set image metadata for myservice-1"
-  assert_output --partial "set image metadata for myservice-2"
+
   unstub docker-compose
-  unstub buildkite-agent
 }
 
 @test "Build with a repository and push retries" {
   export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD=myservice
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_IMAGE_REPOSITORY=my.repository/llamas
   export BUILDKITE_PIPELINE_SLUG=test
   export BUILDKITE_BUILD_NUMBER=1
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_PUSH_RETRIES=3
 
   stub docker-compose \
-    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml build --pull myservice : echo built myservice" \
-    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml push myservice : exit 1" \
-    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml push myservice : exit 1" \
-    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml push myservice : echo pushed myservice" \
-
-  stub buildkite-agent \
-    "meta-data set docker-compose-plugin-built-image-tag-myservice my.repository/llamas:test-myservice-build-1 : echo set image metadata for myservice"
+    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml build --pull myservice : echo built myservice"
 
   run "$PWD"/hooks/command
 
   assert_success
   assert_output --partial "built myservice"
-  assert_output --partial "pushed myservice"
-  assert_output --partial "set image metadata for myservice"
+
   unstub docker-compose
-  unstub buildkite-agent
 }
 
 @test "Build with a repository and custom config file" {
   export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD=myservice
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CONFIG=tests/composefiles/docker-compose.v2.0.yml
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_IMAGE_REPOSITORY=my.repository/llamas
   export BUILDKITE_PIPELINE_SLUG=test
   export BUILDKITE_BUILD_NUMBER=1
 
   stub docker-compose \
-    "-f tests/composefiles/docker-compose.v2.0.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml build --pull myservice : echo built myservice" \
-    "-f tests/composefiles/docker-compose.v2.0.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml push myservice : echo pushed myservice" \
-
-  stub buildkite-agent \
-    "meta-data set docker-compose-plugin-built-image-tag-myservice-tests/composefiles/docker-compose.v2.0.yml my.repository/llamas:test-myservice-build-1 : echo set image metadata for myservice"
+    "-f tests/composefiles/docker-compose.v2.0.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml build --pull myservice : echo built myservice"
 
   run "$PWD"/hooks/command
 
   assert_success
   assert_output --partial "built myservice"
-  assert_output --partial "pushed myservice"
-  assert_output --partial "set image metadata for myservice"
+
   unstub docker-compose
-  unstub buildkite-agent
 }
 
 @test "Build with a repository and multiple custom config files" {
@@ -203,52 +173,36 @@ load '../lib/shared'
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD=myservice
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CONFIG_0=tests/composefiles/docker-compose.v2.0.yml
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CONFIG_1=tests/composefiles/docker-compose.v2.1.yml
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_IMAGE_REPOSITORY=my.repository/llamas
   export BUILDKITE_PIPELINE_SLUG=test
   export BUILDKITE_BUILD_NUMBER=1
 
   stub docker-compose \
-    "-f tests/composefiles/docker-compose.v2.0.yml -f tests/composefiles/docker-compose.v2.1.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml build --pull myservice : echo built myservice" \
-    "-f tests/composefiles/docker-compose.v2.0.yml -f tests/composefiles/docker-compose.v2.1.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml push myservice : echo pushed myservice" \
-
-  stub buildkite-agent \
-    "meta-data set docker-compose-plugin-built-image-tag-myservice-tests/composefiles/docker-compose.v2.0.yml-tests/composefiles/docker-compose.v2.1.yml my.repository/llamas:test-myservice-build-1 : echo set image metadata for myservice"
+    "-f tests/composefiles/docker-compose.v2.0.yml -f tests/composefiles/docker-compose.v2.1.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml build --pull myservice : echo built myservice"
 
   run "$PWD"/hooks/command
 
   assert_success
   assert_output --partial "built myservice"
-  assert_output --partial "pushed myservice"
-  assert_output --partial "set image metadata for myservice"
+
   unstub docker-compose
-  unstub buildkite-agent
 }
 
 @test "Build with a repository and multiple services" {
   export BUILDKITE_JOB_ID=1112
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD_0=myservice1
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD_1=myservice2
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_IMAGE_REPOSITORY=my.repository/llamas
   export BUILDKITE_PIPELINE_SLUG=test
   export BUILDKITE_BUILD_NUMBER=1
 
   stub docker-compose \
-    "-f docker-compose.yml -p buildkite1112 -f docker-compose.buildkite-1-override.yml build --pull myservice1 myservice2 : echo built all services" \
-    "-f docker-compose.yml -p buildkite1112 -f docker-compose.buildkite-1-override.yml push myservice1 myservice2 : echo pushed all services" \
-
-  stub buildkite-agent \
-    "meta-data set docker-compose-plugin-built-image-tag-myservice1 my.repository/llamas:test-myservice1-build-1 : echo set image metadata for myservice1" \
-    "meta-data set docker-compose-plugin-built-image-tag-myservice2 my.repository/llamas:test-myservice2-build-1 : echo set image metadata for myservice2"
+    "-f docker-compose.yml -p buildkite1112 build --pull myservice1 myservice2 : echo built all services"
 
   run "$PWD"/hooks/command
 
   assert_success
   assert_output --partial "built all services"
-  assert_output --partial "pushed all services"
-  assert_output --partial "set image metadata for myservice1"
-  assert_output --partial "set image metadata for myservice2"
+
   unstub docker-compose
-  unstub buildkite-agent
 }
 
 @test "Build with a docker-compose v1.0 configuration file" {
@@ -682,128 +636,9 @@ load '../lib/shared'
   assert_output --partial "pulled cache image"
   assert_output --partial "- my.repository/myservice_cache:latest"
   assert_output --partial "built helloworld"
+
   unstub docker
   unstub docker-compose
-}
-
-@test "Build with a custom image-name" {
-  export BUILDKITE_JOB_ID=1111
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD=myservice
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_IMAGE_NAME=my-llamas-image
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_IMAGE_REPOSITORY=my.repository/llamas
-  export BUILDKITE_PIPELINE_SLUG=test
-  export BUILDKITE_BUILD_NUMBER=1
-
-  stub docker-compose \
-    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml build --pull myservice : echo built myservice" \
-    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml push myservice : echo pushed myservice" \
-
-  stub buildkite-agent \
-    "meta-data set docker-compose-plugin-built-image-tag-myservice my.repository/llamas:my-llamas-image : echo set image metadata for myservice"
-
-  run "$PWD"/hooks/command
-
-  assert_success
-  assert_output --partial "built myservice"
-  assert_output --partial "pushed myservice"
-  assert_output --partial "set image metadata for myservice"
-  unstub docker-compose
-  unstub buildkite-agent
-}
-
-@test "Build with an invalid image-name (start with hyphen) " {
-  export BUILDKITE_JOB_ID=1111
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD=myservice
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_IMAGE_NAME=-llamas-image
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_IMAGE_REPOSITORY=my.repository/llamas
-  export BUILDKITE_BUILD_NUMBER=1
-
-  run "$PWD"/hooks/command
-
-  assert_failure
-  assert_output --partial "-llamas-image is not a valid tag name"
-}
-
-@test "Build with an invalid image-name (start with period) " {
-  export BUILDKITE_JOB_ID=1111
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD=myservice
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_IMAGE_NAME=.llamas-image
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_IMAGE_REPOSITORY=my.repository/llamas
-  export BUILDKITE_BUILD_NUMBER=1
-
-  run "$PWD"/hooks/command
-
-  assert_failure
-  assert_output --partial ".llamas-image is not a valid tag name"
-}
-
-@test "Build with an invalid image-name (too long) " {
-  export BUILDKITE_JOB_ID=1111
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD=myservice
-  # shellcheck disable=SC2155 # numbers from 1 to 69 result in 129 characters
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_IMAGE_NAME="$(seq 69 | tr -d "\n")"
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_IMAGE_REPOSITORY=my.repository/llamas
-  export BUILDKITE_BUILD_NUMBER=1
-
-  run "$PWD"/hooks/command
-
-  assert_failure
-  assert_output --partial "is not a valid tag name"
-}
-
-@test "Build with a custom image-name and a config" {
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CONFIG="tests/composefiles/docker-compose.v3.2.yml"
-  export BUILDKITE_JOB_ID=1111
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD=myservice
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_IMAGE_NAME=my-llamas-image
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_IMAGE_REPOSITORY=my.repository/llamas
-  export BUILDKITE_PIPELINE_SLUG=test
-  export BUILDKITE_BUILD_NUMBER=1
-
-  stub docker-compose \
-    "-f tests/composefiles/docker-compose.v3.2.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml build --pull myservice : echo built myservice" \
-    "-f tests/composefiles/docker-compose.v3.2.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml push myservice : echo pushed myservice" \
-
-  stub buildkite-agent \
-    "meta-data set docker-compose-plugin-built-image-tag-myservice-tests/composefiles/docker-compose.v3.2.yml my.repository/llamas:my-llamas-image : echo set image metadata for myservice"
-
-  run "$PWD"/hooks/command
-
-  assert_success
-  assert_output --partial "built myservice"
-  assert_output --partial "pushed myservice"
-  assert_output --partial "set image metadata for myservice"
-  unstub docker-compose
-  unstub buildkite-agent
-}
-
-@test "Build multiple images with custom image-names" {
-  export BUILDKITE_JOB_ID=1112
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD_0=myservice1
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD_1=myservice2
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_IMAGE_NAME_0=my-llamas-image-1
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_IMAGE_NAME_1=my-llamas-image-2
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_IMAGE_REPOSITORY=my.repository/llamas
-  export BUILDKITE_PIPELINE_SLUG=test
-  export BUILDKITE_BUILD_NUMBER=1
-
-  stub docker-compose \
-    "-f docker-compose.yml -p buildkite1112 -f docker-compose.buildkite-1-override.yml build --pull myservice1 myservice2 : echo built all services" \
-    "-f docker-compose.yml -p buildkite1112 -f docker-compose.buildkite-1-override.yml push myservice1 myservice2 : echo pushed all services" \
-
-  stub buildkite-agent \
-    "meta-data set docker-compose-plugin-built-image-tag-myservice1 my.repository/llamas:my-llamas-image-1 : echo set image metadata for myservice1" \
-    "meta-data set docker-compose-plugin-built-image-tag-myservice2 my.repository/llamas:my-llamas-image-2 : echo set image metadata for myservice2"
-
-  run "$PWD"/hooks/command
-
-  assert_success
-  assert_output --partial "built all services"
-  assert_output --partial "pushed all services"
-  assert_output --partial "set image metadata for myservice1"
-  assert_output --partial "set image metadata for myservice2"
-  unstub docker-compose
-  unstub buildkite-agent
 }
 
 @test "Build with target" {

--- a/tests/build.bats
+++ b/tests/build.bats
@@ -114,26 +114,6 @@ teardown() {
   unstub docker-compose
 }
 
-# TODO: move this to push testing
-@test "Build with a repository and multiple build aliases" {
-  export BUILDKITE_JOB_ID=1111
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD=myservice
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD_ALIAS_0=myservice-1
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD_ALIAS_1=myservice-2
-  export BUILDKITE_PIPELINE_SLUG=test
-  export BUILDKITE_BUILD_NUMBER=1
-
-  stub docker-compose \
-    "-f docker-compose.yml -p buildkite1111 build --pull myservice : echo built myservice"
-
-  run "$PWD"/hooks/command
-
-  assert_success
-  assert_output --partial "built myservice"
-
-  unstub docker-compose
-}
-
 @test "Build with a repository and push retries" {
   export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD=myservice

--- a/tests/build.bats
+++ b/tests/build.bats
@@ -18,13 +18,14 @@ teardown() {
   export BUILDKITE_BUILD_NUMBER=1
 
   stub docker-compose \
-    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml build --pull myservice : echo built myservice"
+    "-f docker-compose.yml -p buildkite1111 build --pull myservice : echo built myservice"
 
   run "$PWD"/hooks/command
 
-  unstub docker-compose
   assert_success
   assert_output --partial "built myservice"
+
+  unstub docker-compose
 }
 
 @test "Build with no-cache" {
@@ -35,7 +36,7 @@ teardown() {
   export BUILDKITE_BUILD_NUMBER=1
 
   stub docker-compose \
-    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml build --pull --no-cache myservice : echo built myservice"
+    "-f docker-compose.yml -p buildkite1111 build --pull --no-cache myservice : echo built myservice"
 
   run "$PWD"/hooks/command
 
@@ -52,7 +53,7 @@ teardown() {
   export BUILDKITE_BUILD_NUMBER=1
 
   stub docker-compose \
-    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml build --pull --parallel myservice : echo built myservice"
+    "-f docker-compose.yml -p buildkite1111 build --pull --parallel myservice : echo built myservice"
 
   run "$PWD"/hooks/command
 
@@ -70,7 +71,7 @@ teardown() {
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_ARGS_1=MYARG=1
 
   stub docker-compose \
-    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml build --pull --build-arg MYARG=0 --build-arg MYARG=1 myservice : echo built myservice"
+    "-f docker-compose.yml -p buildkite1111 build --pull --build-arg MYARG=0 --build-arg MYARG=1 myservice : echo built myservice"
 
   run "$PWD"/hooks/command
 
@@ -87,7 +88,7 @@ teardown() {
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLI_VERSION=1
 
   stub docker-compose \
-    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml build --pull myservice : echo built myservice"
+    "-f docker-compose.yml -p buildkite1111 build --pull myservice : echo built myservice"
 
   run "$PWD"/hooks/command
 
@@ -103,7 +104,7 @@ teardown() {
   export BUILDKITE_BUILD_NUMBER=1
 
   stub docker-compose \
-    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml build --pull myservice : echo built myservice"
+    "-f docker-compose.yml -p buildkite1111 build --pull myservice : echo built myservice"
 
   run "$PWD"/hooks/command
 
@@ -113,6 +114,7 @@ teardown() {
   unstub docker-compose
 }
 
+# TODO: move this to push testing
 @test "Build with a repository and multiple build aliases" {
   export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD=myservice
@@ -122,7 +124,7 @@ teardown() {
   export BUILDKITE_BUILD_NUMBER=1
 
   stub docker-compose \
-    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml build --pull myservice : echo built myservice"
+    "-f docker-compose.yml -p buildkite1111 build --pull myservice : echo built myservice"
 
   run "$PWD"/hooks/command
 
@@ -140,7 +142,7 @@ teardown() {
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_PUSH_RETRIES=3
 
   stub docker-compose \
-    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml build --pull myservice : echo built myservice"
+    "-f docker-compose.yml -p buildkite1111 build --pull myservice : echo built myservice"
 
   run "$PWD"/hooks/command
 
@@ -158,7 +160,7 @@ teardown() {
   export BUILDKITE_BUILD_NUMBER=1
 
   stub docker-compose \
-    "-f tests/composefiles/docker-compose.v2.0.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml build --pull myservice : echo built myservice"
+    "-f tests/composefiles/docker-compose.v2.0.yml -p buildkite1111 build --pull myservice : echo built myservice"
 
   run "$PWD"/hooks/command
 
@@ -177,7 +179,7 @@ teardown() {
   export BUILDKITE_BUILD_NUMBER=1
 
   stub docker-compose \
-    "-f tests/composefiles/docker-compose.v2.0.yml -f tests/composefiles/docker-compose.v2.1.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml build --pull myservice : echo built myservice"
+    "-f tests/composefiles/docker-compose.v2.0.yml -f tests/composefiles/docker-compose.v2.1.yml -p buildkite1111 build --pull myservice : echo built myservice"
 
   run "$PWD"/hooks/command
 
@@ -212,10 +214,15 @@ teardown() {
   export BUILDKITE_PIPELINE_SLUG=test
   export BUILDKITE_BUILD_NUMBER=1
 
+  stub docker-compose \
+    "-f tests/composefiles/docker-compose.v1.0.yml -p buildkite1112 build --pull helloworld : echo built service"
+
   run "$PWD"/hooks/command
 
-  assert_failure
-  assert_output --partial "Compose file versions 2.0 and above"
+  assert_success
+  assert_output --partial "built service"
+
+  unstub docker-compose
 }
 
 @test "Build with a cache-from image" {
@@ -278,7 +285,7 @@ teardown() {
   export BUILDKITE_BUILD_NUMBER=1
 
   stub docker-compose \
-    "-f tests/composefiles/docker-compose.v3.2.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml build --pull --no-cache helloworld : echo built helloworld"
+    "-f tests/composefiles/docker-compose.v3.2.yml -p buildkite1111 build --pull --no-cache helloworld : echo built helloworld"
 
   run "$PWD"/hooks/command
 
@@ -298,7 +305,7 @@ teardown() {
   export BUILDKITE_BUILD_NUMBER=1
 
   stub docker-compose \
-    "-f tests/composefiles/docker-compose.v3.2.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml build --pull helloworld : echo built helloworld"
+    "-f tests/composefiles/docker-compose.v3.2.yml -p buildkite1111 build --pull helloworld : echo built helloworld"
 
   run "$PWD"/hooks/command
 
@@ -552,7 +559,7 @@ teardown() {
     "pull my.repository/myservice_cache:latest : exit 1"
 
   stub docker-compose \
-    "-f tests/composefiles/docker-compose.v3.2.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml build --pull helloworld : echo built helloworld"
+    "-f tests/composefiles/docker-compose.v3.2.yml -p buildkite1111 build --pull helloworld : echo built helloworld"
 
   run "$PWD"/hooks/command
 
@@ -650,13 +657,13 @@ teardown() {
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_TARGET=intermediate
 
   stub docker-compose \
-    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml build --pull --target \* \* : echo built \${11} with target \${10}"
+    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml build --pull \* : echo built \${9}"
 
   run "$PWD"/hooks/command
 
   assert_success
   assert_output --partial "built myservice"
-  assert_output --partial "with target intermediate"
+  assert_output --partial "    target: intermediate"
 
   unstub docker-compose
 }
@@ -686,7 +693,7 @@ teardown() {
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_SSH=true
 
   stub docker-compose \
-    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml build --pull --ssh default \* : echo built \${11} with ssh"
+    "-f docker-compose.yml -p buildkite1111 build --pull --ssh default \* : echo built \${9} with ssh"
 
   run "$PWD"/hooks/command
 
@@ -707,7 +714,7 @@ teardown() {
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_SSH=context
 
   stub docker-compose \
-    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml build --pull --ssh context \* : echo built \${11} with ssh"
+    "-f docker-compose.yml -p buildkite1111 build --pull --ssh context \* : echo built \${9} with ssh"
 
   run "$PWD"/hooks/command
 
@@ -728,7 +735,7 @@ teardown() {
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_SECRETS_1='id=SECRET_VAR'
 
   stub docker-compose \
-    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml build --pull --secret \* --secret \* \* : echo built \${13} with secrets \${10} and \${12}"
+    "-f docker-compose.yml -p buildkite1111 build --pull --secret \* --secret \* \* : echo built \${11} with secrets \${8} and \${10}"
 
   run "$PWD"/hooks/command
 
@@ -747,7 +754,7 @@ teardown() {
   export BUILDKITE_BUILD_NUMBER=1
 
   stub docker-compose \
-    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml build myservice : echo built myservice"
+    "-f docker-compose.yml -p buildkite1111 build myservice : echo built myservice"
 
   run "$PWD"/hooks/command
 

--- a/tests/docker-compose-images.bats
+++ b/tests/docker-compose-images.bats
@@ -42,50 +42,42 @@ setup() {
   run compose_image_for_service "helper"
 
   assert_success
-  assert_output "buildkite_helper"
+  assert_output ""
 
   unstub docker-compose
 }
 
-@test "Image for compose v2 service without an image in config" {
+@test "Default image for compose service" {
+  run default_compose_image_for_service "helper"
+
+  assert_success
+  assert_output "buildkite_helper"
+}
+
+@test "Default image for compose v2 service" {
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLI_VERSION=2
 
-  stub docker \
-    "compose -f docker-compose.yml -p buildkite config : cat $PWD/tests/composefiles/docker-compose.config.v3.2.yml"
-
-  run compose_image_for_service "helper"
+  run default_compose_image_for_service "helper"
 
   assert_success
   assert_output "buildkite-helper"
-
-  unstub docker
 }
 
-@test "Image for compose v2 service without an image in config using compatibility" {
+@test "Default image for compose v2 service using compatibility" {
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLI_VERSION=2
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_COMPATIBILITY=true
 
-  stub docker \
-    "compose --compatibility -f docker-compose.yml -p buildkite config : cat $PWD/tests/composefiles/docker-compose.config.v3.2.yml"
-
-  run compose_image_for_service "helper"
+  run default_compose_image_for_service "helper"
 
   assert_success
   assert_output "buildkite_helper"
-
-  unstub docker
 }
 
-@test "Image for compose service without an image in config using compatibility" {
+@test "Default image for compose service using compatibility" {
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_COMPATIBILITY=true
 
-  stub docker-compose \
-    "--compatibility -f docker-compose.yml -p buildkite config : cat $PWD/tests/composefiles/docker-compose.config.v3.2.yml"
-
-  run compose_image_for_service "helper"
+  run default_compose_image_for_service "helper"
 
   assert_success
   assert_output "buildkite_helper"
-
-  unstub docker-compose
 }

--- a/tests/docker-compose-images.bats
+++ b/tests/docker-compose-images.bats
@@ -1,13 +1,17 @@
 #!/usr/bin/env bats
 
 # export DOCKER_COMPOSE_STUB_DEBUG=/dev/tty
+# export DOCKER_STUB_DEBUG=/dev/tty
 
 load "${BATS_PLUGIN_PATH}/load.bash"
 load '../lib/shared'
 load '../lib/push'
 
-@test "Image for compose service with an image in config" {
+setup() {
   export HIDE_PROMPT=1
+}
+
+@test "Image for compose service with an image in config" {
   stub docker-compose \
     "-f docker-compose.yml -p buildkite config : cat $PWD/tests/composefiles/docker-compose.config.v3.2.yml"
 
@@ -15,23 +19,23 @@ load '../lib/push'
 
   assert_success
   assert_output "somewhere.dkr.ecr.some-region.amazonaws.com/blah"
+
   unstub docker-compose
 }
 
 @test "Image for compose service with a service with hyphens in the name" {
-  export HIDE_PROMPT=1
   stub docker-compose \
     "-f docker-compose.yml -p buildkite config : cat $PWD/tests/composefiles/docker-compose.config.with.hyphens.yml"
 
-  run compose_image_for_service "app"
+  run compose_image_for_service "foo-db"
 
   assert_success
-  assert_output "buildkite_app"
+  assert_output "postgres:9.4"
+
   unstub docker-compose
 }
 
 @test "Image for compose service without an image in config" {
-  export HIDE_PROMPT=1
   stub docker-compose \
     "-f docker-compose.yml -p buildkite config : cat $PWD/tests/composefiles/docker-compose.config.v3.2.yml"
 
@@ -39,5 +43,49 @@ load '../lib/push'
 
   assert_success
   assert_output "buildkite_helper"
+
+  unstub docker-compose
+}
+
+@test "Image for compose v2 service without an image in config" {
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLI_VERSION=2
+
+  stub docker \
+    "compose -f docker-compose.yml -p buildkite config : cat $PWD/tests/composefiles/docker-compose.config.v3.2.yml"
+
+  run compose_image_for_service "helper"
+
+  assert_success
+  assert_output "buildkite-helper"
+
+  unstub docker
+}
+
+@test "Image for compose v2 service without an image in config using compatibility" {
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLI_VERSION=2
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_COMPATIBILITY=true
+
+  stub docker \
+    "compose --compatibility -f docker-compose.yml -p buildkite config : cat $PWD/tests/composefiles/docker-compose.config.v3.2.yml"
+
+  run compose_image_for_service "helper"
+
+  assert_success
+  assert_output "buildkite_helper"
+
+  unstub docker
+}
+
+@test "Image for compose service without an image in config using compatibility" {
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_COMPATIBILITY=true
+
+  stub docker-compose \
+    "--compatibility -f docker-compose.yml -p buildkite config : cat $PWD/tests/composefiles/docker-compose.config.v3.2.yml"
+
+  run compose_image_for_service "helper"
+
+  assert_success
+  assert_output "buildkite_helper"
+
   unstub docker-compose
 }

--- a/tests/image-override-file.bats
+++ b/tests/image-override-file.bats
@@ -3,15 +3,22 @@
 load "${BATS_PLUGIN_PATH}/load.bash"
 load '../lib/shared'
 
-myservice_override_file1=$(cat <<-EOF
+@test "Build a docker-compose override file" {
+  myservice_override_file1=$(cat <<-EOF
 version: '2.1'
 services:
   myservice:
     image: newimage:1.0.0
 EOF
-)
+  )
+  run build_image_override_file_with_version "2.1" "myservice" "newimage:1.0.0" "" 0
 
-myservice_override_file2=$(cat <<-EOF
+  assert_success
+  assert_output "$myservice_override_file1"
+}
+
+@test "Build a docker-compose override file with multiple entries" {
+  myservice_override_file2=$(cat <<-EOF
 version: '2.1'
 services:
   myservice1:
@@ -19,9 +26,18 @@ services:
   myservice2:
     image: newimage2:1.0.0
 EOF
-)
+  )
 
-myservice_override_file3=$(cat <<-EOF
+  run build_image_override_file_with_version "2.1" \
+    "myservice1" "newimage1:1.0.0" "" 0 \
+    "myservice2" "newimage2:1.0.0" "" 0
+
+  assert_success
+  assert_output "$myservice_override_file2"
+}
+
+@test "Build a docker-compose file with cache-from" {
+  myservice_override_file3=$(cat <<-EOF
 version: '3.2'
 services:
   myservice:
@@ -30,9 +46,16 @@ services:
       cache_from:
         - my.repository/myservice:latest
 EOF
-)
+  )
 
-myservice_override_file4=$(cat <<-EOF
+  run build_image_override_file_with_version "3.2" "myservice" "newimage:1.0.0" "" 1 "my.repository/myservice:latest"
+
+  assert_success
+  assert_output "$myservice_override_file3"
+}
+
+@test "Build a docker-compose file with multiple cache-from entries" {
+  myservice_override_file4=$(cat <<-EOF
 version: '3.2'
 services:
   myservice:
@@ -42,70 +65,46 @@ services:
         - my.repository/myservice:latest
         - my.repository/myservice:target
 EOF
-)
+  )
 
-@test "Build a docker-compose override file" {
-  run build_image_override_file_with_version "2.1" "myservice" "newimage:1.0.0" 0
-
-  assert_success
-  assert_output "$myservice_override_file1"
-}
-
-@test "Build a docker-compose override file with multiple entries" {
-  run build_image_override_file_with_version "2.1" \
-    "myservice1" "newimage1:1.0.0" 0 \
-    "myservice2" "newimage2:1.0.0" 0
-
-  assert_success
-  assert_output "$myservice_override_file2"
-}
-
-@test "Build a docker-compose file with cache-from" {
-  run build_image_override_file_with_version "3.2" "myservice" "newimage:1.0.0" 1 "my.repository/myservice:latest"
-
-  assert_success
-  assert_output "$myservice_override_file3"
-}
-
-@test "Build a docker-compose file with multiple cache-from entries" {
-  run build_image_override_file_with_version "3.2" "myservice" "newimage:1.0.0" 2 "my.repository/myservice:latest" "my.repository/myservice:target"
+  run build_image_override_file_with_version "3.2" "myservice" "newimage:1.0.0" "" 2 "my.repository/myservice:latest" "my.repository/myservice:target"
 
   assert_success
   assert_output "$myservice_override_file4"
 }
 
 @test "Build a docker-compose file with cache-from and compose-file version 2" {
-  run build_image_override_file_with_version "2" "myservice" "newimage:1.0.0" 1 "my.repository/myservice:latest"
+  run build_image_override_file_with_version "2" "myservice" "newimage:1.0.0" "" 1 "my.repository/myservice:latest"
 
   assert_failure
 }
 
 @test "Build a docker-compose file with cache-from and compose-file version 2.0" {
-  run build_image_override_file_with_version "2.0" "myservice" "newimage:1.0.0" 1 "my.repository/myservice:latest"
+  run build_image_override_file_with_version "2.0" "myservice" "newimage:1.0.0" "" 1 "my.repository/myservice:latest"
 
   assert_failure
 }
 
 @test "Build a docker-compose file with cache-from and compose-file version 2.1" {
-  run build_image_override_file_with_version "2.1" "myservice" "newimage:1.0.0" 1 "my.repository/myservice:latest"
+  run build_image_override_file_with_version "2.1" "myservice" "newimage:1.0.0" "" 1 "my.repository/myservice:latest"
 
   assert_failure
 }
 
 @test "Build a docker-compose file with cache-from and compose-file version 3" {
-  run build_image_override_file_with_version "3" "myservice" "newimage:1.0.0" 1 "my.repository/myservice:latest"
+  run build_image_override_file_with_version "3" "myservice" "newimage:1.0.0" "" 1 "my.repository/myservice:latest"
 
   assert_failure
 }
 
 @test "Build a docker-compose file with cache-from and compose-file version 3.0" {
-  run build_image_override_file_with_version "3.0" "myservice" "newimage:1.0.0" 1 "my.repository/myservice:latest"
+  run build_image_override_file_with_version "3.0" "myservice" "newimage:1.0.0" "" 1 "my.repository/myservice:latest"
 
   assert_failure
 }
 
 @test "Build a docker-compose file with cache-from and compose-file version 3.1" {
-  run build_image_override_file_with_version "3.1" "myservice" "newimage:1.0.0" 1 "my.repository/myservice:latest"
+  run build_image_override_file_with_version "3.1" "myservice" "newimage:1.0.0" "" 1 "my.repository/myservice:latest"
 
   assert_failure
 }

--- a/tests/multiple-commands.bats
+++ b/tests/multiple-commands.bats
@@ -26,24 +26,18 @@ setup_file() {
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_IMAGE_REPOSITORY=my.repository/llamas
 
   stub docker-compose \
-     "-f docker-compose.yml -p buildkite12 -f docker-compose.buildkite-1-override.yml build --pull myservice : echo built myservice" \
-     "-f docker-compose.yml -p buildkite12 -f docker-compose.buildkite-1-override.yml push myservice : echo pushed myservice" \
-     "-f docker-compose.yml -p buildkite12 -f docker-compose.buildkite-1-override.yml pull myservice : echo pulled myservice" \
-     "-f docker-compose.yml -p buildkite12 -f docker-compose.buildkite-1-override.yml up -d --scale myservice=0 myservice : echo ran dependencies" \
-     "-f docker-compose.yml -p buildkite12 -f docker-compose.buildkite-1-override.yml run --name buildkite12_myservice_build_1 -T --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice"
+    "-f docker-compose.yml -p buildkite12 -f docker-compose.buildkite-1-override.yml build --pull myservice : echo built myservice" \
+    "-f docker-compose.yml -p buildkite12 -f docker-compose.buildkite-1-override.yml up -d --scale myservice=0 myservice : echo ran dependencies" \
+    "-f docker-compose.yml -p buildkite12 -f docker-compose.buildkite-1-override.yml run --name buildkite12_myservice_build_1 -T --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice"
 
   # these commands simulate metadata for a specific value by using an intermediate-file
   stub buildkite-agent \
-     "meta-data set docker-compose-plugin-built-image-tag-myservice \* : echo \$4 > /tmp/build-run-metadata" \
-     "meta-data exists docker-compose-plugin-built-image-tag-myservice : test -f /tmp/build-run-metadata" \
-     "meta-data get docker-compose-plugin-built-image-tag-myservice : cat /tmp/build-run-metadata"
+    "meta-data exists docker-compose-plugin-built-image-tag-myservice : test -f /tmp/build-run-metadata"
 
   run "$PWD"/hooks/command
 
   assert_success
   assert_output --partial "Building services myservice"
-  assert_output --partial "Pushing built images to my.repository/llamas"
-  assert_output --partial "Found a pre-built image for myservice"
   assert_output --partial "Starting dependencies"
   assert_output --partial "ran myservice" 
 
@@ -59,27 +53,24 @@ setup_file() {
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_IMAGE_REPOSITORY=my.repository/llamas
 
   stub docker-compose \
-     "-f docker-compose.yml -p buildkite12 -f docker-compose.buildkite-1-override.yml build --pull myservice : echo built myservice" \
-     "-f docker-compose.yml -p buildkite12 -f docker-compose.buildkite-1-override.yml push myservice : echo build-pushed myservice" \
-     "-f docker-compose.yml -p buildkite12 config : echo ''" \
-     "-f docker-compose.yml -p buildkite12 push myservice : echo push-pushed myservice"
+    "-f docker-compose.yml -p buildkite12 -f docker-compose.buildkite-1-override.yml build --pull myservice : echo built myservice" \
+    "-f docker-compose.yml -p buildkite12 config --images myservice : echo 'myservice'" \
+    "-f docker-compose.yml -p buildkite12 push myservice : echo pushed myservice"
   
   # these commands simulate metadata for a specific value by using an intermediate-file
   stub buildkite-agent \
-     "meta-data set docker-compose-plugin-built-image-tag-myservice \* : echo \$4 > /tmp/build-push-metadata" \
      "meta-data exists docker-compose-plugin-built-image-tag-myservice : test -f /tmp/build-push-metadata" \
-     "meta-data get docker-compose-plugin-built-image-tag-myservice : cat /tmp/build-push-metadata"
+     "meta-data set docker-compose-plugin-built-image-tag-myservice \* : echo \$4 > /tmp/build-push-metadata"
 
   stub docker \
-     "pull my.repository/llamas:test-myservice-build-1 : echo pulled pre-built image"
+     "image inspect myservice : echo existing-image"
 
   run "$PWD"/hooks/command
 
   assert_success
 
   assert_output --partial "Building services myservice"
-  assert_output --partial "Pushing built images to my.repository/llamas"
-  assert_output --partial "Pulling pre-built service myservice"
+  assert_output --partial "Using service image myservice from Docker Compose config"
   assert_output --partial "Pushing images for myservice"
 
   unstub docker
@@ -94,7 +85,7 @@ setup_file() {
   stub docker-compose \
     "-f docker-compose.yml -p buildkite12 up -d --scale myservice=0 myservice : echo ran dependencies" \
     "-f docker-compose.yml -p buildkite12 run --name buildkite12_myservice_build_1 -T --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice" \
-    "-f docker-compose.yml -p buildkite12 config : echo ''" 
+    "-f docker-compose.yml -p buildkite12 config --images myservice : echo 'image-myservice'" 
   
   # these make sure that the image is not pre-built
   stub buildkite-agent \
@@ -121,7 +112,7 @@ setup_file() {
   stub docker-compose \
     "-f docker-compose.yml -p buildkite12 up -d --scale myservice=0 myservice : echo ran dependencies" \
     "-f docker-compose.yml -p buildkite12 run --name buildkite12_myservice_build_1 -T --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice" \
-    "-f docker-compose.yml -p buildkite12 config : echo ''" \
+    "-f docker-compose.yml -p buildkite12 config --images myservice : echo 'image'" \
     "-f docker-compose.yml -p buildkite12 push myservice : echo pushed myservice"
      
   stub docker \
@@ -130,7 +121,8 @@ setup_file() {
   # these make sure that the image is not pre-built
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 1" \
-    "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 1"
+    "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 1" \
+    "meta-data set docker-compose-plugin-built-image-tag-myservice \* : set pre-built image metadata to \$4"
 
   run "$PWD"/hooks/command
 
@@ -146,27 +138,27 @@ setup_file() {
   unstub buildkite-agent
 }
 
-
 @test "Run and push with pre-built image" {
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RUN=myservice
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_PUSH=myservice
 
   stub docker-compose \
-     "-f docker-compose.yml -p buildkite12 -f docker-compose.buildkite-1-override.yml pull myservice : echo pulled myservice" \
-     "-f docker-compose.yml -p buildkite12 -f docker-compose.buildkite-1-override.yml up -d --scale myservice=0 myservice : echo ran dependencies" \
-     "-f docker-compose.yml -p buildkite12 -f docker-compose.buildkite-1-override.yml run --name buildkite12_myservice_build_1 -T --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice" \
-     "-f docker-compose.yml -p buildkite12 config : echo ''" \
-     "-f docker-compose.yml -p buildkite12 push myservice : echo pushed myservice"
+    "-f docker-compose.yml -p buildkite12 -f docker-compose.buildkite-1-override.yml pull myservice : echo pulled myservice" \
+    "-f docker-compose.yml -p buildkite12 -f docker-compose.buildkite-1-override.yml up -d --scale myservice=0 myservice : echo ran dependencies" \
+    "-f docker-compose.yml -p buildkite12 -f docker-compose.buildkite-1-override.yml run --name buildkite12_myservice_build_1 -T --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice" \
+    "-f docker-compose.yml -p buildkite12 config --images myservice : echo 'image'" \
+    "-f docker-compose.yml -p buildkite12 push myservice : echo pushed myservice"
   
   # these make sure that the image is not pre-built
   stub buildkite-agent \
-     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 0" \
-     "meta-data get docker-compose-plugin-built-image-tag-myservice : echo myservice-tag" \
-     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 0" \
-     "meta-data get docker-compose-plugin-built-image-tag-myservice : echo myservice-tag"
+    "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 0" \
+    "meta-data get docker-compose-plugin-built-image-tag-myservice : echo myservice-tag" \
+    "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 0" \
+    "meta-data get docker-compose-plugin-built-image-tag-myservice : echo myservice-tag" \
+    "meta-data set docker-compose-plugin-built-image-tag-myservice \* : set pre-built image metadata to \$4"
 
   stub docker \
-     "pull myservice-tag : echo pulled pre-built image"
+    "pull myservice-tag : echo pulled pre-built image"
 
   run "$PWD"/hooks/command
 

--- a/tests/multiple-commands.bats
+++ b/tests/multiple-commands.bats
@@ -73,7 +73,7 @@ teardown() {
   assert_success
 
   assert_output --partial "Building services myservice"
-  assert_output --partial "Using service image buildkite12_myservice from Docker Compose config"
+  assert_output --partial "Service was built in this step, using that image"
   assert_output --partial "Pushing images for myservice"
 
   unstub docker
@@ -102,29 +102,29 @@ teardown() {
   assert_output --partial "No pre-built image found from a previous "
   assert_output --partial "Starting dependencies"
   assert_output --partial "ran myservice" 
-  assert_output --partial "No prebuilt-image nor service image found for service to push"
+  assert_output --partial "No prebuilt-image nor built image found for service to push"
 
   unstub docker-compose
   unstub buildkite-agent
 }
 
 @test "Run and push without pre-built image with service image" {
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RUN=myservice
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_PUSH=myservice
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RUN=helloworldimage
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_PUSH=helloworldimage
 
   stub docker-compose \
-    "-f docker-compose.yml -p buildkite12 up -d --scale myservice=0 myservice : echo ran dependencies" \
-    "-f docker-compose.yml -p buildkite12 run --name buildkite12_myservice_build_1 -T --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice" \
-    "-f docker-compose.yml -p buildkite12 config : echo ''" \
-    "-f docker-compose.yml -p buildkite12 push myservice : echo pushed myservice"
-     
+    "-f docker-compose.yml -p buildkite12 up -d --scale helloworldimage=0 helloworldimage : echo ran dependencies" \
+    "-f docker-compose.yml -p buildkite12 run --name buildkite12_helloworldimage_build_1 -T --rm helloworldimage /bin/sh -e -c 'pwd' : echo ran helloworldimage" \
+    "-f docker-compose.yml -p buildkite12 config : cat ${PWD}/tests/composefiles/docker-compose.v3.2.yml" \
+    "-f docker-compose.yml -p buildkite12 push helloworldimage : exit 0"
+
   stub docker \
-    "image inspect \* : echo found image \$3"
+    "image inspect \* : exit 0"
 
   # these make sure that the image is not pre-built
   stub buildkite-agent \
-    "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 1" \
-    "meta-data set docker-compose-plugin-built-image-tag-myservice \* : set pre-built image metadata to \$4"
+    "meta-data exists docker-compose-plugin-built-image-tag-helloworldimage : exit 1" \
+    "meta-data set docker-compose-plugin-built-image-tag-helloworldimage \* : set pre-built image metadata to \$4"
 
   run "$PWD"/hooks/command
 
@@ -132,8 +132,8 @@ teardown() {
 
   assert_output --partial "No pre-built image found from a previous "
   assert_output --partial "Starting dependencies"
-  assert_output --partial "ran myservice" 
-  assert_output --partial "Using service image"
+  assert_output --partial "ran helloworldimage" 
+  assert_output --partial 'Service has an image configuration: myhelloworld'
 
   unstub docker
   unstub docker-compose
@@ -160,8 +160,8 @@ teardown() {
     "meta-data set docker-compose-plugin-built-image-tag-myservice \* : set pre-built image metadata to \$4"
 
   stub docker \
-    "image inspect buildkite12_myservice : exit 1" \
-    "pull myservice-tag : echo pulled pre-built image"
+    "pull myservice-tag : echo pulled pre-built image" \
+    "image inspect myservice-tag : exit 0"
 
   run "$PWD"/hooks/command
 

--- a/tests/multiple-commands.bats
+++ b/tests/multiple-commands.bats
@@ -26,11 +26,10 @@ setup_file() {
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_IMAGE_REPOSITORY=my.repository/llamas
 
   stub docker-compose \
-    "-f docker-compose.yml -p buildkite12 -f docker-compose.buildkite-1-override.yml build --pull myservice : echo built myservice" \
-    "-f docker-compose.yml -p buildkite12 -f docker-compose.buildkite-1-override.yml up -d --scale myservice=0 myservice : echo ran dependencies" \
-    "-f docker-compose.yml -p buildkite12 -f docker-compose.buildkite-1-override.yml run --name buildkite12_myservice_build_1 -T --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice"
+    "-f docker-compose.yml -p buildkite12 build --pull myservice : echo built myservice" \
+    "-f docker-compose.yml -p buildkite12 up -d --scale myservice=0 myservice : echo ran dependencies" \
+    "-f docker-compose.yml -p buildkite12 run --name buildkite12_myservice_build_1 -T --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice"
 
-  # these commands simulate metadata for a specific value by using an intermediate-file
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : test -f /tmp/build-run-metadata"
 
@@ -53,7 +52,7 @@ setup_file() {
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_IMAGE_REPOSITORY=my.repository/llamas
 
   stub docker-compose \
-    "-f docker-compose.yml -p buildkite12 -f docker-compose.buildkite-1-override.yml build --pull myservice : echo built myservice" \
+    "-f docker-compose.yml -p buildkite12 build --pull myservice : echo built myservice" \
     "-f docker-compose.yml -p buildkite12 config --images myservice : echo 'myservice'" \
     "-f docker-compose.yml -p buildkite12 push myservice : echo pushed myservice"
   

--- a/tests/multiple-commands.bats
+++ b/tests/multiple-commands.bats
@@ -63,7 +63,6 @@ teardown() {
   
   # these commands simulate metadata for a specific value by using an intermediate-file
   stub buildkite-agent \
-     "meta-data exists docker-compose-plugin-built-image-tag-myservice : test -f /tmp/build-push-metadata" \
      "meta-data set docker-compose-plugin-built-image-tag-myservice \* : echo \$4 > /tmp/build-push-metadata"
 
   stub docker \
@@ -125,7 +124,6 @@ teardown() {
   # these make sure that the image is not pre-built
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 1" \
-    "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 1" \
     "meta-data set docker-compose-plugin-built-image-tag-myservice \* : set pre-built image metadata to \$4"
 
   run "$PWD"/hooks/command
@@ -162,6 +160,7 @@ teardown() {
     "meta-data set docker-compose-plugin-built-image-tag-myservice \* : set pre-built image metadata to \$4"
 
   stub docker \
+    "image inspect buildkite12_myservice : exit 1" \
     "pull myservice-tag : echo pulled pre-built image"
 
   run "$PWD"/hooks/command

--- a/tests/multiple-commands.bats
+++ b/tests/multiple-commands.bats
@@ -20,7 +20,7 @@ setup_file() {
 
 teardown() {
   # some test failures may leave this file around
-  rm -f docker-compose.buildkite-1-override.yml
+  rm -f docker-compose.buildkite*-override.yml
 }
 
 @test "Build and run" {

--- a/tests/push.bats
+++ b/tests/push.bats
@@ -15,8 +15,7 @@ load '../lib/shared'
   export BUILDKITE_BUILD_NUMBER=1
 
   stub buildkite-agent \
-    "meta-data exists docker-compose-plugin-built-image-tag-app : exit 1" \
-    "meta-data set docker-compose-plugin-built-image-tag-app \* : echo \$4 > ${BATS_TEST_TMPDIR}/build-push-metadata"
+    "meta-data set docker-compose-plugin-built-image-tag-app \* : echo setting metadata to \$4"
 
   stub docker-compose \
     "-f docker-compose.yml -p buildkite1111 config : cat ${PWD}/tests/composefiles/docker-compose.config.v3.2.yml" \
@@ -42,6 +41,7 @@ load '../lib/shared'
   export BUILDKITE_BUILD_NUMBER=1
 
   stub docker \
+    "image inspect \* : exit 1" \
     "pull myimage : echo pulled prebuilt image" \
     "tag myimage my.repository/myservice:llamas : echo tagged image" \
     "push my.repository/myservice:llamas : echo pushed myservice"
@@ -74,6 +74,7 @@ load '../lib/shared'
 
 
   stub docker \
+    "image inspect \* : exit 1" \
     "pull prebuilt : echo 'pulled prebuilt image'" \
     "tag prebuilt \* : echo 'invalid tag'; exit 1"
 
@@ -105,11 +106,14 @@ load '../lib/shared'
   export BUILDKITE_BUILD_NUMBER=1
 
   stub docker \
+    "image inspect \* : exit 1" \
     "pull prebuilt : echo pulled prebuilt image" \
     "tag prebuilt my.repository/myservice:llamas : echo tagged image1" \
     "push my.repository/myservice:llamas : echo pushed myservice1" \
+    "image inspect \* : exit 1" \
     "tag prebuilt my.repository/myservice:latest : echo tagged image2" \
     "push my.repository/myservice:latest : echo pushed myservice2" \
+    "image inspect \* : exit 1" \
     "tag prebuilt my.repository/myservice:alpacas : echo tagged image3" \
     "push my.repository/myservice:alpacas : echo pushed myservice3"
 
@@ -210,9 +214,11 @@ load '../lib/shared'
     "-f docker-compose.yml -p buildkite1111 config : echo ''" \
 
   stub docker \
+    "image inspect \* : exit 1" \
     "pull myservice1 : exit 0" \
     "tag myservice1 my.repository/myservice1 : echo tagging image1" \
     "push my.repository/myservice1 : echo pushing myservice1 image" \
+    "image inspect \* : exit 1" \
     "pull myservice2 : exit 0" \
     "tag myservice2 my.repository/myservice2:llamas : echo tagging image2" \
     "push my.repository/myservice2:llamas : echo pushing myservice2 image"

--- a/tests/push.bats
+++ b/tests/push.bats
@@ -15,14 +15,15 @@ load '../lib/shared'
   export BUILDKITE_BUILD_NUMBER=1
 
   stub buildkite-agent \
-    "meta-data exists docker-compose-plugin-built-image-tag-app : exit 1"
+    "meta-data exists docker-compose-plugin-built-image-tag-app : exit 1" \
+    "meta-data set docker-compose-plugin-built-image-tag-app \* : echo \$4 > ${BATS_TEST_TMPDIR}/build-push-metadata"
 
   stub docker-compose \
-    "-f docker-compose.yml -p buildkite1111 config : cat $PWD/tests/composefiles/docker-compose.config.v3.2.yml" \
+    "-f docker-compose.yml -p buildkite1111 config --images app : echo app-image" \
     "-f docker-compose.yml -p buildkite1111 push app : echo pushed app"
 
   stub docker \
-    "image inspect somewhere.dkr.ecr.some-region.amazonaws.com/blah : exit 0"
+    "image inspect app-image : exit 0"
 
   run "$PWD"/hooks/command
 
@@ -45,11 +46,12 @@ load '../lib/shared'
     "push my.repository/myservice:llamas : echo pushed myservice"
 
   stub docker-compose \
-    "-f docker-compose.yml -p buildkite1111 config : echo blah"
+    "-f docker-compose.yml -p buildkite1111 config --images myservice : echo ''"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 0" \
-    "meta-data get docker-compose-plugin-built-image-tag-myservice : echo myimage"
+    "meta-data get docker-compose-plugin-built-image-tag-myservice : echo myimage" \
+    "meta-data set docker-compose-plugin-built-image-tag-myservice \* : echo \$4 > ${BATS_TEST_TMPDIR}/build-push-metadata"
 
   run "$PWD"/hooks/command
 
@@ -69,7 +71,7 @@ load '../lib/shared'
   export BUILDKITE_BUILD_NUMBER=1
 
   stub docker-compose \
-    "-f docker-compose.yml -p buildkite1111 config : echo blah"
+    "-f docker-compose.yml -p buildkite1111 config --images myservice : echo ''"
 
   run "$PWD"/hooks/command
 
@@ -98,17 +100,20 @@ load '../lib/shared'
     "push my.repository/myservice:alpacas : echo pushed myservice3"
 
   stub docker-compose \
-    "-f docker-compose.yml -p buildkite1111 config : echo blah" \
-    "-f docker-compose.yml -p buildkite1111 config : echo blah" \
-    "-f docker-compose.yml -p buildkite1111 config : echo blah"
+    "-f docker-compose.yml -p buildkite1111 config --images myservice : echo ''" \
+    "-f docker-compose.yml -p buildkite1111 config --images myservice : echo ''" \
+    "-f docker-compose.yml -p buildkite1111 config --images myservice : echo ''"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 0" \
     "meta-data get docker-compose-plugin-built-image-tag-myservice : echo prebuilt" \
+    "meta-data set docker-compose-plugin-built-image-tag-myservice \* : echo \$4" \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 0" \
     "meta-data get docker-compose-plugin-built-image-tag-myservice : echo prebuilt" \
+    "meta-data set docker-compose-plugin-built-image-tag-myservice \* : echo \$4" \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 0" \
-    "meta-data get docker-compose-plugin-built-image-tag-myservice : echo prebuilt"
+    "meta-data get docker-compose-plugin-built-image-tag-myservice : echo prebuilt" \
+    "meta-data set docker-compose-plugin-built-image-tag-myservice \* : echo \$4" \
 
   run "$PWD"/hooks/command
 
@@ -135,10 +140,10 @@ load '../lib/shared'
     "meta-data exists docker-compose-plugin-built-image-tag-helper : exit 1"
 
   stub docker-compose \
-    "-f docker-compose.yml -p buildkite1111 config : cat $PWD/tests/composefiles/docker-compose.config.v3.2.yml"
+    "-f docker-compose.yml -p buildkite1111 config --images helper : echo ''"
 
   stub docker \
-    "image inspect buildkite1111_helper : exit 1"
+    "image inspect \* : exit 1"
 
   run "$PWD"/hooks/command
 
@@ -158,10 +163,10 @@ load '../lib/shared'
   export BUILDKITE_BUILD_NUMBER=1
 
   stub docker-compose \
-    "-f docker-compose.yml -p buildkite1111 config : echo blah "
+    "-f docker-compose.yml -p buildkite1111 config --images myservice1 : echo ''"
 
   stub docker \
-    "image inspect buildkite1111_myservice1 : exit 1"
+    "image inspect \* : exit 1"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice1 : exit 1"
@@ -185,8 +190,8 @@ load '../lib/shared'
   export BUILDKITE_BUILD_NUMBER=1
 
   stub docker-compose \
-    "-f docker-compose.yml -p buildkite1111 config : echo blah " \
-    "-f docker-compose.yml -p buildkite1111 config : echo blah " \
+    "-f docker-compose.yml -p buildkite1111 config --images myservice1 : echo ''" \
+    "-f docker-compose.yml -p buildkite1111 config --images myservice2 : echo ''" \
 
   stub docker \
     "pull myservice1 : exit 0" \
@@ -199,8 +204,10 @@ load '../lib/shared'
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice1 : exit 0" \
     "meta-data get docker-compose-plugin-built-image-tag-myservice1 : echo myservice1" \
+    "meta-data set docker-compose-plugin-built-image-tag-myservice1 \* : echo \$4" \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice2 : exit 0" \
-    "meta-data get docker-compose-plugin-built-image-tag-myservice2 : echo myservice2"
+    "meta-data get docker-compose-plugin-built-image-tag-myservice2 : echo myservice2" \
+    "meta-data set docker-compose-plugin-built-image-tag-myservice2 \* : echo \$4" \
 
   run "$PWD"/hooks/command
 

--- a/tests/run.bats
+++ b/tests/run.bats
@@ -12,6 +12,11 @@ setup_file() {
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RUN_LABELS="false"
 }
 
+teardown() {
+  # some test failures may leave this file around
+  rm -f docker-compose.buildkite-1-override.yml
+}
+
 @test "Run without a prebuilt image" {
   export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RUN=myservice

--- a/tests/run.bats
+++ b/tests/run.bats
@@ -14,7 +14,7 @@ setup_file() {
 
 teardown() {
   # some test failures may leave this file around
-  rm -f docker-compose.buildkite-1-override.yml
+  rm -f docker-compose.buildkite*-override.yml
 }
 
 @test "Run without a prebuilt image" {

--- a/tests/v2/build.bats
+++ b/tests/v2/build.bats
@@ -85,36 +85,6 @@ teardown() {
   unstub docker
 }
 
-@test "Build with a repository and multiple build aliases" {
-  skip "need to be moved to push"
-  export BUILDKITE_JOB_ID=1111
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD=myservice
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD_ALIAS_0=myservice-1
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD_ALIAS_1=myservice-2
-  export BUILDKITE_PIPELINE_SLUG=test
-  export BUILDKITE_BUILD_NUMBER=1
-
-  stub docker \
-    "compose -f docker-compose.yml -p buildkite1111 build --pull myservice : echo built myservice" \
-    "compose -f docker-compose.yml -p buildkite1111 push myservice : echo pushed myservice" \
-
-  stub buildkite-agent \
-    "meta-data set docker-compose-plugin-built-image-tag-myservice my.repository/llamas:test-myservice-build-1 : echo set image metadata for myservice" \
-    "meta-data set docker-compose-plugin-built-image-tag-myservice-1 my.repository/llamas:test-myservice-build-1 : echo set image metadata for myservice-1" \
-    "meta-data set docker-compose-plugin-built-image-tag-myservice-2 my.repository/llamas:test-myservice-build-1 : echo set image metadata for myservice-2"
-
-  run "$PWD"/hooks/command
-
-  assert_success
-  assert_output --partial "built myservice"
-  assert_output --partial "pushed myservice"
-  assert_output --partial "set image metadata for myservice"
-  assert_output --partial "set image metadata for myservice-1"
-  assert_output --partial "set image metadata for myservice-2"
-  unstub docker
-  unstub buildkite-agent
-}
-
 @test "Build with a custom config file" {
   export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD=myservice

--- a/tests/v2/build.bats
+++ b/tests/v2/build.bats
@@ -11,6 +11,11 @@ setup_file() {
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLI_VERSION=2
 }
 
+teardown() {
+  # plugin leaves override files around
+  rm -f docker-compose.buildkite*-override.yml
+}
+
 @test "Build without a repository" {
   export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD=myservice
@@ -18,13 +23,14 @@ setup_file() {
   export BUILDKITE_BUILD_NUMBER=1
 
   stub docker \
-    "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml build --pull myservice : echo built myservice"
+    "compose -f docker-compose.yml -p buildkite1111 build --pull myservice : echo built myservice"
 
   run "$PWD"/hooks/command
 
-  unstub docker
   assert_success
   assert_output --partial "built myservice"
+
+  unstub docker
 }
 
 @test "Build with no-cache" {
@@ -35,7 +41,7 @@ setup_file() {
   export BUILDKITE_BUILD_NUMBER=1
 
   stub docker \
-    "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml build --pull --no-cache myservice : echo built myservice"
+    "compose -f docker-compose.yml -p buildkite1111 build --pull --no-cache myservice : echo built myservice"
 
   run "$PWD"/hooks/command
 
@@ -52,7 +58,7 @@ setup_file() {
   export BUILDKITE_BUILD_NUMBER=1
 
   stub docker \
-    "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml build --pull --parallel myservice : echo built myservice"
+    "compose -f docker-compose.yml -p buildkite1111 build --pull --parallel myservice : echo built myservice"
 
   run "$PWD"/hooks/command
 
@@ -70,51 +76,27 @@ setup_file() {
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_ARGS_1=MYARG=1
 
   stub docker \
-    "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml build --pull --build-arg MYARG=0 --build-arg MYARG=1 myservice : echo built myservice"
+    "compose -f docker-compose.yml -p buildkite1111 build --pull --build-arg MYARG=0 --build-arg MYARG=1 myservice : echo built myservice"
 
   run "$PWD"/hooks/command
 
   assert_success
   assert_output --partial "built myservice"
   unstub docker
-}
-
-@test "Build with a repository" {
-  export BUILDKITE_JOB_ID=1111
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD=myservice
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_IMAGE_REPOSITORY=my.repository/llamas
-  export BUILDKITE_PIPELINE_SLUG=test
-  export BUILDKITE_BUILD_NUMBER=1
-
-  stub docker \
-    "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml build --pull myservice : echo built myservice" \
-    "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml push myservice : echo pushed myservice" \
-
-  stub buildkite-agent \
-    "meta-data set docker-compose-plugin-built-image-tag-myservice my.repository/llamas:test-myservice-build-1 : echo set image metadata for myservice"
-
-  run "$PWD"/hooks/command
-
-  assert_success
-  assert_output --partial "built myservice"
-  assert_output --partial "pushed myservice"
-  assert_output --partial "set image metadata for myservice"
-  unstub docker
-  unstub buildkite-agent
 }
 
 @test "Build with a repository and multiple build aliases" {
+  skip "need to be moved to push"
   export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD=myservice
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_IMAGE_REPOSITORY=my.repository/llamas
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD_ALIAS_0=myservice-1
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD_ALIAS_1=myservice-2
   export BUILDKITE_PIPELINE_SLUG=test
   export BUILDKITE_BUILD_NUMBER=1
 
   stub docker \
-    "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml build --pull myservice : echo built myservice" \
-    "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml push myservice : echo pushed myservice" \
+    "compose -f docker-compose.yml -p buildkite1111 build --pull myservice : echo built myservice" \
+    "compose -f docker-compose.yml -p buildkite1111 push myservice : echo pushed myservice" \
 
   stub buildkite-agent \
     "meta-data set docker-compose-plugin-built-image-tag-myservice my.repository/llamas:test-myservice-build-1 : echo set image metadata for myservice" \
@@ -133,56 +115,22 @@ setup_file() {
   unstub buildkite-agent
 }
 
-@test "Build with a repository and push retries" {
-  export BUILDKITE_JOB_ID=1111
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD=myservice
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_IMAGE_REPOSITORY=my.repository/llamas
-  export BUILDKITE_PIPELINE_SLUG=test
-  export BUILDKITE_BUILD_NUMBER=1
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_PUSH_RETRIES=3
-
-  stub docker \
-    "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml build --pull myservice : echo built myservice" \
-    "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml push myservice : exit 1" \
-    "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml push myservice : exit 1" \
-    "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml push myservice : echo pushed myservice" \
-
-  stub buildkite-agent \
-    "meta-data set docker-compose-plugin-built-image-tag-myservice my.repository/llamas:test-myservice-build-1 : echo set image metadata for myservice"
-
-  run "$PWD"/hooks/command
-
-  assert_success
-  assert_output --partial "built myservice"
-  assert_output --partial "pushed myservice"
-  assert_output --partial "set image metadata for myservice"
-  unstub docker
-  unstub buildkite-agent
-}
-
-@test "Build with a repository and custom config file" {
+@test "Build with a custom config file" {
   export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD=myservice
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CONFIG=tests/composefiles/docker-compose.v2.0.yml
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_IMAGE_REPOSITORY=my.repository/llamas
   export BUILDKITE_PIPELINE_SLUG=test
   export BUILDKITE_BUILD_NUMBER=1
 
   stub docker \
-    "compose -f tests/composefiles/docker-compose.v2.0.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml build --pull myservice : echo built myservice" \
-    "compose -f tests/composefiles/docker-compose.v2.0.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml push myservice : echo pushed myservice" \
-
-  stub buildkite-agent \
-    "meta-data set docker-compose-plugin-built-image-tag-myservice-tests/composefiles/docker-compose.v2.0.yml my.repository/llamas:test-myservice-build-1 : echo set image metadata for myservice"
+    "compose -f tests/composefiles/docker-compose.v2.0.yml -p buildkite1111 build --pull myservice : echo built myservice"
 
   run "$PWD"/hooks/command
 
   assert_success
   assert_output --partial "built myservice"
-  assert_output --partial "pushed myservice"
-  assert_output --partial "set image metadata for myservice"
+
   unstub docker
-  unstub buildkite-agent
 }
 
 @test "Build with a repository and multiple custom config files" {
@@ -190,65 +138,55 @@ setup_file() {
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD=myservice
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CONFIG_0=tests/composefiles/docker-compose.v2.0.yml
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CONFIG_1=tests/composefiles/docker-compose.v2.1.yml
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_IMAGE_REPOSITORY=my.repository/llamas
   export BUILDKITE_PIPELINE_SLUG=test
   export BUILDKITE_BUILD_NUMBER=1
 
   stub docker \
-    "compose -f tests/composefiles/docker-compose.v2.0.yml -f tests/composefiles/docker-compose.v2.1.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml build --pull myservice : echo built myservice" \
-    "compose -f tests/composefiles/docker-compose.v2.0.yml -f tests/composefiles/docker-compose.v2.1.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml push myservice : echo pushed myservice" \
-
-  stub buildkite-agent \
-    "meta-data set docker-compose-plugin-built-image-tag-myservice-tests/composefiles/docker-compose.v2.0.yml-tests/composefiles/docker-compose.v2.1.yml my.repository/llamas:test-myservice-build-1 : echo set image metadata for myservice"
+    "compose -f tests/composefiles/docker-compose.v2.0.yml -f tests/composefiles/docker-compose.v2.1.yml -p buildkite1111 build --pull myservice : echo built myservice"
 
   run "$PWD"/hooks/command
 
   assert_success
   assert_output --partial "built myservice"
-  assert_output --partial "pushed myservice"
-  assert_output --partial "set image metadata for myservice"
+
   unstub docker
-  unstub buildkite-agent
 }
 
 @test "Build with a repository and multiple services" {
   export BUILDKITE_JOB_ID=1112
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD_0=myservice1
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD_1=myservice2
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_IMAGE_REPOSITORY=my.repository/llamas
   export BUILDKITE_PIPELINE_SLUG=test
   export BUILDKITE_BUILD_NUMBER=1
 
   stub docker \
-    "compose -f docker-compose.yml -p buildkite1112 -f docker-compose.buildkite-1-override.yml build --pull myservice1 myservice2 : echo built all services" \
-    "compose -f docker-compose.yml -p buildkite1112 -f docker-compose.buildkite-1-override.yml push myservice1 myservice2 : echo pushed all services" \
-
-  stub buildkite-agent \
-    "meta-data set docker-compose-plugin-built-image-tag-myservice1 my.repository/llamas:test-myservice1-build-1 : echo set image metadata for myservice1" \
-    "meta-data set docker-compose-plugin-built-image-tag-myservice2 my.repository/llamas:test-myservice2-build-1 : echo set image metadata for myservice2"
+    "compose -f docker-compose.yml -p buildkite1112 build --pull myservice1 myservice2 : echo built all services"
 
   run "$PWD"/hooks/command
 
   assert_success
   assert_output --partial "built all services"
-  assert_output --partial "pushed all services"
-  assert_output --partial "set image metadata for myservice1"
-  assert_output --partial "set image metadata for myservice2"
+
   unstub docker
-  unstub buildkite-agent
 }
 
 @test "Build with a docker-compose v1.0 configuration file" {
   export BUILDKITE_JOB_ID=1112
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CONFIG="tests/composefiles/docker-compose.v1.0.yml"
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD_0=helloworld
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CACHE_FROM_0=helloworld:my.repository/myservice_cache:latest
   export BUILDKITE_PIPELINE_SLUG=test
   export BUILDKITE_BUILD_NUMBER=1
+
+  stub docker \
+    "pull my.repository/myservice_cache:latest : echo pulled cache image"
 
   run "$PWD"/hooks/command
 
   assert_failure
   assert_output --partial "Compose file versions 2.0 and above"
+
+  unstub docker
 }
 
 @test "Build with a cache-from image" {
@@ -269,6 +207,7 @@ setup_file() {
   assert_output --partial "pulled cache image"
   assert_output --partial "- my.repository/myservice_cache:latest"
   assert_output --partial "built helloworld"
+
   unstub docker
 }
 
@@ -292,6 +231,7 @@ setup_file() {
   assert_output --partial "pulled cache image"
   assert_output --partial "- my.repository:port/myservice_cache:latest"
   assert_output --partial "built helloworld"
+
   unstub docker
 }
 
@@ -304,7 +244,7 @@ setup_file() {
   export BUILDKITE_BUILD_NUMBER=1
 
   stub docker \
-    "compose -f tests/composefiles/docker-compose.v3.2.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml build --pull helloworld : echo built helloworld"
+    "compose -f tests/composefiles/docker-compose.v3.2.yml -p buildkite1111 build --pull helloworld : echo built helloworld"
 
   run "$PWD"/hooks/command
 
@@ -313,6 +253,7 @@ setup_file() {
   refute_output --partial "- my.repository/myservice_cache:-latest"
   assert_output --partial "invalid tag so it will be ignored"
   assert_output --partial "built helloworld"
+
   unstub docker
 }
 
@@ -335,6 +276,7 @@ setup_file() {
   assert_output --partial "pulled cache image"
   assert_output --partial "- my.repository/myservice_cache"
   assert_output --partial "built helloworld"
+
   unstub docker
 }
 
@@ -348,7 +290,7 @@ setup_file() {
   export BUILDKITE_BUILD_NUMBER=1
 
   stub docker \
-    "compose -f tests/composefiles/docker-compose.v3.2.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml build --pull --no-cache helloworld : echo built helloworld"
+    "compose -f tests/composefiles/docker-compose.v3.2.yml -p buildkite1111 build --pull --no-cache helloworld : echo built helloworld"
 
   run "$PWD"/hooks/command
 
@@ -356,6 +298,7 @@ setup_file() {
   refute_output --partial "pulled cache image"
   refute_output --partial "- my.repository/myservice_cache:latest"
   assert_output --partial "built helloworld"
+
   unstub docker
 }
 
@@ -379,6 +322,7 @@ setup_file() {
   assert_output --partial "- my.repository/myservice_cache:branch-name"
   refute_output --partial "- my.repository/myservice_cache:latest"
   assert_output --partial "built helloworld"
+
   unstub docker
 }
 
@@ -403,6 +347,7 @@ setup_file() {
   refute_output --partial "- my.repository/myservice_cache:branch-name"
   assert_output --partial "- my.repository/myservice_cache:latest"
   assert_output --partial "built helloworld"
+
   unstub docker
 }
 
@@ -416,7 +361,7 @@ setup_file() {
 
   stub docker \
     "pull my.repository/myservice_cache:latest : exit 1" \
-    "compose -f tests/composefiles/docker-compose.v3.2.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml build --pull helloworld : echo built helloworld"
+    "compose -f tests/composefiles/docker-compose.v3.2.yml -p buildkite1111 build --pull helloworld : echo built helloworld"
 
   run "$PWD"/hooks/command
 
@@ -424,6 +369,7 @@ setup_file() {
   assert_output --partial "my.repository/myservice_cache:latest will not be used as a cache for helloworld"
   refute_output --partial "- my.repository/myservice_cache:latest"
   assert_output --partial "built helloworld"
+
   unstub docker
 }
 
@@ -445,6 +391,7 @@ setup_file() {
   assert_output --partial "pulled cache image"
   assert_output --partial "- my.repository/my-service_cache:latest"
   assert_output --partial "built hello-world"
+
   unstub docker
 }
 
@@ -466,6 +413,7 @@ setup_file() {
   assert_output --partial "pulled cache image"
   assert_output --partial "- my.repository/my-service_cache:latest"
   assert_output --partial "built hello.world"
+
   unstub docker
 }
 
@@ -490,127 +438,8 @@ setup_file() {
   assert_output --partial "pulled cache image"
   assert_output --partial "- my.repository/myservice_cache:latest"
   assert_output --partial "built helloworld"
+
   unstub docker
-}
-
-@test "Build with a custom image-name" {
-  export BUILDKITE_JOB_ID=1111
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD=myservice
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_IMAGE_NAME=my-llamas-image
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_IMAGE_REPOSITORY=my.repository/llamas
-  export BUILDKITE_PIPELINE_SLUG=test
-  export BUILDKITE_BUILD_NUMBER=1
-
-  stub docker \
-    "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml build --pull myservice : echo built myservice" \
-    "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml push myservice : echo pushed myservice" \
-
-  stub buildkite-agent \
-    "meta-data set docker-compose-plugin-built-image-tag-myservice my.repository/llamas:my-llamas-image : echo set image metadata for myservice"
-
-  run "$PWD"/hooks/command
-
-  assert_success
-  assert_output --partial "built myservice"
-  assert_output --partial "pushed myservice"
-  assert_output --partial "set image metadata for myservice"
-  unstub docker
-  unstub buildkite-agent
-}
-
-@test "Build with an invalid image-name (start with hyphen) " {
-  export BUILDKITE_JOB_ID=1111
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD=myservice
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_IMAGE_NAME=-llamas-image
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_IMAGE_REPOSITORY=my.repository/llamas
-  export BUILDKITE_BUILD_NUMBER=1
-
-  run "$PWD"/hooks/command
-
-  assert_failure
-  assert_output --partial "-llamas-image is not a valid tag name"
-}
-
-@test "Build with an invalid image-name (start with period) " {
-  export BUILDKITE_JOB_ID=1111
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD=myservice
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_IMAGE_NAME=.llamas-image
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_IMAGE_REPOSITORY=my.repository/llamas
-  export BUILDKITE_BUILD_NUMBER=1
-
-  run "$PWD"/hooks/command
-
-  assert_failure
-  assert_output --partial ".llamas-image is not a valid tag name"
-}
-
-@test "Build with an invalid image-name (too long) " {
-  export BUILDKITE_JOB_ID=1111
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD=myservice
-  # shellcheck disable=SC2155 # numbers from 1 to 69 result in 129 characters
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_IMAGE_NAME="$(seq 69 | tr -d "\n")"
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_IMAGE_REPOSITORY=my.repository/llamas
-  export BUILDKITE_BUILD_NUMBER=1
-
-  run "$PWD"/hooks/command
-
-  assert_failure
-  assert_output --partial "is not a valid tag name"
-}
-
-@test "Build with a custom image-name and a config" {
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CONFIG="tests/composefiles/docker-compose.v3.2.yml"
-  export BUILDKITE_JOB_ID=1111
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD=myservice
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_IMAGE_NAME=my-llamas-image
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_IMAGE_REPOSITORY=my.repository/llamas
-  export BUILDKITE_PIPELINE_SLUG=test
-  export BUILDKITE_BUILD_NUMBER=1
-
-  stub docker \
-    "compose -f tests/composefiles/docker-compose.v3.2.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml build --pull myservice : echo built myservice" \
-    "compose -f tests/composefiles/docker-compose.v3.2.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml push myservice : echo pushed myservice" \
-
-  stub buildkite-agent \
-    "meta-data set docker-compose-plugin-built-image-tag-myservice-tests/composefiles/docker-compose.v3.2.yml my.repository/llamas:my-llamas-image : echo set image metadata for myservice"
-
-  run "$PWD"/hooks/command
-
-  assert_success
-  assert_output --partial "built myservice"
-  assert_output --partial "pushed myservice"
-  assert_output --partial "set image metadata for myservice"
-  unstub docker
-  unstub buildkite-agent
-}
-
-@test "Build multiple images with custom image-names" {
-  export BUILDKITE_JOB_ID=1112
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD_0=myservice1
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD_1=myservice2
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_IMAGE_NAME_0=my-llamas-image-1
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_IMAGE_NAME_1=my-llamas-image-2
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_IMAGE_REPOSITORY=my.repository/llamas
-  export BUILDKITE_PIPELINE_SLUG=test
-  export BUILDKITE_BUILD_NUMBER=1
-
-  stub docker \
-    "compose -f docker-compose.yml -p buildkite1112 -f docker-compose.buildkite-1-override.yml build --pull myservice1 myservice2 : echo built all services" \
-    "compose -f docker-compose.yml -p buildkite1112 -f docker-compose.buildkite-1-override.yml push myservice1 myservice2 : echo pushed all services" \
-
-  stub buildkite-agent \
-    "meta-data set docker-compose-plugin-built-image-tag-myservice1 my.repository/llamas:my-llamas-image-1 : echo set image metadata for myservice1" \
-    "meta-data set docker-compose-plugin-built-image-tag-myservice2 my.repository/llamas:my-llamas-image-2 : echo set image metadata for myservice2"
-
-  run "$PWD"/hooks/command
-
-  assert_success
-  assert_output --partial "built all services"
-  assert_output --partial "pushed all services"
-  assert_output --partial "set image metadata for myservice1"
-  assert_output --partial "set image metadata for myservice2"
-  unstub docker
-  unstub buildkite-agent
 }
 
 @test "Build with target" {
@@ -622,13 +451,13 @@ setup_file() {
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_TARGET=intermediate
 
   stub docker \
-    "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml build --pull --target \* \* : echo built \${12} with target \${11}"
+    "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml build --pull \* : echo built \${10}"
 
   run "$PWD"/hooks/command
 
   assert_success
   assert_output --partial "built myservice"
-  assert_output --partial "with target intermediate"
+  assert_output --partial "    target: intermediate"
 
   unstub docker
 }
@@ -642,7 +471,7 @@ setup_file() {
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_SSH=true
 
   stub docker \
-    "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml build --pull --ssh default \* : echo built \${12} with ssh"
+    "compose -f docker-compose.yml -p buildkite1111 build --pull --ssh default \* : echo built \${10} with ssh"
 
   run "$PWD"/hooks/command
 
@@ -662,7 +491,7 @@ setup_file() {
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_SSH=context
 
   stub docker \
-    "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml build --pull --ssh context \* : echo built \${12} with ssh"
+    "compose -f docker-compose.yml -p buildkite1111 build --pull --ssh context \* : echo built \${10} with ssh"
 
   run "$PWD"/hooks/command
 
@@ -683,7 +512,7 @@ setup_file() {
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_SECRETS_1='id=SECRET_VAR'
 
   stub docker \
-    "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml build --pull --secret \* --secret \* \* : echo built \${14} with secrets \${11} and \${13}"
+    "compose -f docker-compose.yml -p buildkite1111 build --pull --secret \* --secret \* \* : echo built \${12} with secrets \${9} and \${11}"
 
   run "$PWD"/hooks/command
 
@@ -702,11 +531,12 @@ setup_file() {
   export BUILDKITE_BUILD_NUMBER=1
 
   stub docker \
-    "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml build myservice : echo built myservice"
+    "compose -f docker-compose.yml -p buildkite1111 build myservice : echo built myservice"
 
   run "$PWD"/hooks/command
 
   assert_success
   assert_output --partial "built myservice"
+
   unstub docker
 }

--- a/tests/v2/push.bats
+++ b/tests/v2/push.bats
@@ -23,7 +23,7 @@ setup_file() {
     "meta-data set docker-compose-plugin-built-image-tag-app \* : echo \$4"
 
   stub docker \
-    "compose -f docker-compose.yml -p buildkite1111 config --images app : echo somewhere.dkr.ecr.some-region.amazonaws.com/blah" \
+    "compose -f docker-compose.yml -p buildkite1111 config : cat ${PWD}/tests/composefiles/docker-compose.config.v3.2.yml" \
     "image inspect somewhere.dkr.ecr.some-region.amazonaws.com/blah : exit 0" \
     "compose -f docker-compose.yml -p buildkite1111 push app : echo pushed app"
 
@@ -42,7 +42,7 @@ setup_file() {
   export BUILDKITE_BUILD_NUMBER=1
 
   stub docker \
-    "compose -f docker-compose.yml -p buildkite1111 config --images myservice : echo ''" \
+    "compose -f docker-compose.yml -p buildkite1111 config : echo ''" \
     "pull myimage : echo pulled prebuilt image" \
     "tag myimage my.repository/myservice:llamas : echo tagged image" \
     "push my.repository/myservice:llamas : echo pushed myservice"
@@ -71,7 +71,7 @@ setup_file() {
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_COMPATIBILITY=true
 
   stub docker \
-    "compose --compatibility -f docker-compose.yml -p buildkite1111 config --images myservice : echo ''" \
+    "compose --compatibility -f docker-compose.yml -p buildkite1111 config : echo ''" \
     "pull myimage : echo pulled prebuilt image" \
     "tag myimage my.repository/myservice:llamas : echo tagged image" \
     "push my.repository/myservice:llamas : echo pushed myservice"
@@ -99,15 +99,24 @@ setup_file() {
   export BUILDKITE_BUILD_NUMBER=1
 
   stub docker \
-    "compose -f docker-compose.yml -p buildkite1111 config --images myservice : echo ''"
+    "compose -f docker-compose.yml -p buildkite1111 config : echo ''" \
+    "pull prebuilt : echo ''" \
+    "tag prebuilt \* : echo 'invalid tag'; exit 1"
+
+  stub buildkite-agent \
+    "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 0" \
+    "meta-data get docker-compose-plugin-built-image-tag-myservice : echo prebuilt" \
 
   run "$PWD"/hooks/command
 
-  assert_success
+  assert_failure
+
   refute_output --partial "pulled prebuilt image"
   refute_output --partial "tagged image"
   assert_output --partial "invalid tag"
+
   unstub docker
+  unstub buildkite-agent
 }
 
 @test "Push a prebuilt image to multiple tags" {
@@ -119,14 +128,14 @@ setup_file() {
   export BUILDKITE_BUILD_NUMBER=1
 
   stub docker \
-    "compose -f docker-compose.yml -p buildkite1111 config --images myservice : echo ''" \
+    "compose -f docker-compose.yml -p buildkite1111 config : echo ''" \
     "pull prebuilt : echo pulled prebuilt image" \
     "tag prebuilt my.repository/myservice:llamas : echo tagged image1" \
     "push my.repository/myservice:llamas : echo pushed myservice1" \
-    "compose -f docker-compose.yml -p buildkite1111 config --images myservice : echo ''" \
+    "compose -f docker-compose.yml -p buildkite1111 config : echo ''" \
     "tag prebuilt2 my.repository/myservice:latest : echo tagged image2" \
     "push my.repository/myservice:latest : echo pushed myservice2" \
-    "compose -f docker-compose.yml -p buildkite1111 config --images myservice : echo ''" \
+    "compose -f docker-compose.yml -p buildkite1111 config : echo ''" \
     "tag prebuilt3 my.repository/myservice:alpacas : echo tagged image3" \
     "push my.repository/myservice:alpacas : echo pushed myservice3"
 
@@ -166,7 +175,7 @@ setup_file() {
     "meta-data set docker-compose-plugin-built-image-tag-helper \* : echo \$4"
 
   stub docker \
-    "compose -f docker-compose.yml -p buildkite1111 config --images helper : echo buildkite1111-helper" \
+    "compose -f docker-compose.yml -p buildkite1111 config : cat ${PWD}/tests/composefiles/docker-compose.config.v3.2.yml" \
     "image inspect buildkite1111-helper : exit 0" \
     "tag buildkite1111-helper my.repository/helper:llamas : echo tagged helper" \
     "push my.repository/helper:llamas : echo pushed helper"
@@ -190,7 +199,7 @@ setup_file() {
     "meta-data exists docker-compose-plugin-built-image-tag-helper : exit 1"
 
   stub docker \
-    "compose -f docker-compose.yml -p buildkite1111 config --images helper : echo 'buildkite1111-helper'" \
+    "compose -f docker-compose.yml -p buildkite1111 config : cat ${PWD}/tests/composefiles/docker-compose.config.v3.2.yml" \
     "image inspect buildkite1111-helper : exit 1" 
 
   run "$PWD"/hooks/command
@@ -210,11 +219,11 @@ setup_file() {
   export BUILDKITE_BUILD_NUMBER=1
 
   stub docker \
-    "compose -f docker-compose.yml -p buildkite1111 config --images myservice1 : echo ''" \
+    "compose -f docker-compose.yml -p buildkite1111 config : echo ''" \
     "pull prebuilt1 : exit 0" \
     "tag prebuilt1 my.repository/myservice1 : echo tagging image1" \
     "push my.repository/myservice1 : echo pushing myservice1 image" \
-    "compose -f docker-compose.yml -p buildkite1111 config --images myservice2 : echo ''" \
+    "compose -f docker-compose.yml -p buildkite1111 config : echo ''" \
     "pull prebuilt2 : exit 0" \
     "tag prebuilt2 my.repository/myservice2:llamas : echo tagging image2" \
     "push my.repository/myservice2:llamas : echo pushing myservice2 image"

--- a/tests/v2/push.bats
+++ b/tests/v2/push.bats
@@ -19,7 +19,6 @@ setup_file() {
   export BUILDKITE_BUILD_NUMBER=1
 
   stub buildkite-agent \
-    "meta-data exists docker-compose-plugin-built-image-tag-app : exit 1" \
     "meta-data set docker-compose-plugin-built-image-tag-app \* : echo \$4"
 
   stub docker \
@@ -43,6 +42,7 @@ setup_file() {
 
   stub docker \
     "compose -f docker-compose.yml -p buildkite1111 config : echo ''" \
+    "image inspect \* : exit 1" \
     "pull myimage : echo pulled prebuilt image" \
     "tag myimage my.repository/myservice:llamas : echo tagged image" \
     "push my.repository/myservice:llamas : echo pushed myservice"
@@ -72,6 +72,7 @@ setup_file() {
 
   stub docker \
     "compose --compatibility -f docker-compose.yml -p buildkite1111 config : echo ''" \
+    "image inspect \* : exit 1" \
     "pull myimage : echo pulled prebuilt image" \
     "tag myimage my.repository/myservice:llamas : echo tagged image" \
     "push my.repository/myservice:llamas : echo pushed myservice"
@@ -100,6 +101,7 @@ setup_file() {
 
   stub docker \
     "compose -f docker-compose.yml -p buildkite1111 config : echo ''" \
+    "image inspect \* : exit 1" \
     "pull prebuilt : echo ''" \
     "tag prebuilt \* : echo 'invalid tag'; exit 1"
 
@@ -129,13 +131,16 @@ setup_file() {
 
   stub docker \
     "compose -f docker-compose.yml -p buildkite1111 config : echo ''" \
+    "image inspect \* : exit 1" \
     "pull prebuilt : echo pulled prebuilt image" \
     "tag prebuilt my.repository/myservice:llamas : echo tagged image1" \
     "push my.repository/myservice:llamas : echo pushed myservice1" \
     "compose -f docker-compose.yml -p buildkite1111 config : echo ''" \
+    "image inspect \* : exit 1" \
     "tag prebuilt2 my.repository/myservice:latest : echo tagged image2" \
     "push my.repository/myservice:latest : echo pushed myservice2" \
     "compose -f docker-compose.yml -p buildkite1111 config : echo ''" \
+    "image inspect \* : exit 1" \
     "tag prebuilt3 my.repository/myservice:alpacas : echo tagged image3" \
     "push my.repository/myservice:alpacas : echo pushed myservice3"
 
@@ -171,7 +176,6 @@ setup_file() {
   export BUILDKITE_BUILD_NUMBER=1
 
   stub buildkite-agent \
-    "meta-data exists docker-compose-plugin-built-image-tag-helper : exit 1" \
     "meta-data set docker-compose-plugin-built-image-tag-helper \* : echo \$4"
 
   stub docker \
@@ -220,10 +224,12 @@ setup_file() {
 
   stub docker \
     "compose -f docker-compose.yml -p buildkite1111 config : echo ''" \
+    "image inspect buildkite1111-myservice1 : exit 1" \
     "pull prebuilt1 : exit 0" \
     "tag prebuilt1 my.repository/myservice1 : echo tagging image1" \
     "push my.repository/myservice1 : echo pushing myservice1 image" \
     "compose -f docker-compose.yml -p buildkite1111 config : echo ''" \
+    "image inspect buildkite1111-myservice2 : exit 1" \
     "pull prebuilt2 : exit 0" \
     "tag prebuilt2 my.repository/myservice2:llamas : echo tagging image2" \
     "push my.repository/myservice2:llamas : echo pushing myservice2 image"

--- a/tests/v2/run.bats
+++ b/tests/v2/run.bats
@@ -13,6 +13,11 @@ setup_file() {
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RUN_LABELS="false"
 }
 
+teardown() {
+  # plugin leaves override files around
+  rm -f docker-compose.buildkite*-override.yml
+}
+
 @test "Run without a prebuilt image" {
   export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RUN=myservice


### PR DESCRIPTION
Simplified configuration removing `image-repository` and `image-name` configurations. Changed the way build and push interact. Now builds do not push, so metadata to signal pre-built images to further steps in the pipeline is moved to pushes as well.

Also refactored the logic to create override files only when necessary and with other information (like `target` values), thus correcting #391
