### PR TITLE
Cache from simplification

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -61,7 +61,7 @@ steps:
     plugins:
       ${BUILDKITE_PULL_REQUEST_REPO:-$BUILDKITE_REPO}#${BUILDKITE_COMMIT}:
         build: helloworld
-        image-repository: "$IMAGE_REPO"
+        push: "helloworld:${IMAGE_REPO}"
         config: tests/composefiles/docker-compose.v2.0.yml
 
   - label: run after build with v2.0
@@ -83,7 +83,7 @@ steps:
     plugins:
       ${BUILDKITE_PULL_REQUEST_REPO:-$BUILDKITE_REPO}#${BUILDKITE_COMMIT}:
         build: helloworld
-        image-repository: "$IMAGE_REPO"
+        push: "helloworld:${IMAGE_REPO}"
         config: tests/composefiles/docker-compose.v2.1.yml
 
   - label: run with default command
@@ -95,42 +95,19 @@ steps:
         run: helloworld
         config: tests/composefiles/docker-compose.v2.1.yml
 
-  - label: prebuild, where service has build and image-repo
-    key: prebuild-2-1-build-image-repo
-    env:
-      PERSIST_REGISTRY: true
-    plugins:
-      ${BUILDKITE_PULL_REQUEST_REPO:-$BUILDKITE_REPO}#${BUILDKITE_COMMIT}:
-        build: helloworldimage
-        image-repository: "$IMAGE_REPO"
-        config: tests/composefiles/docker-compose.v2.1.yml
-        commmand: ["/hello"]
-
-  - label: run after prebuild
-    depends_on: prebuild-2-1-build-image-repo
-    env:
-      RESTORE_REGISTRY_FROM: prebuild-2-1-build-image-repo
-    plugins:
-      ${BUILDKITE_PULL_REQUEST_REPO:-$BUILDKITE_REPO}#${BUILDKITE_COMMIT}:
-        run: helloworldimage
-        require-prebuild: true
-        config: tests/composefiles/docker-compose.v2.1.yml
-        commmand: ["/hello"]
-
   - wait: ~
 
-  - label: prebuild with custom image-name
+  - label: prebuild with custom tag
     key: prebuild-custom-image-name
     env:
       PERSIST_REGISTRY: true
     plugins:
       ${BUILDKITE_PULL_REQUEST_REPO:-$BUILDKITE_REPO}#${BUILDKITE_COMMIT}:
         build: helloworld
-        image-repository: "$IMAGE_REPO"
-        image-name: llamas-build-${BUILDKITE_BUILD_NUMBER}
+        push: "helloworld:${IMAGE_REPO}:llamas-build-${BUILDKITE_BUILD_NUMBER}"
         config: tests/composefiles/docker-compose.v2.1.yml
 
-  - label: run after prebuild with custom image-name
+  - label: run after prebuild with custom tag
     depends_on: prebuild-custom-image-name
     env:
       RESTORE_REGISTRY_FROM: prebuild-custom-image-name
@@ -141,12 +118,11 @@ steps:
         config: tests/composefiles/docker-compose.v2.1.yml
         commmand: ["/hello"]
 
-  - label: push after build with custom image-name
+  - label: push after build with custom tag
     depends_on: prebuild-custom-image-name
     env:
       RESTORE_REGISTRY_FROM: prebuild-custom-image-name
     plugins:
       ${BUILDKITE_PULL_REQUEST_REPO:-$BUILDKITE_REPO}#${BUILDKITE_COMMIT}:
-        push: helloworld
-        image-name: llamas-build-${BUILDKITE_BUILD_NUMBER}
+        push: helloworld:${IMAGE_REPO}:llamas-build-${BUILDKITE_BUILD_NUMBER}-push
         config: tests/composefiles/docker-compose.v2.1.yml

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -23,6 +23,8 @@ steps:
       ${BUILDKITE_PULL_REQUEST_REPO:-$BUILDKITE_REPO}#${BUILDKITE_COMMIT}:
         run: tests
         command: ["bats", "tests", "tests/v2"]
+        # for pretty colors
+        tty: true
 
   # The rest of the steps are integration tests
 

--- a/README.md
+++ b/README.md
@@ -256,11 +256,11 @@ A newly spawned agent won't contain any of the docker caches for the first run w
 
 ```yaml
 steps:
-  - label: ":docker Build an image"
+  - label: ":docker: Build an image"
     plugins:
       - docker-compose#v4.16.0:
           build: app
-          push: app:index.docker.io/myorg/myrepo:my-branch
+          push: app:myregistry:port/myrepo/myapp:my-branch
           cache-from:
             - "app:myregistry:port/myrepo/myapp:my-branch"
             - "app:myregistry:port/myrepo/myapp:latest"
@@ -280,7 +280,7 @@ The values you add in the `cache-from` will be mapped to the corresponding servi
 
 ```yaml
 steps:
-  - label: ":docker Build an image"
+  - label: ":docker: Build an image"
     plugins:
       - docker-compose#v4.16.0:
           build: app

--- a/README.md
+++ b/README.md
@@ -609,9 +609,9 @@ The default is `false`.
 
 ### `tty` (optional, run only)
 
-If set to false, doesn't allocate a TTY. This is useful in some situations where TTY's aren't supported, for instance windows.
+If set to true, allocates a TTY. This is useful in some situations TTYs are required.
 
-The default is `true` on unix, `false` on windows
+The default is `false`.
 
 ### `dependencies` (optional, run only)
 

--- a/README.md
+++ b/README.md
@@ -430,9 +430,9 @@ Will cause the image to be pushed twice (once by the build step and another by t
 
 Pull down multiple pre-built images. By default only the service that is being run will be pulled down, but this allows multiple images to be specified to handle prebuilt dependent images. Note that pulling will be skipped if the `skip-pull` option is activated.
 
-### `collapse-run-log-group` (optional, boolean, run only)
+### `collapse-logs` (optional, boolean)
 
-Whether to collapse or expand the log group that is created for the output of `docker-compose run`. When this setting is `true`, the output is collected into a `---` group, when `false` the output is collected into a `+++` group. Setting this to `true` can be useful to de-emphasize plugin output if your command creates its own `+++` group.
+Whether to collapse or expand the log group that is created for the output of the main commands (`run`, `build` and `push`). When this setting is `true`, the output is collected into a `---` group, when `false` the output is collected into a `+++` group. Setting this to `true` can be useful to de-emphasize plugin output if your command creates its own `+++` group.
 
 For more information see [Managing log output](https://buildkite.com/docs/pipelines/managing-log-output).
 

--- a/README.md
+++ b/README.md
@@ -508,7 +508,7 @@ They will be mapped directly to `cache-from` elements in the build according to 
 
 ### `target` (optional, build only)
 
-Allow for intermediate builds with `--target VALUE` options.
+Allow for intermediate builds as if building with docker's `--target VALUE` options.
 
 Note that there is a single build command run for all services so the target value will apply to all of them.
 

--- a/README.md
+++ b/README.md
@@ -444,21 +444,11 @@ The file name of the Docker Compose configuration file to use. Can also be a lis
 
 Default: `docker-compose.yml`
 
-### `image-repository` (optional, build only)
-
-The repository for pushing and pulling pre-built images, same as the repository location you would use for a `docker push`, for example `"index.docker.io/myorg/myrepo"`. Each image is tagged to the specific build so you can safely share the same image repository for any number of projects and builds.
-
-The default is `""` which only builds images on the local Docker host doing the build.
-
-This option can also be configured on the agent machine using the environment variable `BUILDKITE_PLUGIN_DOCKER_COMPOSE_IMAGE_REPOSITORY`.
-
-### `image-name` (optional, build only)
-
-The name to use when tagging pre-built images. If multiple images are built in the build phase, you must provide an array of image names.
-
 ### `build-alias` (optional, build only)
 
-Other docker-compose services that should be aliased to the main service that was built. This is for when different docker-compose services share the same prebuilt image.
+Other docker-compose services that should be aliased to the service that was built. This is to have a pre-built image set for different services based off a single definitio.
+
+Important: this only works when building a single service, an error will be generated otherwise
 
 ### `args` (optional, build and run only)
 

--- a/README.md
+++ b/README.md
@@ -502,16 +502,9 @@ This option can also be configured on the agent machine using the environment va
 
 ### `cache-from` (optional, build only)
 
-A list of images to attempt pulling before building in the format `service:index.docker.io/myorg/myrepo/myapp:tag:group`, ignoring any failures, to allow docker to re-use layers. The parameters `service` and `image-repo` are mandatory, without them it won't work. For each combination of service and group, it will attempt to pull each in order until one is successful (the rest will be ignored). Those elements that don't have a group specified will use a `:default:` group.
-Requires docker-compose file version `3.2+`.
+A list of images to attempt pulling before building in the format `service:CACHE-SPEC` to allow for layer re-use. Will be ignored if `no-cache` is turned on.
 
-### `separator-cache-from` (optional, build only, single character)
-
-A single character that specifies the character to use for splitting elements in the `cache-from` option.
-
-By default it is `:` which should not be a problem unless your registry's URL contains a port, in which case you will have to use this option to specify a different character.
-
-**Important**: the tag to use is its own field, so you will have to specify elements like `service#registry:port/myrepo/myapp#tag#group`
+They will be mapped directly to `cache-from` elements in the build according to the spec so any valid format there should be allowed.
 
 ### `target` (optional, build only)
 

--- a/commands/build.sh
+++ b/commands/build.sh
@@ -1,9 +1,7 @@
 #!/bin/bash
 set -ueo pipefail
 
-image_repository="$(plugin_read_config IMAGE_REPOSITORY)"
 pull_retries="$(plugin_read_config PULL_RETRIES "0")"
-push_retries="$(plugin_read_config PUSH_RETRIES "0")"
 separator="$(plugin_read_config SEPARATOR_CACHE_FROM ":")"
 override_file="docker-compose.buildkite-${BUILDKITE_BUILD_NUMBER}-override.yml"
 build_images=()
@@ -45,11 +43,6 @@ named_array_values() {
   local copy=( "${!tmp}" )
   echo "${copy[@]}"
 }
-
-if [[ -z "$image_repository" ]] ; then
-  echo "+++ ⚠️ Build step missing image-repository setting"
-  echo "This build step has no image-repository set. Without an image-repository, the Docker image won't be pushed to a repository, and won't be automatically used by any run steps."
-fi
 
 if [[ "$(plugin_read_config BUILDKIT "false")" == "true" ]]; then
   export DOCKER_BUILDKIT=1
@@ -113,32 +106,23 @@ fi
 # write into a docker-compose override file
 service_idx=0
 for service_name in $(plugin_read_list BUILD) ; do
-  image_name=$(build_image_name "${service_name}" "${service_idx}")
-
-  if ! validate_tag "$image_name"; then
-    echo "🚨 ${image_name} is not a valid tag name"
-    exit 1
-  fi
-
   service_idx=$((service_idx+1))
-
-  if [[ -n "$image_repository" ]] ; then
-    image_name="${image_repository}:${image_name}"
-  fi
-
-  build_images+=("$service_name" "$image_name")
+  image_name="" # no longer used here
 
   cache_from_var="$(service_name_cache_from_var "${service_name}")"
   if [[ -n "${!cache_from_var-}" ]]; then
     cache_from_length="$(count_of_named_array "${cache_from_var}")"
-    build_images+=("${cache_from_length}")
+  else
+    cache_from_length=0
+  fi
+
+  if [[ "${cache_from_length:-0}" -gt 0 ]]; then
+    build_images+=("$service_name" "${image_name}" "${cache_from_length}")
 
     for i in $(seq 0 "$((cache_from_length-1))"); do
       cache_from_group_var="$(service_name_group_name_cache_from_var "$service_name" "$i")"
       build_images+=("${!cache_from_group_var}")
     done
-  else
-    build_images+=(0)
   fi
 done
 
@@ -197,23 +181,4 @@ while read -r arg ; do
 done <<< "$(plugin_read_list ARGS)"
 
 echo "${group_type} :docker: Building services ${services[*]}"
-run_docker_compose -f "$override_file" "${build_params[@]}" "${services[@]}"
-
-if [[ -n "$image_repository" ]] ; then
-  echo "~~~ :docker: Pushing built images to $image_repository"
-  retry "$push_retries" run_docker_compose -f "$override_file" push "${services[@]}"
-
-  # iterate over build images
-  while [[ ${#build_images[@]} -gt 0 ]] ; do
-    set_prebuilt_image "${build_images[0]}" "${build_images[1]}"
-
-    # set aliases
-    for service_alias in $(plugin_read_list BUILD_ALIAS) ; do
-      set_prebuilt_image "$service_alias" "${build_images[1]}"
-    done
-
-    # pop-off the last build image
-    # 3 for service, image, num_cache_from; plus num_cache_from
-    build_images=("${build_images[@]:(3 + ${build_images[2]})}")
-  done
-fi
+run_docker_compose "${build_params[@]}" "${services[@]}"

--- a/commands/build.sh
+++ b/commands/build.sh
@@ -8,6 +8,12 @@ separator="$(plugin_read_config SEPARATOR_CACHE_FROM ":")"
 override_file="docker-compose.buildkite-${BUILDKITE_BUILD_NUMBER}-override.yml"
 build_images=()
 
+if [[ "${BUILDKITE_PLUGIN_DOCKER_COMPOSE_COLLAPSE_LOGS:-false}" = "true" ]]; then
+  group_type="---"
+else
+  group_type="+++"
+fi
+
 normalize_var_name() {
   local orig_value="$1"
   # POSIX variable names should match [a-zA-Z_][a-zA-Z0-9_]*
@@ -190,7 +196,7 @@ while read -r arg ; do
   [[ -n "${arg:-}" ]] && build_params+=("--build-arg" "${arg}")
 done <<< "$(plugin_read_list ARGS)"
 
-echo "+++ :docker: Building services ${services[*]}"
+echo "${group_type} :docker: Building services ${services[*]}"
 run_docker_compose -f "$override_file" "${build_params[@]}" "${services[@]}"
 
 if [[ -n "$image_repository" ]] ; then

--- a/commands/build.sh
+++ b/commands/build.sh
@@ -51,11 +51,6 @@ if [[ "$(plugin_read_config BUILDKIT "false")" == "true" ]]; then
   export BUILDKIT_PROGRESS=plain
 fi
 
-if [[ -n "$(plugin_read_config TARGET "")" ]] && [[ -z "$(plugin_read_config BUILD "")" ]]; then
-  echo "+++ 🚨 You can not use target if you are not building a single service"
-  exit 1
-fi
-
 # Read any cache-from parameters provided and pull down those images first
 # If no-cache is set skip pulling the cache-from images
 if [[ "$(plugin_read_config NO_CACHE "false")" == "false" ]] ; then

--- a/commands/build.sh
+++ b/commands/build.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 set -ueo pipefail
 
-pull_retries="$(plugin_read_config PULL_RETRIES "0")"
 override_file="docker-compose.buildkite-${BUILDKITE_BUILD_NUMBER}-override.yml"
 build_images=()
 build_params=()
@@ -12,93 +11,51 @@ else
   group_type="+++"
 fi
 
-normalize_var_name() {
-  local orig_value="$1"
-  # POSIX variable names should match [a-zA-Z_][a-zA-Z0-9_]*
-  # service names and the like also allow periods and dashes
-  no_periods="${orig_value//./_}"
-  no_dashes="${no_periods//-/_}"
-  echo "${no_dashes}"
-}
-
-service_name_cache_from_var() {
-  local service_name="$1"
-  echo "cache_from__$(normalize_var_name "${service_name}")"
-}
-
-service_name_group_name_cache_from_var() {
-  local service_name="$1"
-  local group_index="$2"
-  echo "group_cache_from__$(normalize_var_name "${service_name}")__$(normalize_var_name "${group_index}")"
-}
-
-count_of_named_array() {
-  local tmp="$1[@]"
-  local copy=( "${!tmp}" )
-  echo "${#copy[@]}"
-}
-
-named_array_values() {
-  local tmp="$1[@]"
-  local copy=( "${!tmp}" )
-  echo "${copy[@]}"
-}
-
 if [[ "$(plugin_read_config BUILDKIT "false")" == "true" ]]; then
   export DOCKER_BUILDKIT=1
   export COMPOSE_DOCKER_CLI_BUILD=1
   export BUILDKIT_PROGRESS=plain
 fi
 
-# Read any cache-from parameters provided and pull down those images first
-# If no-cache is set skip pulling the cache-from images
-if [[ "$(plugin_read_config NO_CACHE "false")" == "false" ]] ; then
-  for line in $(plugin_read_list CACHE_FROM) ; do
-    IFS=':' read -r -a tokens <<< "$line"
-    service_name=${tokens[0]}
-    service_image=$(IFS=':'; echo "${tokens[*]:1}")
+get_caches_for_service() {
+  local service="$1"
 
-    # The variable with this name will hold an array of group names:
-    cache_image_name="$(service_name_cache_from_var "$service_name")"
+  # Read any cache-from parameters provided
+  # If no-cache is set skip pulling the cache-from images
+  if [[ "$(plugin_read_config NO_CACHE "false")" == "false" ]] ; then
+    for line in $(plugin_read_list CACHE_FROM) ; do
+      IFS=':' read -r -a tokens <<< "$line"
+      service_name=${tokens[0]}
+      service_image=$(IFS=':'; echo "${tokens[*]:1}")
 
-    if [[ -z "${!cache_image_name+x}" ]]; then
-      declare -a "$cache_image_name"
-      cache_image_length=0
-    else
-      cache_image_length="$(count_of_named_array "${cache_image_name}")"
-    fi
-
-    declare "$cache_image_name+=( $cache_from_group_name )"
-    # The variable with this name will hold the image for the this group
-    # (based on index into the array of group names):
-    cache_from_group_var="$(service_name_group_name_cache_from_var "$service_name" "${cache_image_length}")"
-    printf -v "$cache_from_group_var" "%s" "$service_image"
-  done
-fi
+      if [ "${service_name}" == "${service}" ]; then
+        echo "$service_image"
+      fi
+    done
+  fi
+}
 
 # Run through all images in the build property, either a single item or a list
 # and build up a list of service name, image name and optional cache-froms to
 # write into a docker-compose override file
-service_idx=0
 for service_name in $(plugin_read_list BUILD) ; do
-  service_idx=$((service_idx+1))
   target="$(plugin_read_config TARGET "")"
   image_name="" # no longer used here
 
-  cache_from_var="$(service_name_cache_from_var "${service_name}")"
-  if [[ -n "${!cache_from_var-}" ]]; then
-    cache_from_length="$(count_of_named_array "${cache_from_var}")"
-  else
-    cache_from_length=0
-  fi
+  cache_from=()
+  cache_length=0
+  
+  for cache_line in $(get_caches_for_service "$service_name"); do
+    cache_from+=("$cache_line")
+    cache_length=$((cache_length + 1))
+  done
 
-  if [[ -n "${target}" ]] || [[ "${cache_from_length:-0}" -gt 0 ]]; then
-    build_images+=("$service_name" "${image_name}" "${target}" "${cache_from_length}")
+  if [[ -n "${target}" ]] || [[ "${cache_length:-0}" -gt 0 ]]; then
+    build_images+=("$service_name" "${image_name}" "${target}" "${cache_length}")
 
-    for i in $(seq 0 "$((cache_from_length-1))"); do
-      cache_from_group_var="$(service_name_group_name_cache_from_var "$service_name" "$i")"
-      build_images+=("${!cache_from_group_var}")
-    done
+    if [[ "${cache_length:-0}" -gt 0 ]]; then
+      build_images+=("${cache_from[@]}")
+    fi
   fi
 done
 

--- a/commands/push.sh
+++ b/commands/push.sh
@@ -27,7 +27,9 @@ for line in $(plugin_read_list PUSH) ; do
   service_name=${tokens[0]}
   service_image=$(compose_image_for_service "$service_name")
 
-  if prebuilt_image="$(get_prebuilt_image "$service_name")"; then
+  if docker_image_exists "${service_image}"; then
+    echo "~~~ :docker: Using service image ${service_image} from Docker Compose config"
+  elif prebuilt_image="$(get_prebuilt_image "$service_name")"; then
     echo "~~~ :docker: Using pre-built image ${prebuilt_image}"
 
     # Only pull it down once
@@ -38,8 +40,6 @@ for line in $(plugin_read_list PUSH) ; do
     fi
 
     service_image="${prebuilt_image}"
-  elif docker_image_exists "${service_image}"; then
-    echo "~~~ :docker: Using service image ${service_image} from Docker Compose config"
   else
     echo "+++ 🚨 No prebuilt-image nor service image found for service to push"
     exit 1

--- a/commands/push.sh
+++ b/commands/push.sh
@@ -3,6 +3,12 @@ set -ueo pipefail
 
 push_retries="$(plugin_read_config PUSH_RETRIES "0")"
 
+if [[ "${BUILDKITE_PLUGIN_DOCKER_COMPOSE_COLLAPSE_LOGS:-false}" = "true" ]]; then
+  group_type="---"
+else
+  group_type="+++"
+fi
+
 # Targets for pushing come in a variety of forms:
 
 # service <- just a service name
@@ -55,7 +61,7 @@ for line in $(plugin_read_list PUSH) ; do
   # push: "service-name:repo:tag"
   else
     target_image="$(IFS=:; echo "${tokens[*]:1}")"
-    echo "~~~ :docker: Pushing image $target_image" >&2;
+    echo "${group_type} :docker: Pushing image $target_image" >&2;
     plugin_prompt_and_run docker tag "$service_image" "$target_image"
     retry "$push_retries" plugin_prompt_and_run docker push "$target_image"
   fi

--- a/commands/push.sh
+++ b/commands/push.sh
@@ -27,15 +27,6 @@ for line in $(plugin_read_list PUSH) ; do
   service_name=${tokens[0]}
   service_image=$(compose_image_for_service "$service_name")
 
-  # push in the form of service:repo:tag
-  # if the registry contains a port this means that the tag is mandatory
-  if [[ ${#tokens[@]} -gt 2 ]]; then 
-    if ! validate_tag "${tokens[-1]}"; then
-      echo "🚨 specified image to push ${line} has an invalid tag so it will be ignored"
-      continue
-    fi
-  fi
-
   if prebuilt_image="$(get_prebuilt_image "$service_name")"; then
     echo "~~~ :docker: Using pre-built image ${prebuilt_image}"
 

--- a/commands/run.sh
+++ b/commands/run.sh
@@ -43,7 +43,7 @@ prebuilt_services=()
 for service_name in "${prebuilt_candidates[@]}" ; do
   if prebuilt_image=$(get_prebuilt_image "$service_name") ; then
     echo "~~~ :docker: Found a pre-built image for $service_name"
-    prebuilt_service_overrides+=("$service_name" "$prebuilt_image" 0)
+    prebuilt_service_overrides+=("$service_name" "$prebuilt_image" "" 0)
     prebuilt_services+=("$service_name")
 
     # If it's prebuilt, we need to pull it down

--- a/commands/run.sh
+++ b/commands/run.sh
@@ -155,7 +155,7 @@ if is_windows ; then
   pwd_default="$(cmd.exe //C "echo %CD%")"
 fi
 
-# Optionally disable allocating a TTY
+# Disable allocating a TTY
 if [[ "$(plugin_read_config TTY "$tty_default")" == "false" ]] ; then
   run_params+=(-T)
 fi
@@ -406,11 +406,12 @@ ensure_stopped() {
 
 trap ensure_stopped SIGINT SIGTERM SIGQUIT
 
-if [[ "${BUILDKITE_PLUGIN_DOCKER_COMPOSE_COLLAPSE_RUN_LOG_GROUP:-false}" = "true" ]]; then
+if [[ "${BUILDKITE_PLUGIN_DOCKER_COMPOSE_COLLAPSE_LOGS:-false}" = "true" ]]; then
   group_type="---"
 else
   group_type="+++"
 fi
+
 # Disable -e to prevent cancelling step if the command fails for whatever reason
 set +e
 ( # subshell is necessary to trap signals (compose v2 fails to stop otherwise)

--- a/commands/run.sh
+++ b/commands/run.sh
@@ -142,14 +142,13 @@ if [[ -n "${BUILDKITE_REPO_MIRROR:-}" ]]; then
   run_params+=("-v" "$BUILDKITE_REPO_MIRROR:$BUILDKITE_REPO_MIRROR:ro")
 fi
 
-tty_default='true'
+tty_default='false'
 workdir_default="/workdir"
 pwd_default="$PWD"
 run_dependencies="true"
 
 # Set operating system specific defaults
 if is_windows ; then
-  tty_default='false'
   workdir_default="C:\\workdir"
   # escaping /C is a necessary workaround for an issue with Git for Windows 2.24.1.2
   # https://github.com/git-for-windows/git/issues/2442

--- a/hooks/command
+++ b/hooks/command
@@ -21,7 +21,7 @@ fi
 
 if [[ ${#commands[@]} -lt 1 ]] ; then
   echo "+++ Docker Compose plugin error"
-  echo "No build or run options were specified"
+  echo "No build, run or push options were specified"
   exit 1
 fi
 

--- a/hooks/pre-exit
+++ b/hooks/pre-exit
@@ -8,6 +8,9 @@ DIR="$(cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd)"
 # shellcheck source=lib/metadata.bash
 . "$DIR/../lib/metadata.bash"
 
+# remove build override files
+rm -f "docker-compose.buildkite-${BUILDKITE_BUILD_NUMBER}-override.yml"
+
 # clean up resources after a run command. we do this here so that it will
 # run after a job is cancelled
 if [[ -n "$(plugin_read_list RUN)" ]] && [[ "$(plugin_read_config CLEANUP "true")" == "true" ]] ; then

--- a/lib/shared.bash
+++ b/lib/shared.bash
@@ -161,10 +161,32 @@ function build_image_override_file_with_version() {
 
   shift
   while test ${#} -gt 0 ; do
-    printf "  %s:\\n" "$1"
-    printf "    image: %s\\n" "$2"
+    service_name=$1
+    image_name=$2
+    target=$3
+    cache_from_amt=$4
+    shift 4
 
-    if [[ "$3" -gt 0 ]] ; then
+    if [[ -z "$image_name" ]] && [[ -z "$target" ]] && [[ "$cache_from_amt" -eq 0 ]]; then
+      # should not print out an empty service
+      continue
+    fi
+
+    printf "  %s:\\n" "$service_name"
+
+    if [[ -n "$image_name" ]]; then
+      printf "    image: %s\\n" "$image_name"
+    fi
+
+    if [[ "$cache_from_amt" -gt 0 ]] || [[ -n "$target" ]]; then
+      printf "    build:\\n"
+    fi
+
+    if [[ -n "$target" ]]; then
+      printf "      target: %s\\n" "$target"
+    fi
+
+    if [[ "$cache_from_amt" -gt 0 ]] ; then
       if ! docker_compose_supports_cache_from "$version" ; then
         echo "Unsupported Docker Compose config file version: $version"
         echo "The 'cache_from' option can only be used with Compose file versions 2.2 or 3.2 and above."
@@ -173,15 +195,12 @@ function build_image_override_file_with_version() {
         exit 1
       fi
 
-      printf "    build:\\n"
       printf "      cache_from:\\n"
-      for cache_from_i in $(seq 4 "$((3 + $3))"); do
+      for cache_from_i in $(seq 1 "$cache_from_amt"); do
         printf "        - %s\\n" "${!cache_from_i}"
       done
-      shift "$3"
+      shift "$cache_from_amt"
     fi
-
-    shift 3
   done
 }
 

--- a/lib/shared.bash
+++ b/lib/shared.bash
@@ -214,20 +214,6 @@ function run_docker_compose() {
   plugin_prompt_and_run "${command[@]}" "$@"
 }
 
-# Create an image name that is used to tag custom images
-function build_image_name() {
-  local service_name="$1"
-  local service_idx="$2"
-  local image_names=()
-
-  while read -r name ; do
-    image_names+=("$name")
-  done <<< "$(plugin_read_list IMAGE_NAME)"
-
-  # Either look in custom image_name values, or use our default
-  echo "${image_names[$service_idx]:-${BUILDKITE_PIPELINE_SLUG}-${service_name}-build-${BUILDKITE_BUILD_NUMBER}}"
-}
-
 function in_array() {
   local e
   for e in "${@:2}"; do [[ "$e" == "$1" ]] && return 0; done

--- a/plugin.yml
+++ b/plugin.yml
@@ -56,10 +56,6 @@ configuration:
       type: string
     expand-volume-vars:
       type: boolean
-    image-repository:
-      type: string
-    image-name:
-      type: [ string, array ]
     leave-volumes:
       type: boolean
     mount-buildkite-agent:

--- a/plugin.yml
+++ b/plugin.yml
@@ -85,10 +85,6 @@ configuration:
       type: boolean
     run-labels:
       type: boolean
-    separator-cache-from:
-      type: string
-      minLength: 1
-      maxLength: 1
     service-ports:
       type: boolean
     skip-checkout:
@@ -128,13 +124,10 @@ configuration:
     ansi: [ run ]
     buildkit: [ build ]
     cache-from: [ build ]
-    cache-from-separator: [ cache-from ]
     dependencies: [ run ]
     env: [ run ]
     environment: [ run ]
     expand-volume-vars: [ volumes ]
-    image-repository: [ build ]
-    image-name: [ build ]
     leave-volumes: [ run ]
     mount-buildkite-agent: [ run ]
     mount-checkout: [ run ]

--- a/plugin.yml
+++ b/plugin.yml
@@ -37,7 +37,7 @@ configuration:
           enum: [ 1, 2 ]
     command:
       type: array
-    collapse-run-log-group:
+    collapse-logs:
       type: boolean
     config:
       type: [ string, array ]

--- a/tests/build.bats
+++ b/tests/build.bats
@@ -11,11 +11,14 @@ teardown() {
   rm -f docker-compose.buildkite*-override.yml
 }
 
-@test "Build without a repository" {
+setup_file() {
   export BUILDKITE_JOB_ID=1111
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD=myservice
   export BUILDKITE_PIPELINE_SLUG=test
   export BUILDKITE_BUILD_NUMBER=1
+}
+
+@test "Build without a repository" {
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD=myservice
 
   stub docker \
     "compose -f docker-compose.yml -p buildkite1111 build --pull myservice : echo built myservice"
@@ -29,11 +32,8 @@ teardown() {
 }
 
 @test "Build with no-cache" {
-  export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD=myservice
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_NO_CACHE=true
-  export BUILDKITE_PIPELINE_SLUG=test
-  export BUILDKITE_BUILD_NUMBER=1
 
   stub docker \
     "compose -f docker-compose.yml -p buildkite1111 build --pull --no-cache myservice : echo built myservice"
@@ -47,11 +47,8 @@ teardown() {
 }
 
 @test "Build with parallel" {
-  export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD=myservice
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD_PARALLEL=true
-  export BUILDKITE_PIPELINE_SLUG=test
-  export BUILDKITE_BUILD_NUMBER=1
 
   stub docker \
     "compose -f docker-compose.yml -p buildkite1111 build --pull --parallel myservice : echo built myservice"
@@ -65,10 +62,7 @@ teardown() {
 }
 
 @test "Build with build args" {
-  export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD=myservice
-  export BUILDKITE_PIPELINE_SLUG=test
-  export BUILDKITE_BUILD_NUMBER=1
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_ARGS_0=MYARG=0
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_ARGS_1=MYARG=1
 
@@ -85,12 +79,9 @@ teardown() {
 
 @test "Build with a repository and multiple build aliases" {
   skip 'move to push'
-  export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD=myservice
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD_ALIAS_0=myservice-1
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD_ALIAS_1=myservice-2
-  export BUILDKITE_PIPELINE_SLUG=test
-  export BUILDKITE_BUILD_NUMBER=1
 
   stub docker \
     "compose -f docker-compose.yml -p buildkite1111 build --pull myservice : echo built myservice"
@@ -104,12 +95,9 @@ teardown() {
 }
 
 @test "Build with an override file and docker-compose v1.0 configuration file" {
-  export BUILDKITE_JOB_ID=1112
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CONFIG="tests/composefiles/docker-compose.v1.0.yml"
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD_0=helloworld
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CACHE_FROM_0=helloworld:my.repository/myservice_cache:latest
-  export BUILDKITE_PIPELINE_SLUG=test
-  export BUILDKITE_BUILD_NUMBER=1
 
   run "$PWD"/hooks/command
 
@@ -120,11 +108,8 @@ teardown() {
 
 @test "Build with a cache-from image" {
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CONFIG="tests/composefiles/docker-compose.v3.2.yml"
-  export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD_0=helloworld
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CACHE_FROM_0=helloworld:my.repository/myservice_cache:latest
-  export BUILDKITE_PIPELINE_SLUG=test
-  export BUILDKITE_BUILD_NUMBER=1
 
   stub docker \
     "compose -f tests/composefiles/docker-compose.v3.2.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml build --pull helloworld : echo built helloworld"
@@ -140,12 +125,9 @@ teardown() {
 
 @test "Build with a cache-from image with no-cache also set" {
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CONFIG="tests/composefiles/docker-compose.v3.2.yml"
-  export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD_0=helloworld
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CACHE_FROM_0=helloworld:my.repository/myservice_cache:latest
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_NO_CACHE=true
-  export BUILDKITE_PIPELINE_SLUG=test
-  export BUILDKITE_BUILD_NUMBER=1
 
   stub docker \
     "compose -f tests/composefiles/docker-compose.v3.2.yml -p buildkite1111 build --pull --no-cache helloworld : echo built helloworld"
@@ -161,11 +143,8 @@ teardown() {
 
 @test "Build with an invalid cache-from tag" {
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CONFIG="tests/composefiles/docker-compose.v3.2.yml"
-  export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD_0=helloworld
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CACHE_FROM_0=helloworld:my.repository/myservice_cache:-latest
-  export BUILDKITE_PIPELINE_SLUG=test
-  export BUILDKITE_BUILD_NUMBER=1
 
   stub docker \
     "compose -f tests/composefiles/docker-compose.v3.2.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml build --pull helloworld : echo built helloworld"
@@ -181,10 +160,6 @@ teardown() {
 }
 
 @test "Build with a cache-from image with no tag" {
-  export BUILDKITE_BUILD_NUMBER=1
-  export BUILDKITE_JOB_ID=1111
-  export BUILDKITE_PIPELINE_SLUG=test
-
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD_0=helloworld
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CACHE_FROM_0=helloworld:my.repository/myservice_cache
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CONFIG="tests/composefiles/docker-compose.v3.2.yml"
@@ -203,12 +178,9 @@ teardown() {
 
 @test "Build with several cache-from images for one service" {
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CONFIG="tests/composefiles/docker-compose.v3.2.yml"
-  export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD_0=helloworld
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CACHE_FROM_0=helloworld:my.repository/myservice_cache:branch-name
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CACHE_FROM_1=helloworld:my.repository/myservice_cache:latest
-  export BUILDKITE_PIPELINE_SLUG=test
-  export BUILDKITE_BUILD_NUMBER=1
 
   stub docker \
     "compose -f tests/composefiles/docker-compose.v3.2.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml build --pull helloworld : echo built helloworld"
@@ -225,11 +197,8 @@ teardown() {
 
 @test "Build with a cache-from image with hyphen" {
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CONFIG="tests/composefiles/docker-compose.v3.2.yml"
-  export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD_0=hello-world
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CACHE_FROM_0=hello-world:my.repository/my-service_cache:latest
-  export BUILDKITE_PIPELINE_SLUG=test
-  export BUILDKITE_BUILD_NUMBER=1
 
   stub docker \
     "compose -f tests/composefiles/docker-compose.v3.2.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml build --pull hello-world : echo built hello-world"
@@ -245,11 +214,8 @@ teardown() {
 
 @test "Build with a service name and cache-from with period" {
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CONFIG="tests/composefiles/docker-compose.v3.2.yml"
-  export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD_0=hello.world
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CACHE_FROM_0=hello.world:my.repository/my-service_cache:latest
-  export BUILDKITE_PIPELINE_SLUG=test
-  export BUILDKITE_BUILD_NUMBER=1
 
   stub docker \
     "compose -f tests/composefiles/docker-compose.v3.2.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml build --pull \* : echo built \${10}}"
@@ -264,10 +230,6 @@ teardown() {
 }
 
 @test "Build with target" {
-  export BUILDKITE_BUILD_NUMBER=1
-  export BUILDKITE_JOB_ID=1111
-  export BUILDKITE_PIPELINE_SLUG=test
-
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD=myservice
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_TARGET=intermediate
 
@@ -284,10 +246,6 @@ teardown() {
 }
 
 @test "Build with ssh option (but no buildkit)" {
-  export BUILDKITE_BUILD_NUMBER=1
-  export BUILDKITE_JOB_ID=1111
-  export BUILDKITE_PIPELINE_SLUG=test
-
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD=myservice
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_SSH=true
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILDKIT=false
@@ -305,10 +263,6 @@ teardown() {
 }
 
 @test "Build with ssh option as true and buildkit" {
-  export BUILDKITE_BUILD_NUMBER=1
-  export BUILDKITE_JOB_ID=1111
-  export BUILDKITE_PIPELINE_SLUG=test
-
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD=myservice
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILDKIT=true
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_SSH=true
@@ -326,10 +280,6 @@ teardown() {
 }
 
 @test "Build with ssh option as string and buildkit" {
-  export BUILDKITE_BUILD_NUMBER=1
-  export BUILDKITE_JOB_ID=1111
-  export BUILDKITE_PIPELINE_SLUG=test
-
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD=myservice
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILDKIT=true
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_SSH=context
@@ -347,10 +297,6 @@ teardown() {
 }
 
 @test "Build with secrets" {
-  export BUILDKITE_BUILD_NUMBER=1
-  export BUILDKITE_JOB_ID=1111
-  export BUILDKITE_PIPELINE_SLUG=test
-
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD=myservice
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_SECRETS_0='id=test,file=~/.test'
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_SECRETS_1='id=SECRET_VAR'
@@ -368,11 +314,8 @@ teardown() {
 }
 
 @test "Build without pull" {
-  export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD=myservice
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_SKIP_PULL=true
-  export BUILDKITE_PIPELINE_SLUG=test
-  export BUILDKITE_BUILD_NUMBER=1
 
   stub docker \
     "compose -f docker-compose.yml -p buildkite1111 build myservice : echo built myservice"

--- a/tests/build.bats
+++ b/tests/build.bats
@@ -3,7 +3,7 @@
 load "${BATS_PLUGIN_PATH}/load.bash"
 load '../lib/shared'
 
- export DOCKER_COMPOSE_STUB_DEBUG=/dev/stdout
+# export DOCKER_COMPOSE_STUB_DEBUG=/dev/stdout
 # export BATS_MOCK_TMPDIR=$PWD
 
 teardown() {

--- a/tests/build.bats
+++ b/tests/build.bats
@@ -4,8 +4,12 @@ load "${BATS_PLUGIN_PATH}/load.bash"
 load '../lib/shared'
 
 # export DOCKER_COMPOSE_STUB_DEBUG=/dev/stdout
-# export BUILDKITE_AGENT_STUB_DEBUG=/dev/stdout
 # export BATS_MOCK_TMPDIR=$PWD
+
+teardown() {
+  # some test failures may leave this file around
+  rm -f docker-compose.buildkite-1-override.yml
+}
 
 @test "Build without a repository" {
   export BUILDKITE_JOB_ID=1111
@@ -95,107 +99,73 @@ load '../lib/shared'
 @test "Build with a repository" {
   export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD=myservice
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_IMAGE_REPOSITORY=my.repository/llamas
   export BUILDKITE_PIPELINE_SLUG=test
   export BUILDKITE_BUILD_NUMBER=1
 
   stub docker-compose \
-    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml build --pull myservice : echo built myservice" \
-    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml push myservice : echo pushed myservice" \
-
-  stub buildkite-agent \
-    "meta-data set docker-compose-plugin-built-image-tag-myservice my.repository/llamas:test-myservice-build-1 : echo set image metadata for myservice"
+    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml build --pull myservice : echo built myservice"
 
   run "$PWD"/hooks/command
 
   assert_success
   assert_output --partial "built myservice"
-  assert_output --partial "pushed myservice"
-  assert_output --partial "set image metadata for myservice"
+
   unstub docker-compose
-  unstub buildkite-agent
 }
 
 @test "Build with a repository and multiple build aliases" {
   export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD=myservice
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_IMAGE_REPOSITORY=my.repository/llamas
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD_ALIAS_0=myservice-1
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD_ALIAS_1=myservice-2
   export BUILDKITE_PIPELINE_SLUG=test
   export BUILDKITE_BUILD_NUMBER=1
 
   stub docker-compose \
-    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml build --pull myservice : echo built myservice" \
-    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml push myservice : echo pushed myservice" \
-
-  stub buildkite-agent \
-    "meta-data set docker-compose-plugin-built-image-tag-myservice my.repository/llamas:test-myservice-build-1 : echo set image metadata for myservice" \
-    "meta-data set docker-compose-plugin-built-image-tag-myservice-1 my.repository/llamas:test-myservice-build-1 : echo set image metadata for myservice-1" \
-    "meta-data set docker-compose-plugin-built-image-tag-myservice-2 my.repository/llamas:test-myservice-build-1 : echo set image metadata for myservice-2"
+    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml build --pull myservice : echo built myservice"
 
   run "$PWD"/hooks/command
 
   assert_success
   assert_output --partial "built myservice"
-  assert_output --partial "pushed myservice"
-  assert_output --partial "set image metadata for myservice"
-  assert_output --partial "set image metadata for myservice-1"
-  assert_output --partial "set image metadata for myservice-2"
+
   unstub docker-compose
-  unstub buildkite-agent
 }
 
 @test "Build with a repository and push retries" {
   export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD=myservice
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_IMAGE_REPOSITORY=my.repository/llamas
   export BUILDKITE_PIPELINE_SLUG=test
   export BUILDKITE_BUILD_NUMBER=1
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_PUSH_RETRIES=3
 
   stub docker-compose \
-    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml build --pull myservice : echo built myservice" \
-    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml push myservice : exit 1" \
-    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml push myservice : exit 1" \
-    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml push myservice : echo pushed myservice" \
-
-  stub buildkite-agent \
-    "meta-data set docker-compose-plugin-built-image-tag-myservice my.repository/llamas:test-myservice-build-1 : echo set image metadata for myservice"
+    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml build --pull myservice : echo built myservice"
 
   run "$PWD"/hooks/command
 
   assert_success
   assert_output --partial "built myservice"
-  assert_output --partial "pushed myservice"
-  assert_output --partial "set image metadata for myservice"
+
   unstub docker-compose
-  unstub buildkite-agent
 }
 
 @test "Build with a repository and custom config file" {
   export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD=myservice
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CONFIG=tests/composefiles/docker-compose.v2.0.yml
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_IMAGE_REPOSITORY=my.repository/llamas
   export BUILDKITE_PIPELINE_SLUG=test
   export BUILDKITE_BUILD_NUMBER=1
 
   stub docker-compose \
-    "-f tests/composefiles/docker-compose.v2.0.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml build --pull myservice : echo built myservice" \
-    "-f tests/composefiles/docker-compose.v2.0.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml push myservice : echo pushed myservice" \
-
-  stub buildkite-agent \
-    "meta-data set docker-compose-plugin-built-image-tag-myservice-tests/composefiles/docker-compose.v2.0.yml my.repository/llamas:test-myservice-build-1 : echo set image metadata for myservice"
+    "-f tests/composefiles/docker-compose.v2.0.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml build --pull myservice : echo built myservice"
 
   run "$PWD"/hooks/command
 
   assert_success
   assert_output --partial "built myservice"
-  assert_output --partial "pushed myservice"
-  assert_output --partial "set image metadata for myservice"
+
   unstub docker-compose
-  unstub buildkite-agent
 }
 
 @test "Build with a repository and multiple custom config files" {
@@ -203,52 +173,36 @@ load '../lib/shared'
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD=myservice
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CONFIG_0=tests/composefiles/docker-compose.v2.0.yml
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CONFIG_1=tests/composefiles/docker-compose.v2.1.yml
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_IMAGE_REPOSITORY=my.repository/llamas
   export BUILDKITE_PIPELINE_SLUG=test
   export BUILDKITE_BUILD_NUMBER=1
 
   stub docker-compose \
-    "-f tests/composefiles/docker-compose.v2.0.yml -f tests/composefiles/docker-compose.v2.1.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml build --pull myservice : echo built myservice" \
-    "-f tests/composefiles/docker-compose.v2.0.yml -f tests/composefiles/docker-compose.v2.1.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml push myservice : echo pushed myservice" \
-
-  stub buildkite-agent \
-    "meta-data set docker-compose-plugin-built-image-tag-myservice-tests/composefiles/docker-compose.v2.0.yml-tests/composefiles/docker-compose.v2.1.yml my.repository/llamas:test-myservice-build-1 : echo set image metadata for myservice"
+    "-f tests/composefiles/docker-compose.v2.0.yml -f tests/composefiles/docker-compose.v2.1.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml build --pull myservice : echo built myservice"
 
   run "$PWD"/hooks/command
 
   assert_success
   assert_output --partial "built myservice"
-  assert_output --partial "pushed myservice"
-  assert_output --partial "set image metadata for myservice"
+
   unstub docker-compose
-  unstub buildkite-agent
 }
 
 @test "Build with a repository and multiple services" {
   export BUILDKITE_JOB_ID=1112
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD_0=myservice1
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD_1=myservice2
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_IMAGE_REPOSITORY=my.repository/llamas
   export BUILDKITE_PIPELINE_SLUG=test
   export BUILDKITE_BUILD_NUMBER=1
 
   stub docker-compose \
-    "-f docker-compose.yml -p buildkite1112 -f docker-compose.buildkite-1-override.yml build --pull myservice1 myservice2 : echo built all services" \
-    "-f docker-compose.yml -p buildkite1112 -f docker-compose.buildkite-1-override.yml push myservice1 myservice2 : echo pushed all services" \
-
-  stub buildkite-agent \
-    "meta-data set docker-compose-plugin-built-image-tag-myservice1 my.repository/llamas:test-myservice1-build-1 : echo set image metadata for myservice1" \
-    "meta-data set docker-compose-plugin-built-image-tag-myservice2 my.repository/llamas:test-myservice2-build-1 : echo set image metadata for myservice2"
+    "-f docker-compose.yml -p buildkite1112 build --pull myservice1 myservice2 : echo built all services"
 
   run "$PWD"/hooks/command
 
   assert_success
   assert_output --partial "built all services"
-  assert_output --partial "pushed all services"
-  assert_output --partial "set image metadata for myservice1"
-  assert_output --partial "set image metadata for myservice2"
+
   unstub docker-compose
-  unstub buildkite-agent
 }
 
 @test "Build with a docker-compose v1.0 configuration file" {
@@ -682,128 +636,9 @@ load '../lib/shared'
   assert_output --partial "pulled cache image"
   assert_output --partial "- my.repository/myservice_cache:latest"
   assert_output --partial "built helloworld"
+
   unstub docker
   unstub docker-compose
-}
-
-@test "Build with a custom image-name" {
-  export BUILDKITE_JOB_ID=1111
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD=myservice
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_IMAGE_NAME=my-llamas-image
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_IMAGE_REPOSITORY=my.repository/llamas
-  export BUILDKITE_PIPELINE_SLUG=test
-  export BUILDKITE_BUILD_NUMBER=1
-
-  stub docker-compose \
-    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml build --pull myservice : echo built myservice" \
-    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml push myservice : echo pushed myservice" \
-
-  stub buildkite-agent \
-    "meta-data set docker-compose-plugin-built-image-tag-myservice my.repository/llamas:my-llamas-image : echo set image metadata for myservice"
-
-  run "$PWD"/hooks/command
-
-  assert_success
-  assert_output --partial "built myservice"
-  assert_output --partial "pushed myservice"
-  assert_output --partial "set image metadata for myservice"
-  unstub docker-compose
-  unstub buildkite-agent
-}
-
-@test "Build with an invalid image-name (start with hyphen) " {
-  export BUILDKITE_JOB_ID=1111
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD=myservice
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_IMAGE_NAME=-llamas-image
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_IMAGE_REPOSITORY=my.repository/llamas
-  export BUILDKITE_BUILD_NUMBER=1
-
-  run "$PWD"/hooks/command
-
-  assert_failure
-  assert_output --partial "-llamas-image is not a valid tag name"
-}
-
-@test "Build with an invalid image-name (start with period) " {
-  export BUILDKITE_JOB_ID=1111
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD=myservice
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_IMAGE_NAME=.llamas-image
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_IMAGE_REPOSITORY=my.repository/llamas
-  export BUILDKITE_BUILD_NUMBER=1
-
-  run "$PWD"/hooks/command
-
-  assert_failure
-  assert_output --partial ".llamas-image is not a valid tag name"
-}
-
-@test "Build with an invalid image-name (too long) " {
-  export BUILDKITE_JOB_ID=1111
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD=myservice
-  # shellcheck disable=SC2155 # numbers from 1 to 69 result in 129 characters
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_IMAGE_NAME="$(seq 69 | tr -d "\n")"
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_IMAGE_REPOSITORY=my.repository/llamas
-  export BUILDKITE_BUILD_NUMBER=1
-
-  run "$PWD"/hooks/command
-
-  assert_failure
-  assert_output --partial "is not a valid tag name"
-}
-
-@test "Build with a custom image-name and a config" {
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CONFIG="tests/composefiles/docker-compose.v3.2.yml"
-  export BUILDKITE_JOB_ID=1111
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD=myservice
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_IMAGE_NAME=my-llamas-image
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_IMAGE_REPOSITORY=my.repository/llamas
-  export BUILDKITE_PIPELINE_SLUG=test
-  export BUILDKITE_BUILD_NUMBER=1
-
-  stub docker-compose \
-    "-f tests/composefiles/docker-compose.v3.2.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml build --pull myservice : echo built myservice" \
-    "-f tests/composefiles/docker-compose.v3.2.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml push myservice : echo pushed myservice" \
-
-  stub buildkite-agent \
-    "meta-data set docker-compose-plugin-built-image-tag-myservice-tests/composefiles/docker-compose.v3.2.yml my.repository/llamas:my-llamas-image : echo set image metadata for myservice"
-
-  run "$PWD"/hooks/command
-
-  assert_success
-  assert_output --partial "built myservice"
-  assert_output --partial "pushed myservice"
-  assert_output --partial "set image metadata for myservice"
-  unstub docker-compose
-  unstub buildkite-agent
-}
-
-@test "Build multiple images with custom image-names" {
-  export BUILDKITE_JOB_ID=1112
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD_0=myservice1
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD_1=myservice2
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_IMAGE_NAME_0=my-llamas-image-1
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_IMAGE_NAME_1=my-llamas-image-2
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_IMAGE_REPOSITORY=my.repository/llamas
-  export BUILDKITE_PIPELINE_SLUG=test
-  export BUILDKITE_BUILD_NUMBER=1
-
-  stub docker-compose \
-    "-f docker-compose.yml -p buildkite1112 -f docker-compose.buildkite-1-override.yml build --pull myservice1 myservice2 : echo built all services" \
-    "-f docker-compose.yml -p buildkite1112 -f docker-compose.buildkite-1-override.yml push myservice1 myservice2 : echo pushed all services" \
-
-  stub buildkite-agent \
-    "meta-data set docker-compose-plugin-built-image-tag-myservice1 my.repository/llamas:my-llamas-image-1 : echo set image metadata for myservice1" \
-    "meta-data set docker-compose-plugin-built-image-tag-myservice2 my.repository/llamas:my-llamas-image-2 : echo set image metadata for myservice2"
-
-  run "$PWD"/hooks/command
-
-  assert_success
-  assert_output --partial "built all services"
-  assert_output --partial "pushed all services"
-  assert_output --partial "set image metadata for myservice1"
-  assert_output --partial "set image metadata for myservice2"
-  unstub docker-compose
-  unstub buildkite-agent
 }
 
 @test "Build with target" {

--- a/tests/build.bats
+++ b/tests/build.bats
@@ -3,7 +3,7 @@
 load "${BATS_PLUGIN_PATH}/load.bash"
 load '../lib/shared'
 
-# export DOCKER_COMPOSE_STUB_DEBUG=/dev/stdout
+ export DOCKER_COMPOSE_STUB_DEBUG=/dev/stdout
 # export BATS_MOCK_TMPDIR=$PWD
 
 teardown() {
@@ -229,12 +229,9 @@ teardown() {
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CONFIG="tests/composefiles/docker-compose.v3.2.yml"
   export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD_0=helloworld
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CACHE_FROM_0=helloworld::my.repository/myservice_cache:latest
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CACHE_FROM_0=helloworld:my.repository/myservice_cache:latest
   export BUILDKITE_PIPELINE_SLUG=test
   export BUILDKITE_BUILD_NUMBER=1
-
-  stub docker \
-    "pull my.repository/myservice_cache:latest : echo pulled cache image"
 
   stub docker-compose \
     "-f tests/composefiles/docker-compose.v3.2.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml build --pull helloworld : echo built helloworld"
@@ -242,10 +239,9 @@ teardown() {
   run "$PWD"/hooks/command
 
   assert_success
-  assert_output --partial "pulled cache image"
   assert_output --partial "- my.repository/myservice_cache:latest"
   assert_output --partial "built helloworld"
-  unstub docker
+
   unstub docker-compose
 }
 
@@ -253,7 +249,7 @@ teardown() {
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CONFIG="tests/composefiles/docker-compose.v3.2.yml"
   export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD_0=helloworld
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CACHE_FROM_0=helloworld::my.repository/myservice_cache:latest
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CACHE_FROM_0=helloworld:my.repository/myservice_cache:latest
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_NO_CACHE=true
   export BUILDKITE_PIPELINE_SLUG=test
   export BUILDKITE_BUILD_NUMBER=1
@@ -264,7 +260,6 @@ teardown() {
   run "$PWD"/hooks/command
 
   assert_success
-  refute_output --partial "pulled cache image"
   refute_output --partial "- my.repository/myservice_cache:latest"
   assert_output --partial "built helloworld"
   unstub docker-compose
@@ -274,26 +269,20 @@ teardown() {
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CONFIG="tests/composefiles/docker-compose.v3.2.yml"
   export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD_0=helloworld
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CACHE_FROM_0=helloworld::my.repository/myservice_cache:-latest
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CACHE_FROM_0=helloworld:my.repository/myservice_cache:-latest
   export BUILDKITE_PIPELINE_SLUG=test
   export BUILDKITE_BUILD_NUMBER=1
 
   stub docker-compose \
-    "-f tests/composefiles/docker-compose.v3.2.yml -p buildkite1111 build --pull helloworld : echo built helloworld"
-
-  stub docker \
-    "pull my.repository/myservice_cache:-latest : exit 1"
+    "-f tests/composefiles/docker-compose.v3.2.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml build --pull helloworld : echo built helloworld"
 
   run "$PWD"/hooks/command
 
   assert_success
-  refute_output --partial "pulled cache image"
-  refute_output --partial "- my.repository/myservice_cache:-latest"
-  assert_output --partial "Pull failed"
+  assert_output --partial "- my.repository/myservice_cache:-latest"
   assert_output --partial "built helloworld"
 
   unstub docker-compose
-  unstub docker
 }
 
 @test "Build with a cache-from image with no tag" {
@@ -302,11 +291,8 @@ teardown() {
   export BUILDKITE_PIPELINE_SLUG=test
 
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD_0=helloworld
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CACHE_FROM_0=helloworld::my.repository/myservice_cache
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CACHE_FROM_0=helloworld:my.repository/myservice_cache
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CONFIG="tests/composefiles/docker-compose.v3.2.yml"
-
-  stub docker \
-    "pull my.repository/myservice_cache : echo pulled cache image"
 
   stub docker-compose \
     "-f tests/composefiles/docker-compose.v3.2.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml build --pull helloworld : echo built helloworld"
@@ -314,10 +300,9 @@ teardown() {
   run "$PWD"/hooks/command
 
   assert_success
-  assert_output --partial "pulled cache image"
   assert_output --partial "- my.repository/myservice_cache"
   assert_output --partial "built helloworld"
-  unstub docker
+
   unstub docker-compose
 }
 
@@ -325,13 +310,10 @@ teardown() {
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CONFIG="tests/composefiles/docker-compose.v3.2.yml"
   export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD_0=helloworld
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CACHE_FROM_0=helloworld::my.repository/myservice_cache:branch-name
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CACHE_FROM_1=helloworld::my.repository/myservice_cache:latest
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CACHE_FROM_0=helloworld:my.repository/myservice_cache:branch-name
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CACHE_FROM_1=helloworld:my.repository/myservice_cache:latest
   export BUILDKITE_PIPELINE_SLUG=test
   export BUILDKITE_BUILD_NUMBER=1
-
-  stub docker \
-    "pull my.repository/myservice_cache:branch-name : echo pulled cache image"
 
   stub docker-compose \
     "-f tests/composefiles/docker-compose.v3.2.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml build --pull helloworld : echo built helloworld"
@@ -339,174 +321,10 @@ teardown() {
   run "$PWD"/hooks/command
 
   assert_success
-  assert_output --partial "pulled cache image"
   assert_output --partial "- my.repository/myservice_cache:branch-name"
-  refute_output --partial "- my.repository/myservice_cache:latest"
-  assert_output --partial "built helloworld"
-  unstub docker
-  unstub docker-compose
-}
-
-@test "Build with several cache-from image groups for one service" {
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CONFIG="tests/composefiles/docker-compose.v3.2.yml"
-  export BUILDKITE_JOB_ID=1111
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD_0=helloworld
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CACHE_FROM_0=helloworld:target1:my.repository/myservice_cache:build-target-build-1
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CACHE_FROM_1=helloworld:target1:my.repository/myservice_cache:build-target-latest
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CACHE_FROM_2=helloworld:target2:my.repository/myservice_cache:install-target-build-1
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CACHE_FROM_3=helloworld::my.repository/myservice_cache:branch-name
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CACHE_FROM_4=helloworld::my.repository/myservice_cache:latest
-  export BUILDKITE_PIPELINE_SLUG=test
-  export BUILDKITE_BUILD_NUMBER=1
-
-  stub docker \
-    "pull my.repository/myservice_cache:build-target-build-1 : echo pulled cache image build-target" \
-    "pull my.repository/myservice_cache:install-target-build-1 : echo pulled cache image install-target" \
-    "pull my.repository/myservice_cache:branch-name : echo pulled cache image branch-name"
-
-  stub docker-compose \
-    "-f tests/composefiles/docker-compose.v3.2.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml build --pull helloworld : echo built helloworld"
-
-  run "$PWD"/hooks/command
-
-  assert_success
-  assert_output --partial "pulled cache image build-target"
-  assert_output --partial "pulled cache image install-target"
-  assert_output --partial "pulled cache image branch-name"
-  assert_output --partial "- my.repository/myservice_cache:build-target-build-1"
-  refute_output --partial "- my.repository/myservice_cache:build-target-latest"
-  assert_output --partial "- my.repository/myservice_cache:install-target-build-1"
-  assert_output --partial "- my.repository/myservice_cache:branch-name"
-  refute_output --partial "- my.repository/myservice_cache:latest"
-  assert_output --partial "built helloworld"
-  unstub docker
-  unstub docker-compose
-}
-
-@test "Build with several cache-from image groups for one service with failures" {
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CONFIG="tests/composefiles/docker-compose.v3.2.yml"
-  export BUILDKITE_JOB_ID=1111
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD_0=helloworld
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CACHE_FROM_0=helloworld:target1:my.repository/myservice_cache:build-target-build-1
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CACHE_FROM_1=helloworld:target1:my.repository/myservice_cache:build-target-latest
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CACHE_FROM_2=helloworld:target2:my.repository/myservice_cache:install-target-build-1
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CACHE_FROM_3=helloworld::my.repository/myservice_cache:branch-name
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CACHE_FROM_4=helloworld::my.repository/myservice_cache:latest
-  export BUILDKITE_PIPELINE_SLUG=test
-  export BUILDKITE_BUILD_NUMBER=1
-
-  stub docker \
-    "pull my.repository/myservice_cache:build-target-build-1 : exit 1" \
-    "pull my.repository/myservice_cache:build-target-latest : echo pulled cache image build-target-latest" \
-    "pull my.repository/myservice_cache:install-target-build-1 : echo pulled cache image install-target" \
-    "pull my.repository/myservice_cache:branch-name : echo pulled cache image branch-name"
-
-  stub docker-compose \
-    "-f tests/composefiles/docker-compose.v3.2.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml build --pull helloworld : echo built helloworld"
-
-  run "$PWD"/hooks/command
-
-  assert_success
-  assert_output --partial "pulled cache image build-target-latest"
-  assert_output --partial "pulled cache image install-target"
-  assert_output --partial "pulled cache image branch-name"
-  assert_output --partial "- my.repository/myservice_cache:build-target-latest"
-  assert_output --partial "- my.repository/myservice_cache:build-target-latest"
-  assert_output --partial "- my.repository/myservice_cache:install-target-build-1"
-  assert_output --partial "- my.repository/myservice_cache:branch-name"
-  refute_output --partial "- my.repository/myservice_cache:latest"
-  assert_output --partial "built helloworld"
-  unstub docker
-  unstub docker-compose
-}
-
-@test "Build with several cache-from image groups out of order" {
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CONFIG="tests/composefiles/docker-compose.v3.2.yml"
-  export BUILDKITE_JOB_ID=1111
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD_0=helloworld
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CACHE_FROM_0=helloworld::my.repository/myservice_cache:branch-name
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CACHE_FROM_1=helloworld:target1:my.repository/myservice_cache:build-target-build-1
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CACHE_FROM_2=helloworld:target2:my.repository/myservice_cache:install-target-build-1
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CACHE_FROM_3=helloworld:target1:my.repository/myservice_cache:build-target-latest
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CACHE_FROM_4=helloworld::my.repository/myservice_cache:latest
-  export BUILDKITE_PIPELINE_SLUG=test
-  export BUILDKITE_BUILD_NUMBER=1
-
-  stub docker \
-    "pull my.repository/myservice_cache:branch-name : exit 1" \
-    "pull my.repository/myservice_cache:build-target-build-1 : exit 1" \
-    "pull my.repository/myservice_cache:install-target-build-1 : echo pulled cache image install-target" \
-    "pull my.repository/myservice_cache:build-target-latest : echo pulled cache image build-target-latest" \
-    "pull my.repository/myservice_cache:latest : echo pulled cache image branch-name-latest"
-
-
-  stub docker-compose \
-    "-f tests/composefiles/docker-compose.v3.2.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml build --pull helloworld : echo built helloworld"
-
-  run "$PWD"/hooks/command
-
-  assert_success
-  assert_output --partial "pulled cache image build-target-latest"
-  assert_output --partial "pulled cache image install-target"
-  assert_output --partial "pulled cache image branch-name"
-  assert_output --partial "- my.repository/myservice_cache:build-target-latest"
-  assert_output --partial "- my.repository/myservice_cache:build-target-latest"
-  assert_output --partial "- my.repository/myservice_cache:install-target-build-1"
-  refute_output --partial "- my.repository/myservice_cache:branch-name"
   assert_output --partial "- my.repository/myservice_cache:latest"
   assert_output --partial "built helloworld"
-  unstub docker
-  unstub docker-compose
-}
 
-@test "Build with several cache-from images for one service with first image being not available" {
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CONFIG="tests/composefiles/docker-compose.v3.2.yml"
-  export BUILDKITE_JOB_ID=1111
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD_0=helloworld
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CACHE_FROM_0=helloworld::my.repository/myservice_cache:branch-name
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CACHE_FROM_1=helloworld::my.repository/myservice_cache:latest
-  export BUILDKITE_PIPELINE_SLUG=test
-  export BUILDKITE_BUILD_NUMBER=1
-
-  stub docker \
-    "pull my.repository/myservice_cache:branch-name : exit 1" \
-    "pull my.repository/myservice_cache:latest : echo pulled cache image"
-
-  stub docker-compose \
-    "-f tests/composefiles/docker-compose.v3.2.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml build --pull helloworld : echo built helloworld"
-
-  run "$PWD"/hooks/command
-
-  assert_success
-  assert_output --partial "pulled cache image"
-  refute_output --partial "- my.repository/myservice_cache:branch-name"
-  assert_output --partial "- my.repository/myservice_cache:latest"
-  assert_output --partial "built helloworld"
-  unstub docker
-  unstub docker-compose
-}
-
-@test "Build with a cache-from image when pulling of the cache-from image failed" {
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CONFIG="tests/composefiles/docker-compose.v3.2.yml"
-  export BUILDKITE_JOB_ID=1111
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD_0=helloworld
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CACHE_FROM_0=helloworld::my.repository/myservice_cache:latest
-  export BUILDKITE_PIPELINE_SLUG=test
-  export BUILDKITE_BUILD_NUMBER=1
-
-  stub docker \
-    "pull my.repository/myservice_cache:latest : exit 1"
-
-  stub docker-compose \
-    "-f tests/composefiles/docker-compose.v3.2.yml -p buildkite1111 build --pull helloworld : echo built helloworld"
-
-  run "$PWD"/hooks/command
-
-  assert_success
-  assert_output --partial "my.repository/myservice_cache:latest will not be used as a cache for helloworld"
-  refute_output --partial "- my.repository/myservice_cache:latest"
-  assert_output --partial "built helloworld"
-  unstub docker
   unstub docker-compose
 }
 
@@ -514,12 +332,9 @@ teardown() {
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CONFIG="tests/composefiles/docker-compose.v3.2.yml"
   export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD_0=hello-world
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CACHE_FROM_0=hello-world::my.repository/my-service_cache:latest
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CACHE_FROM_0=hello-world:my.repository/my-service_cache:latest
   export BUILDKITE_PIPELINE_SLUG=test
   export BUILDKITE_BUILD_NUMBER=1
-
-  stub docker \
-    "pull my.repository/my-service_cache:latest : echo pulled cache image"
 
   stub docker-compose \
     "-f tests/composefiles/docker-compose.v3.2.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml build --pull hello-world : echo built hello-world"
@@ -527,10 +342,9 @@ teardown() {
   run "$PWD"/hooks/command
 
   assert_success
-  assert_output --partial "pulled cache image"
   assert_output --partial "- my.repository/my-service_cache:latest"
   assert_output --partial "built hello-world"
-  unstub docker
+
   unstub docker-compose
 }
 
@@ -538,12 +352,9 @@ teardown() {
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CONFIG="tests/composefiles/docker-compose.v3.2.yml"
   export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD_0=hello.world
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CACHE_FROM_0=hello.world::my.repository/my-service_cache:latest
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CACHE_FROM_0=hello.world:my.repository/my-service_cache:latest
   export BUILDKITE_PIPELINE_SLUG=test
   export BUILDKITE_BUILD_NUMBER=1
-
-  stub docker \
-    "pull my.repository/my-service_cache:latest : echo pulled cache image"
 
   stub docker-compose \
     "-f tests/composefiles/docker-compose.v3.2.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml build --pull \* : echo built \$9"
@@ -551,39 +362,9 @@ teardown() {
   run "$PWD"/hooks/command
 
   assert_success
-  assert_output --partial "pulled cache image"
   assert_output --partial "- my.repository/my-service_cache:latest"
   assert_output --partial "built hello.world"
-  unstub docker
-  unstub docker-compose
-}
 
-
-@test "Build with a cache-from image retry on failing pull" {
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CONFIG="tests/composefiles/docker-compose.v3.2.yml"
-  export BUILDKITE_JOB_ID=1111
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD_0=helloworld
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CACHE_FROM_0=helloworld::my.repository/myservice_cache:latest
-  export BUILDKITE_PIPELINE_SLUG=test
-  export BUILDKITE_BUILD_NUMBER=1
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_PULL_RETRIES=3
-
-  stub docker \
-    "pull my.repository/myservice_cache:latest : exit 1" \
-    "pull my.repository/myservice_cache:latest : exit 1" \
-    "pull my.repository/myservice_cache:latest : echo pulled cache image"
-
-  stub docker-compose \
-    "-f tests/composefiles/docker-compose.v3.2.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml build --pull helloworld : echo built helloworld"
-
-  run "$PWD"/hooks/command
-
-  assert_success
-  assert_output --partial "pulled cache image"
-  assert_output --partial "- my.repository/myservice_cache:latest"
-  assert_output --partial "built helloworld"
-
-  unstub docker
   unstub docker-compose
 }
 

--- a/tests/build.bats
+++ b/tests/build.bats
@@ -229,7 +229,7 @@ teardown() {
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CONFIG="tests/composefiles/docker-compose.v3.2.yml"
   export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD_0=helloworld
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CACHE_FROM_0=helloworld:my.repository/myservice_cache:latest
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CACHE_FROM_0=helloworld::my.repository/myservice_cache:latest
   export BUILDKITE_PIPELINE_SLUG=test
   export BUILDKITE_BUILD_NUMBER=1
 
@@ -249,37 +249,11 @@ teardown() {
   unstub docker-compose
 }
 
-@test "Build with a cache-from image and custom separator" {
-  export BUILDKITE_JOB_ID=1111
-  export BUILDKITE_BUILD_NUMBER=1
-  export BUILDKITE_PIPELINE_SLUG=test
-
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD_0=helloworld
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CONFIG="tests/composefiles/docker-compose.v3.2.yml"
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CACHE_FROM_0='helloworld#my.repository:port/myservice_cache#latest'
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_SEPARATOR_CACHE_FROM='#'
-
-  stub docker \
-    "pull my.repository:port/myservice_cache:latest : echo pulled cache image"
-
-  stub docker-compose \
-    "-f tests/composefiles/docker-compose.v3.2.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml build --pull helloworld : echo built helloworld"
-
-  run "$PWD"/hooks/command
-
-  assert_success
-  assert_output --partial "pulled cache image"
-  assert_output --partial "- my.repository:port/myservice_cache:latest"
-  assert_output --partial "built helloworld"
-  unstub docker
-  unstub docker-compose
-}
-
 @test "Build with a cache-from image with no-cache also set" {
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CONFIG="tests/composefiles/docker-compose.v3.2.yml"
   export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD_0=helloworld
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CACHE_FROM_0=helloworld:my.repository/myservice_cache:latest
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CACHE_FROM_0=helloworld::my.repository/myservice_cache:latest
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_NO_CACHE=true
   export BUILDKITE_PIPELINE_SLUG=test
   export BUILDKITE_BUILD_NUMBER=1
@@ -300,21 +274,26 @@ teardown() {
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CONFIG="tests/composefiles/docker-compose.v3.2.yml"
   export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD_0=helloworld
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CACHE_FROM_0=helloworld:my.repository/myservice_cache:-latest
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CACHE_FROM_0=helloworld::my.repository/myservice_cache:-latest
   export BUILDKITE_PIPELINE_SLUG=test
   export BUILDKITE_BUILD_NUMBER=1
 
   stub docker-compose \
     "-f tests/composefiles/docker-compose.v3.2.yml -p buildkite1111 build --pull helloworld : echo built helloworld"
 
+  stub docker \
+    "pull my.repository/myservice_cache:-latest : exit 1"
+
   run "$PWD"/hooks/command
 
   assert_success
   refute_output --partial "pulled cache image"
   refute_output --partial "- my.repository/myservice_cache:-latest"
-  assert_output --partial "invalid tag so it will be ignored"
+  assert_output --partial "Pull failed"
   assert_output --partial "built helloworld"
+
   unstub docker-compose
+  unstub docker
 }
 
 @test "Build with a cache-from image with no tag" {
@@ -323,7 +302,7 @@ teardown() {
   export BUILDKITE_PIPELINE_SLUG=test
 
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD_0=helloworld
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CACHE_FROM_0=helloworld:my.repository/myservice_cache
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CACHE_FROM_0=helloworld::my.repository/myservice_cache
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CONFIG="tests/composefiles/docker-compose.v3.2.yml"
 
   stub docker \
@@ -346,8 +325,8 @@ teardown() {
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CONFIG="tests/composefiles/docker-compose.v3.2.yml"
   export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD_0=helloworld
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CACHE_FROM_0=helloworld:my.repository/myservice_cache:branch-name
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CACHE_FROM_1=helloworld:my.repository/myservice_cache:latest
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CACHE_FROM_0=helloworld::my.repository/myservice_cache:branch-name
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CACHE_FROM_1=helloworld::my.repository/myservice_cache:latest
   export BUILDKITE_PIPELINE_SLUG=test
   export BUILDKITE_BUILD_NUMBER=1
 
@@ -372,11 +351,11 @@ teardown() {
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CONFIG="tests/composefiles/docker-compose.v3.2.yml"
   export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD_0=helloworld
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CACHE_FROM_0=helloworld:my.repository/myservice_cache:build-target-build-1:target1
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CACHE_FROM_1=helloworld:my.repository/myservice_cache:build-target-latest:target1
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CACHE_FROM_2=helloworld:my.repository/myservice_cache:install-target-build-1:target2
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CACHE_FROM_3=helloworld:my.repository/myservice_cache:branch-name
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CACHE_FROM_4=helloworld:my.repository/myservice_cache:latest
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CACHE_FROM_0=helloworld:target1:my.repository/myservice_cache:build-target-build-1
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CACHE_FROM_1=helloworld:target1:my.repository/myservice_cache:build-target-latest
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CACHE_FROM_2=helloworld:target2:my.repository/myservice_cache:install-target-build-1
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CACHE_FROM_3=helloworld::my.repository/myservice_cache:branch-name
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CACHE_FROM_4=helloworld::my.repository/myservice_cache:latest
   export BUILDKITE_PIPELINE_SLUG=test
   export BUILDKITE_BUILD_NUMBER=1
 
@@ -408,11 +387,11 @@ teardown() {
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CONFIG="tests/composefiles/docker-compose.v3.2.yml"
   export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD_0=helloworld
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CACHE_FROM_0=helloworld:my.repository/myservice_cache:build-target-build-1:target1
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CACHE_FROM_1=helloworld:my.repository/myservice_cache:build-target-latest:target1
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CACHE_FROM_2=helloworld:my.repository/myservice_cache:install-target-build-1:target2
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CACHE_FROM_3=helloworld:my.repository/myservice_cache:branch-name
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CACHE_FROM_4=helloworld:my.repository/myservice_cache:latest
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CACHE_FROM_0=helloworld:target1:my.repository/myservice_cache:build-target-build-1
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CACHE_FROM_1=helloworld:target1:my.repository/myservice_cache:build-target-latest
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CACHE_FROM_2=helloworld:target2:my.repository/myservice_cache:install-target-build-1
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CACHE_FROM_3=helloworld::my.repository/myservice_cache:branch-name
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CACHE_FROM_4=helloworld::my.repository/myservice_cache:latest
   export BUILDKITE_PIPELINE_SLUG=test
   export BUILDKITE_BUILD_NUMBER=1
 
@@ -441,55 +420,15 @@ teardown() {
   unstub docker-compose
 }
 
-@test "Build with several cache-from image groups for one service with failures and separator" {
-  export BUILDKITE_BUILD_NUMBER=1
-  export BUILDKITE_JOB_ID=1111
-  export BUILDKITE_PIPELINE_SLUG=test
-
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD_0=helloworld
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CONFIG="tests/composefiles/docker-compose.v3.2.yml"
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CACHE_FROM_0=helloworld#my.repository:port/myservice_cache#build-target-build-1#target1
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CACHE_FROM_1=helloworld#my.repository:port/myservice_cache#build-target-latest#target1
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CACHE_FROM_2=helloworld#my.repository:port/myservice_cache#install-target-build-1#target2
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CACHE_FROM_3=helloworld#my.repository:port/myservice_cache#branch-name
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CACHE_FROM_4=helloworld#my.repository:port/myservice_cache#latest
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_SEPARATOR_CACHE_FROM='#'
-
-  stub docker \
-    "pull my.repository:port/myservice_cache:build-target-build-1 : exit 1" \
-    "pull my.repository:port/myservice_cache:build-target-latest : echo pulled cache image build-target-latest" \
-    "pull my.repository:port/myservice_cache:install-target-build-1 : echo pulled cache image install-target" \
-    "pull my.repository:port/myservice_cache:branch-name : echo pulled cache image branch-name"
-
-  stub docker-compose \
-    "-f tests/composefiles/docker-compose.v3.2.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml build --pull helloworld : echo built helloworld"
-
-  run "$PWD"/hooks/command
-
-  assert_success
-  assert_output --partial "pulled cache image build-target-latest"
-  assert_output --partial "pulled cache image install-target"
-  assert_output --partial "pulled cache image branch-name"
-  assert_output --partial "- my.repository:port/myservice_cache:build-target-latest"
-  assert_output --partial "- my.repository:port/myservice_cache:build-target-latest"
-  assert_output --partial "- my.repository:port/myservice_cache:install-target-build-1"
-  assert_output --partial "- my.repository:port/myservice_cache:branch-name"
-  refute_output --partial "- my.repository:port/myservice_cache:latest"
-  assert_output --partial "built helloworld"
-  
-  unstub docker
-  unstub docker-compose
-}
-
 @test "Build with several cache-from image groups out of order" {
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CONFIG="tests/composefiles/docker-compose.v3.2.yml"
   export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD_0=helloworld
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CACHE_FROM_0=helloworld:my.repository/myservice_cache:branch-name
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CACHE_FROM_1=helloworld:my.repository/myservice_cache:build-target-build-1:target1
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CACHE_FROM_2=helloworld:my.repository/myservice_cache:install-target-build-1:target2
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CACHE_FROM_3=helloworld:my.repository/myservice_cache:build-target-latest:target1
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CACHE_FROM_4=helloworld:my.repository/myservice_cache:latest
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CACHE_FROM_0=helloworld::my.repository/myservice_cache:branch-name
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CACHE_FROM_1=helloworld:target1:my.repository/myservice_cache:build-target-build-1
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CACHE_FROM_2=helloworld:target2:my.repository/myservice_cache:install-target-build-1
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CACHE_FROM_3=helloworld:target1:my.repository/myservice_cache:build-target-latest
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CACHE_FROM_4=helloworld::my.repository/myservice_cache:latest
   export BUILDKITE_PIPELINE_SLUG=test
   export BUILDKITE_BUILD_NUMBER=1
 
@@ -524,8 +463,8 @@ teardown() {
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CONFIG="tests/composefiles/docker-compose.v3.2.yml"
   export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD_0=helloworld
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CACHE_FROM_0=helloworld:my.repository/myservice_cache:branch-name
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CACHE_FROM_1=helloworld:my.repository/myservice_cache:latest
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CACHE_FROM_0=helloworld::my.repository/myservice_cache:branch-name
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CACHE_FROM_1=helloworld::my.repository/myservice_cache:latest
   export BUILDKITE_PIPELINE_SLUG=test
   export BUILDKITE_BUILD_NUMBER=1
 
@@ -551,7 +490,7 @@ teardown() {
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CONFIG="tests/composefiles/docker-compose.v3.2.yml"
   export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD_0=helloworld
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CACHE_FROM_0=helloworld:my.repository/myservice_cache:latest
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CACHE_FROM_0=helloworld::my.repository/myservice_cache:latest
   export BUILDKITE_PIPELINE_SLUG=test
   export BUILDKITE_BUILD_NUMBER=1
 
@@ -575,7 +514,7 @@ teardown() {
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CONFIG="tests/composefiles/docker-compose.v3.2.yml"
   export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD_0=hello-world
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CACHE_FROM_0=hello-world:my.repository/my-service_cache:latest
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CACHE_FROM_0=hello-world::my.repository/my-service_cache:latest
   export BUILDKITE_PIPELINE_SLUG=test
   export BUILDKITE_BUILD_NUMBER=1
 
@@ -599,7 +538,7 @@ teardown() {
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CONFIG="tests/composefiles/docker-compose.v3.2.yml"
   export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD_0=hello.world
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CACHE_FROM_0=hello.world:my.repository/my-service_cache:latest
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CACHE_FROM_0=hello.world::my.repository/my-service_cache:latest
   export BUILDKITE_PIPELINE_SLUG=test
   export BUILDKITE_BUILD_NUMBER=1
 
@@ -624,7 +563,7 @@ teardown() {
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CONFIG="tests/composefiles/docker-compose.v3.2.yml"
   export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD_0=helloworld
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CACHE_FROM_0=helloworld:my.repository/myservice_cache:latest
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CACHE_FROM_0=helloworld::my.repository/myservice_cache:latest
   export BUILDKITE_PIPELINE_SLUG=test
   export BUILDKITE_BUILD_NUMBER=1
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_PULL_RETRIES=3

--- a/tests/build.bats
+++ b/tests/build.bats
@@ -18,13 +18,14 @@ teardown() {
   export BUILDKITE_BUILD_NUMBER=1
 
   stub docker-compose \
-    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml build --pull myservice : echo built myservice"
+    "-f docker-compose.yml -p buildkite1111 build --pull myservice : echo built myservice"
 
   run "$PWD"/hooks/command
 
-  unstub docker-compose
   assert_success
   assert_output --partial "built myservice"
+
+  unstub docker-compose
 }
 
 @test "Build with no-cache" {
@@ -35,7 +36,7 @@ teardown() {
   export BUILDKITE_BUILD_NUMBER=1
 
   stub docker-compose \
-    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml build --pull --no-cache myservice : echo built myservice"
+    "-f docker-compose.yml -p buildkite1111 build --pull --no-cache myservice : echo built myservice"
 
   run "$PWD"/hooks/command
 
@@ -52,7 +53,7 @@ teardown() {
   export BUILDKITE_BUILD_NUMBER=1
 
   stub docker-compose \
-    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml build --pull --parallel myservice : echo built myservice"
+    "-f docker-compose.yml -p buildkite1111 build --pull --parallel myservice : echo built myservice"
 
   run "$PWD"/hooks/command
 
@@ -70,7 +71,7 @@ teardown() {
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_ARGS_1=MYARG=1
 
   stub docker-compose \
-    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml build --pull --build-arg MYARG=0 --build-arg MYARG=1 myservice : echo built myservice"
+    "-f docker-compose.yml -p buildkite1111 build --pull --build-arg MYARG=0 --build-arg MYARG=1 myservice : echo built myservice"
 
   run "$PWD"/hooks/command
 
@@ -87,7 +88,7 @@ teardown() {
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLI_VERSION=1
 
   stub docker-compose \
-    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml build --pull myservice : echo built myservice"
+    "-f docker-compose.yml -p buildkite1111 build --pull myservice : echo built myservice"
 
   run "$PWD"/hooks/command
 
@@ -103,7 +104,7 @@ teardown() {
   export BUILDKITE_BUILD_NUMBER=1
 
   stub docker-compose \
-    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml build --pull myservice : echo built myservice"
+    "-f docker-compose.yml -p buildkite1111 build --pull myservice : echo built myservice"
 
   run "$PWD"/hooks/command
 
@@ -113,6 +114,7 @@ teardown() {
   unstub docker-compose
 }
 
+# TODO: move this to push testing
 @test "Build with a repository and multiple build aliases" {
   export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD=myservice
@@ -122,7 +124,7 @@ teardown() {
   export BUILDKITE_BUILD_NUMBER=1
 
   stub docker-compose \
-    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml build --pull myservice : echo built myservice"
+    "-f docker-compose.yml -p buildkite1111 build --pull myservice : echo built myservice"
 
   run "$PWD"/hooks/command
 
@@ -140,7 +142,7 @@ teardown() {
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_PUSH_RETRIES=3
 
   stub docker-compose \
-    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml build --pull myservice : echo built myservice"
+    "-f docker-compose.yml -p buildkite1111 build --pull myservice : echo built myservice"
 
   run "$PWD"/hooks/command
 
@@ -158,7 +160,7 @@ teardown() {
   export BUILDKITE_BUILD_NUMBER=1
 
   stub docker-compose \
-    "-f tests/composefiles/docker-compose.v2.0.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml build --pull myservice : echo built myservice"
+    "-f tests/composefiles/docker-compose.v2.0.yml -p buildkite1111 build --pull myservice : echo built myservice"
 
   run "$PWD"/hooks/command
 
@@ -177,7 +179,7 @@ teardown() {
   export BUILDKITE_BUILD_NUMBER=1
 
   stub docker-compose \
-    "-f tests/composefiles/docker-compose.v2.0.yml -f tests/composefiles/docker-compose.v2.1.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml build --pull myservice : echo built myservice"
+    "-f tests/composefiles/docker-compose.v2.0.yml -f tests/composefiles/docker-compose.v2.1.yml -p buildkite1111 build --pull myservice : echo built myservice"
 
   run "$PWD"/hooks/command
 
@@ -212,10 +214,15 @@ teardown() {
   export BUILDKITE_PIPELINE_SLUG=test
   export BUILDKITE_BUILD_NUMBER=1
 
+  stub docker-compose \
+    "-f tests/composefiles/docker-compose.v1.0.yml -p buildkite1112 build --pull helloworld : echo built service"
+
   run "$PWD"/hooks/command
 
-  assert_failure
-  assert_output --partial "Compose file versions 2.0 and above"
+  assert_success
+  assert_output --partial "built service"
+
+  unstub docker-compose
 }
 
 @test "Build with a cache-from image" {
@@ -278,7 +285,7 @@ teardown() {
   export BUILDKITE_BUILD_NUMBER=1
 
   stub docker-compose \
-    "-f tests/composefiles/docker-compose.v3.2.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml build --pull --no-cache helloworld : echo built helloworld"
+    "-f tests/composefiles/docker-compose.v3.2.yml -p buildkite1111 build --pull --no-cache helloworld : echo built helloworld"
 
   run "$PWD"/hooks/command
 
@@ -298,7 +305,7 @@ teardown() {
   export BUILDKITE_BUILD_NUMBER=1
 
   stub docker-compose \
-    "-f tests/composefiles/docker-compose.v3.2.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml build --pull helloworld : echo built helloworld"
+    "-f tests/composefiles/docker-compose.v3.2.yml -p buildkite1111 build --pull helloworld : echo built helloworld"
 
   run "$PWD"/hooks/command
 
@@ -552,7 +559,7 @@ teardown() {
     "pull my.repository/myservice_cache:latest : exit 1"
 
   stub docker-compose \
-    "-f tests/composefiles/docker-compose.v3.2.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml build --pull helloworld : echo built helloworld"
+    "-f tests/composefiles/docker-compose.v3.2.yml -p buildkite1111 build --pull helloworld : echo built helloworld"
 
   run "$PWD"/hooks/command
 
@@ -650,13 +657,13 @@ teardown() {
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_TARGET=intermediate
 
   stub docker-compose \
-    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml build --pull --target \* \* : echo built \${11} with target \${10}"
+    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml build --pull \* : echo built \${9}"
 
   run "$PWD"/hooks/command
 
   assert_success
   assert_output --partial "built myservice"
-  assert_output --partial "with target intermediate"
+  assert_output --partial "    target: intermediate"
 
   unstub docker-compose
 }
@@ -686,7 +693,7 @@ teardown() {
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_SSH=true
 
   stub docker-compose \
-    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml build --pull --ssh default \* : echo built \${11} with ssh"
+    "-f docker-compose.yml -p buildkite1111 build --pull --ssh default \* : echo built \${9} with ssh"
 
   run "$PWD"/hooks/command
 
@@ -707,7 +714,7 @@ teardown() {
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_SSH=context
 
   stub docker-compose \
-    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml build --pull --ssh context \* : echo built \${11} with ssh"
+    "-f docker-compose.yml -p buildkite1111 build --pull --ssh context \* : echo built \${9} with ssh"
 
   run "$PWD"/hooks/command
 
@@ -728,7 +735,7 @@ teardown() {
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_SECRETS_1='id=SECRET_VAR'
 
   stub docker-compose \
-    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml build --pull --secret \* --secret \* \* : echo built \${13} with secrets \${10} and \${12}"
+    "-f docker-compose.yml -p buildkite1111 build --pull --secret \* --secret \* \* : echo built \${11} with secrets \${8} and \${10}"
 
   run "$PWD"/hooks/command
 
@@ -747,7 +754,7 @@ teardown() {
   export BUILDKITE_BUILD_NUMBER=1
 
   stub docker-compose \
-    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml build myservice : echo built myservice"
+    "-f docker-compose.yml -p buildkite1111 build myservice : echo built myservice"
 
   run "$PWD"/hooks/command
 

--- a/tests/docker-compose-images.bats
+++ b/tests/docker-compose-images.bats
@@ -1,13 +1,17 @@
 #!/usr/bin/env bats
 
 # export DOCKER_COMPOSE_STUB_DEBUG=/dev/tty
+# export DOCKER_STUB_DEBUG=/dev/tty
 
 load "${BATS_PLUGIN_PATH}/load.bash"
 load '../lib/shared'
 load '../lib/push'
 
-@test "Image for compose service with an image in config" {
+setup() {
   export HIDE_PROMPT=1
+}
+
+@test "Image for compose service with an image in config" {
   stub docker-compose \
     "-f docker-compose.yml -p buildkite config : cat $PWD/tests/composefiles/docker-compose.config.v3.2.yml"
 
@@ -15,23 +19,23 @@ load '../lib/push'
 
   assert_success
   assert_output "somewhere.dkr.ecr.some-region.amazonaws.com/blah"
+
   unstub docker-compose
 }
 
 @test "Image for compose service with a service with hyphens in the name" {
-  export HIDE_PROMPT=1
   stub docker-compose \
     "-f docker-compose.yml -p buildkite config : cat $PWD/tests/composefiles/docker-compose.config.with.hyphens.yml"
 
-  run compose_image_for_service "app"
+  run compose_image_for_service "foo-db"
 
   assert_success
-  assert_output "buildkite_app"
+  assert_output "postgres:9.4"
+
   unstub docker-compose
 }
 
 @test "Image for compose service without an image in config" {
-  export HIDE_PROMPT=1
   stub docker-compose \
     "-f docker-compose.yml -p buildkite config : cat $PWD/tests/composefiles/docker-compose.config.v3.2.yml"
 
@@ -39,5 +43,49 @@ load '../lib/push'
 
   assert_success
   assert_output "buildkite_helper"
+
+  unstub docker-compose
+}
+
+@test "Image for compose v2 service without an image in config" {
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLI_VERSION=2
+
+  stub docker \
+    "compose -f docker-compose.yml -p buildkite config : cat $PWD/tests/composefiles/docker-compose.config.v3.2.yml"
+
+  run compose_image_for_service "helper"
+
+  assert_success
+  assert_output "buildkite-helper"
+
+  unstub docker
+}
+
+@test "Image for compose v2 service without an image in config using compatibility" {
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLI_VERSION=2
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_COMPATIBILITY=true
+
+  stub docker \
+    "compose --compatibility -f docker-compose.yml -p buildkite config : cat $PWD/tests/composefiles/docker-compose.config.v3.2.yml"
+
+  run compose_image_for_service "helper"
+
+  assert_success
+  assert_output "buildkite_helper"
+
+  unstub docker
+}
+
+@test "Image for compose service without an image in config using compatibility" {
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_COMPATIBILITY=true
+
+  stub docker-compose \
+    "--compatibility -f docker-compose.yml -p buildkite config : cat $PWD/tests/composefiles/docker-compose.config.v3.2.yml"
+
+  run compose_image_for_service "helper"
+
+  assert_success
+  assert_output "buildkite_helper"
+
   unstub docker-compose
 }

--- a/tests/image-override-file.bats
+++ b/tests/image-override-file.bats
@@ -3,15 +3,22 @@
 load "${BATS_PLUGIN_PATH}/load.bash"
 load '../lib/shared'
 
-myservice_override_file1=$(cat <<-EOF
+@test "Build a docker-compose override file" {
+  myservice_override_file1=$(cat <<-EOF
 version: '2.1'
 services:
   myservice:
     image: newimage:1.0.0
 EOF
-)
+  )
+  run build_image_override_file_with_version "2.1" "myservice" "newimage:1.0.0" "" 0
 
-myservice_override_file2=$(cat <<-EOF
+  assert_success
+  assert_output "$myservice_override_file1"
+}
+
+@test "Build a docker-compose override file with multiple entries" {
+  myservice_override_file2=$(cat <<-EOF
 version: '2.1'
 services:
   myservice1:
@@ -19,9 +26,18 @@ services:
   myservice2:
     image: newimage2:1.0.0
 EOF
-)
+  )
 
-myservice_override_file3=$(cat <<-EOF
+  run build_image_override_file_with_version "2.1" \
+    "myservice1" "newimage1:1.0.0" "" 0 \
+    "myservice2" "newimage2:1.0.0" "" 0
+
+  assert_success
+  assert_output "$myservice_override_file2"
+}
+
+@test "Build a docker-compose file with cache-from" {
+  myservice_override_file3=$(cat <<-EOF
 version: '3.2'
 services:
   myservice:
@@ -30,9 +46,16 @@ services:
       cache_from:
         - my.repository/myservice:latest
 EOF
-)
+  )
 
-myservice_override_file4=$(cat <<-EOF
+  run build_image_override_file_with_version "3.2" "myservice" "newimage:1.0.0" "" 1 "my.repository/myservice:latest"
+
+  assert_success
+  assert_output "$myservice_override_file3"
+}
+
+@test "Build a docker-compose file with multiple cache-from entries" {
+  myservice_override_file4=$(cat <<-EOF
 version: '3.2'
 services:
   myservice:
@@ -42,70 +65,46 @@ services:
         - my.repository/myservice:latest
         - my.repository/myservice:target
 EOF
-)
+  )
 
-@test "Build a docker-compose override file" {
-  run build_image_override_file_with_version "2.1" "myservice" "newimage:1.0.0" 0
-
-  assert_success
-  assert_output "$myservice_override_file1"
-}
-
-@test "Build a docker-compose override file with multiple entries" {
-  run build_image_override_file_with_version "2.1" \
-    "myservice1" "newimage1:1.0.0" 0 \
-    "myservice2" "newimage2:1.0.0" 0
-
-  assert_success
-  assert_output "$myservice_override_file2"
-}
-
-@test "Build a docker-compose file with cache-from" {
-  run build_image_override_file_with_version "3.2" "myservice" "newimage:1.0.0" 1 "my.repository/myservice:latest"
-
-  assert_success
-  assert_output "$myservice_override_file3"
-}
-
-@test "Build a docker-compose file with multiple cache-from entries" {
-  run build_image_override_file_with_version "3.2" "myservice" "newimage:1.0.0" 2 "my.repository/myservice:latest" "my.repository/myservice:target"
+  run build_image_override_file_with_version "3.2" "myservice" "newimage:1.0.0" "" 2 "my.repository/myservice:latest" "my.repository/myservice:target"
 
   assert_success
   assert_output "$myservice_override_file4"
 }
 
 @test "Build a docker-compose file with cache-from and compose-file version 2" {
-  run build_image_override_file_with_version "2" "myservice" "newimage:1.0.0" 1 "my.repository/myservice:latest"
+  run build_image_override_file_with_version "2" "myservice" "newimage:1.0.0" "" 1 "my.repository/myservice:latest"
 
   assert_failure
 }
 
 @test "Build a docker-compose file with cache-from and compose-file version 2.0" {
-  run build_image_override_file_with_version "2.0" "myservice" "newimage:1.0.0" 1 "my.repository/myservice:latest"
+  run build_image_override_file_with_version "2.0" "myservice" "newimage:1.0.0" "" 1 "my.repository/myservice:latest"
 
   assert_failure
 }
 
 @test "Build a docker-compose file with cache-from and compose-file version 2.1" {
-  run build_image_override_file_with_version "2.1" "myservice" "newimage:1.0.0" 1 "my.repository/myservice:latest"
+  run build_image_override_file_with_version "2.1" "myservice" "newimage:1.0.0" "" 1 "my.repository/myservice:latest"
 
   assert_failure
 }
 
 @test "Build a docker-compose file with cache-from and compose-file version 3" {
-  run build_image_override_file_with_version "3" "myservice" "newimage:1.0.0" 1 "my.repository/myservice:latest"
+  run build_image_override_file_with_version "3" "myservice" "newimage:1.0.0" "" 1 "my.repository/myservice:latest"
 
   assert_failure
 }
 
 @test "Build a docker-compose file with cache-from and compose-file version 3.0" {
-  run build_image_override_file_with_version "3.0" "myservice" "newimage:1.0.0" 1 "my.repository/myservice:latest"
+  run build_image_override_file_with_version "3.0" "myservice" "newimage:1.0.0" "" 1 "my.repository/myservice:latest"
 
   assert_failure
 }
 
 @test "Build a docker-compose file with cache-from and compose-file version 3.1" {
-  run build_image_override_file_with_version "3.1" "myservice" "newimage:1.0.0" 1 "my.repository/myservice:latest"
+  run build_image_override_file_with_version "3.1" "myservice" "newimage:1.0.0" "" 1 "my.repository/myservice:latest"
 
   assert_failure
 }

--- a/tests/multiple-commands.bats
+++ b/tests/multiple-commands.bats
@@ -26,24 +26,18 @@ setup_file() {
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_IMAGE_REPOSITORY=my.repository/llamas
 
   stub docker-compose \
-     "-f docker-compose.yml -p buildkite12 -f docker-compose.buildkite-1-override.yml build --pull myservice : echo built myservice" \
-     "-f docker-compose.yml -p buildkite12 -f docker-compose.buildkite-1-override.yml push myservice : echo pushed myservice" \
-     "-f docker-compose.yml -p buildkite12 -f docker-compose.buildkite-1-override.yml pull myservice : echo pulled myservice" \
-     "-f docker-compose.yml -p buildkite12 -f docker-compose.buildkite-1-override.yml up -d --scale myservice=0 myservice : echo ran dependencies" \
-     "-f docker-compose.yml -p buildkite12 -f docker-compose.buildkite-1-override.yml run --name buildkite12_myservice_build_1 -T --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice"
+    "-f docker-compose.yml -p buildkite12 -f docker-compose.buildkite-1-override.yml build --pull myservice : echo built myservice" \
+    "-f docker-compose.yml -p buildkite12 -f docker-compose.buildkite-1-override.yml up -d --scale myservice=0 myservice : echo ran dependencies" \
+    "-f docker-compose.yml -p buildkite12 -f docker-compose.buildkite-1-override.yml run --name buildkite12_myservice_build_1 -T --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice"
 
   # these commands simulate metadata for a specific value by using an intermediate-file
   stub buildkite-agent \
-     "meta-data set docker-compose-plugin-built-image-tag-myservice \* : echo \$4 > /tmp/build-run-metadata" \
-     "meta-data exists docker-compose-plugin-built-image-tag-myservice : test -f /tmp/build-run-metadata" \
-     "meta-data get docker-compose-plugin-built-image-tag-myservice : cat /tmp/build-run-metadata"
+    "meta-data exists docker-compose-plugin-built-image-tag-myservice : test -f /tmp/build-run-metadata"
 
   run "$PWD"/hooks/command
 
   assert_success
   assert_output --partial "Building services myservice"
-  assert_output --partial "Pushing built images to my.repository/llamas"
-  assert_output --partial "Found a pre-built image for myservice"
   assert_output --partial "Starting dependencies"
   assert_output --partial "ran myservice" 
 
@@ -59,27 +53,24 @@ setup_file() {
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_IMAGE_REPOSITORY=my.repository/llamas
 
   stub docker-compose \
-     "-f docker-compose.yml -p buildkite12 -f docker-compose.buildkite-1-override.yml build --pull myservice : echo built myservice" \
-     "-f docker-compose.yml -p buildkite12 -f docker-compose.buildkite-1-override.yml push myservice : echo build-pushed myservice" \
-     "-f docker-compose.yml -p buildkite12 config : echo ''" \
-     "-f docker-compose.yml -p buildkite12 push myservice : echo push-pushed myservice"
+    "-f docker-compose.yml -p buildkite12 -f docker-compose.buildkite-1-override.yml build --pull myservice : echo built myservice" \
+    "-f docker-compose.yml -p buildkite12 config --images myservice : echo 'myservice'" \
+    "-f docker-compose.yml -p buildkite12 push myservice : echo pushed myservice"
   
   # these commands simulate metadata for a specific value by using an intermediate-file
   stub buildkite-agent \
-     "meta-data set docker-compose-plugin-built-image-tag-myservice \* : echo \$4 > /tmp/build-push-metadata" \
      "meta-data exists docker-compose-plugin-built-image-tag-myservice : test -f /tmp/build-push-metadata" \
-     "meta-data get docker-compose-plugin-built-image-tag-myservice : cat /tmp/build-push-metadata"
+     "meta-data set docker-compose-plugin-built-image-tag-myservice \* : echo \$4 > /tmp/build-push-metadata"
 
   stub docker \
-     "pull my.repository/llamas:test-myservice-build-1 : echo pulled pre-built image"
+     "image inspect myservice : echo existing-image"
 
   run "$PWD"/hooks/command
 
   assert_success
 
   assert_output --partial "Building services myservice"
-  assert_output --partial "Pushing built images to my.repository/llamas"
-  assert_output --partial "Pulling pre-built service myservice"
+  assert_output --partial "Using service image myservice from Docker Compose config"
   assert_output --partial "Pushing images for myservice"
 
   unstub docker
@@ -94,7 +85,7 @@ setup_file() {
   stub docker-compose \
     "-f docker-compose.yml -p buildkite12 up -d --scale myservice=0 myservice : echo ran dependencies" \
     "-f docker-compose.yml -p buildkite12 run --name buildkite12_myservice_build_1 -T --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice" \
-    "-f docker-compose.yml -p buildkite12 config : echo ''" 
+    "-f docker-compose.yml -p buildkite12 config --images myservice : echo 'image-myservice'" 
   
   # these make sure that the image is not pre-built
   stub buildkite-agent \
@@ -121,7 +112,7 @@ setup_file() {
   stub docker-compose \
     "-f docker-compose.yml -p buildkite12 up -d --scale myservice=0 myservice : echo ran dependencies" \
     "-f docker-compose.yml -p buildkite12 run --name buildkite12_myservice_build_1 -T --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice" \
-    "-f docker-compose.yml -p buildkite12 config : echo ''" \
+    "-f docker-compose.yml -p buildkite12 config --images myservice : echo 'image'" \
     "-f docker-compose.yml -p buildkite12 push myservice : echo pushed myservice"
      
   stub docker \
@@ -130,7 +121,8 @@ setup_file() {
   # these make sure that the image is not pre-built
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 1" \
-    "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 1"
+    "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 1" \
+    "meta-data set docker-compose-plugin-built-image-tag-myservice \* : set pre-built image metadata to \$4"
 
   run "$PWD"/hooks/command
 
@@ -146,27 +138,27 @@ setup_file() {
   unstub buildkite-agent
 }
 
-
 @test "Run and push with pre-built image" {
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RUN=myservice
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_PUSH=myservice
 
   stub docker-compose \
-     "-f docker-compose.yml -p buildkite12 -f docker-compose.buildkite-1-override.yml pull myservice : echo pulled myservice" \
-     "-f docker-compose.yml -p buildkite12 -f docker-compose.buildkite-1-override.yml up -d --scale myservice=0 myservice : echo ran dependencies" \
-     "-f docker-compose.yml -p buildkite12 -f docker-compose.buildkite-1-override.yml run --name buildkite12_myservice_build_1 -T --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice" \
-     "-f docker-compose.yml -p buildkite12 config : echo ''" \
-     "-f docker-compose.yml -p buildkite12 push myservice : echo pushed myservice"
+    "-f docker-compose.yml -p buildkite12 -f docker-compose.buildkite-1-override.yml pull myservice : echo pulled myservice" \
+    "-f docker-compose.yml -p buildkite12 -f docker-compose.buildkite-1-override.yml up -d --scale myservice=0 myservice : echo ran dependencies" \
+    "-f docker-compose.yml -p buildkite12 -f docker-compose.buildkite-1-override.yml run --name buildkite12_myservice_build_1 -T --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice" \
+    "-f docker-compose.yml -p buildkite12 config --images myservice : echo 'image'" \
+    "-f docker-compose.yml -p buildkite12 push myservice : echo pushed myservice"
   
   # these make sure that the image is not pre-built
   stub buildkite-agent \
-     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 0" \
-     "meta-data get docker-compose-plugin-built-image-tag-myservice : echo myservice-tag" \
-     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 0" \
-     "meta-data get docker-compose-plugin-built-image-tag-myservice : echo myservice-tag"
+    "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 0" \
+    "meta-data get docker-compose-plugin-built-image-tag-myservice : echo myservice-tag" \
+    "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 0" \
+    "meta-data get docker-compose-plugin-built-image-tag-myservice : echo myservice-tag" \
+    "meta-data set docker-compose-plugin-built-image-tag-myservice \* : set pre-built image metadata to \$4"
 
   stub docker \
-     "pull myservice-tag : echo pulled pre-built image"
+    "pull myservice-tag : echo pulled pre-built image"
 
   run "$PWD"/hooks/command
 

--- a/tests/multiple-commands.bats
+++ b/tests/multiple-commands.bats
@@ -30,7 +30,7 @@ setup_file() {
      "-f docker-compose.yml -p buildkite12 -f docker-compose.buildkite-1-override.yml push myservice : echo pushed myservice" \
      "-f docker-compose.yml -p buildkite12 -f docker-compose.buildkite-1-override.yml pull myservice : echo pulled myservice" \
      "-f docker-compose.yml -p buildkite12 -f docker-compose.buildkite-1-override.yml up -d --scale myservice=0 myservice : echo ran dependencies" \
-     "-f docker-compose.yml -p buildkite12 -f docker-compose.buildkite-1-override.yml run --name buildkite12_myservice_build_1 --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice"
+     "-f docker-compose.yml -p buildkite12 -f docker-compose.buildkite-1-override.yml run --name buildkite12_myservice_build_1 -T --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice"
 
   # these commands simulate metadata for a specific value by using an intermediate-file
   stub buildkite-agent \
@@ -93,7 +93,7 @@ setup_file() {
 
   stub docker-compose \
     "-f docker-compose.yml -p buildkite12 up -d --scale myservice=0 myservice : echo ran dependencies" \
-    "-f docker-compose.yml -p buildkite12 run --name buildkite12_myservice_build_1 --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice" \
+    "-f docker-compose.yml -p buildkite12 run --name buildkite12_myservice_build_1 -T --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice" \
     "-f docker-compose.yml -p buildkite12 config : echo ''" 
   
   # these make sure that the image is not pre-built
@@ -120,7 +120,7 @@ setup_file() {
 
   stub docker-compose \
     "-f docker-compose.yml -p buildkite12 up -d --scale myservice=0 myservice : echo ran dependencies" \
-    "-f docker-compose.yml -p buildkite12 run --name buildkite12_myservice_build_1 --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice" \
+    "-f docker-compose.yml -p buildkite12 run --name buildkite12_myservice_build_1 -T --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice" \
     "-f docker-compose.yml -p buildkite12 config : echo ''" \
     "-f docker-compose.yml -p buildkite12 push myservice : echo pushed myservice"
      
@@ -154,7 +154,7 @@ setup_file() {
   stub docker-compose \
      "-f docker-compose.yml -p buildkite12 -f docker-compose.buildkite-1-override.yml pull myservice : echo pulled myservice" \
      "-f docker-compose.yml -p buildkite12 -f docker-compose.buildkite-1-override.yml up -d --scale myservice=0 myservice : echo ran dependencies" \
-     "-f docker-compose.yml -p buildkite12 -f docker-compose.buildkite-1-override.yml run --name buildkite12_myservice_build_1 --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice" \
+     "-f docker-compose.yml -p buildkite12 -f docker-compose.buildkite-1-override.yml run --name buildkite12_myservice_build_1 -T --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice" \
      "-f docker-compose.yml -p buildkite12 config : echo ''" \
      "-f docker-compose.yml -p buildkite12 push myservice : echo pushed myservice"
   
@@ -183,4 +183,3 @@ setup_file() {
   unstub docker-compose
   unstub buildkite-agent
 }
-

--- a/tests/multiple-commands.bats
+++ b/tests/multiple-commands.bats
@@ -82,6 +82,7 @@ setup_file() {
   assert_output --partial "Pulling pre-built service myservice"
   assert_output --partial "Pushing images for myservice"
 
+  unstub docker
   unstub docker-compose
   unstub buildkite-agent
 }
@@ -165,8 +166,7 @@ setup_file() {
      "meta-data get docker-compose-plugin-built-image-tag-myservice : echo myservice-tag"
 
   stub docker \
-     "pull myservice-tag : echo pulled pre-built image" \
-     "tag myservice-tag buildkite12_myservice : echo re-tagged pre-built image"
+     "pull myservice-tag : echo pulled pre-built image"
 
   run "$PWD"/hooks/command
 
@@ -179,6 +179,7 @@ setup_file() {
   assert_output --partial "Pulling pre-built service myservice"
   assert_output --partial "Pushing images for myservice" 
 
+  unstub docker
   unstub docker-compose
   unstub buildkite-agent
 }

--- a/tests/multiple-commands.bats
+++ b/tests/multiple-commands.bats
@@ -26,11 +26,10 @@ setup_file() {
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_IMAGE_REPOSITORY=my.repository/llamas
 
   stub docker-compose \
-    "-f docker-compose.yml -p buildkite12 -f docker-compose.buildkite-1-override.yml build --pull myservice : echo built myservice" \
-    "-f docker-compose.yml -p buildkite12 -f docker-compose.buildkite-1-override.yml up -d --scale myservice=0 myservice : echo ran dependencies" \
-    "-f docker-compose.yml -p buildkite12 -f docker-compose.buildkite-1-override.yml run --name buildkite12_myservice_build_1 -T --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice"
+    "-f docker-compose.yml -p buildkite12 build --pull myservice : echo built myservice" \
+    "-f docker-compose.yml -p buildkite12 up -d --scale myservice=0 myservice : echo ran dependencies" \
+    "-f docker-compose.yml -p buildkite12 run --name buildkite12_myservice_build_1 -T --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice"
 
-  # these commands simulate metadata for a specific value by using an intermediate-file
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : test -f /tmp/build-run-metadata"
 
@@ -53,7 +52,7 @@ setup_file() {
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_IMAGE_REPOSITORY=my.repository/llamas
 
   stub docker-compose \
-    "-f docker-compose.yml -p buildkite12 -f docker-compose.buildkite-1-override.yml build --pull myservice : echo built myservice" \
+    "-f docker-compose.yml -p buildkite12 build --pull myservice : echo built myservice" \
     "-f docker-compose.yml -p buildkite12 config --images myservice : echo 'myservice'" \
     "-f docker-compose.yml -p buildkite12 push myservice : echo pushed myservice"
   

--- a/tests/multiple-commands.bats
+++ b/tests/multiple-commands.bats
@@ -63,7 +63,6 @@ teardown() {
   
   # these commands simulate metadata for a specific value by using an intermediate-file
   stub buildkite-agent \
-     "meta-data exists docker-compose-plugin-built-image-tag-myservice : test -f /tmp/build-push-metadata" \
      "meta-data set docker-compose-plugin-built-image-tag-myservice \* : echo \$4 > /tmp/build-push-metadata"
 
   stub docker \
@@ -125,7 +124,6 @@ teardown() {
   # these make sure that the image is not pre-built
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 1" \
-    "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 1" \
     "meta-data set docker-compose-plugin-built-image-tag-myservice \* : set pre-built image metadata to \$4"
 
   run "$PWD"/hooks/command
@@ -162,6 +160,7 @@ teardown() {
     "meta-data set docker-compose-plugin-built-image-tag-myservice \* : set pre-built image metadata to \$4"
 
   stub docker \
+    "image inspect buildkite12_myservice : exit 1" \
     "pull myservice-tag : echo pulled pre-built image"
 
   run "$PWD"/hooks/command

--- a/tests/output.bats
+++ b/tests/output.bats
@@ -32,7 +32,7 @@ setup_file() {
 
   stub docker-compose \
     "-f docker-compose.yml -p buildkite1111 up -d --scale myservice=0 myservice : echo ran myservice dependencies" \
-    "-f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 --rm myservice echo 'hello world' : echo ran myservice command"
+    "-f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 -T --rm myservice echo 'hello world' : echo ran myservice command"
 
   stub docker \
     "ps -a --filter label=com.docker.compose.project=buildkite1111 -q : cat tests/fixtures/id-multiple-services.txt" \
@@ -114,7 +114,7 @@ setup_file() {
 
   stub docker-compose \
     "-f docker-compose.yml -p buildkite1111 up -d --scale myservice=0 myservice : echo ran myservice dependencies" \
-    "-f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 --rm myservice echo 'hello world' : echo ran myservice command"
+    "-f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 -T --rm myservice echo 'hello world' : echo ran myservice command"
 
   stub docker \
     "ps -a --filter label=com.docker.compose.project=buildkite1111 -q : cat tests/fixtures/id-multiple-services.txt" \
@@ -155,7 +155,7 @@ setup_file() {
 
   stub docker-compose \
     "-f docker-compose.yml -p buildkite1111 up -d --scale myservice=0 myservice : echo ran myservice dependencies" \
-    "-f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 --rm myservice echo 'hello world' : echo ran myservice command"
+    "-f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 -T --rm myservice echo 'hello world' : echo ran myservice command"
 
   stub docker \
     "ps -a --filter label=com.docker.compose.project=buildkite1111 -q : echo" \

--- a/tests/push.bats
+++ b/tests/push.bats
@@ -15,8 +15,7 @@ load '../lib/shared'
   export BUILDKITE_BUILD_NUMBER=1
 
   stub buildkite-agent \
-    "meta-data exists docker-compose-plugin-built-image-tag-app : exit 1" \
-    "meta-data set docker-compose-plugin-built-image-tag-app \* : echo \$4 > ${BATS_TEST_TMPDIR}/build-push-metadata"
+    "meta-data set docker-compose-plugin-built-image-tag-app \* : echo setting metadata to \$4"
 
   stub docker-compose \
     "-f docker-compose.yml -p buildkite1111 config : cat ${PWD}/tests/composefiles/docker-compose.config.v3.2.yml" \
@@ -42,6 +41,7 @@ load '../lib/shared'
   export BUILDKITE_BUILD_NUMBER=1
 
   stub docker \
+    "image inspect \* : exit 1" \
     "pull myimage : echo pulled prebuilt image" \
     "tag myimage my.repository/myservice:llamas : echo tagged image" \
     "push my.repository/myservice:llamas : echo pushed myservice"
@@ -74,6 +74,7 @@ load '../lib/shared'
 
 
   stub docker \
+    "image inspect \* : exit 1" \
     "pull prebuilt : echo 'pulled prebuilt image'" \
     "tag prebuilt \* : echo 'invalid tag'; exit 1"
 
@@ -105,11 +106,14 @@ load '../lib/shared'
   export BUILDKITE_BUILD_NUMBER=1
 
   stub docker \
+    "image inspect \* : exit 1" \
     "pull prebuilt : echo pulled prebuilt image" \
     "tag prebuilt my.repository/myservice:llamas : echo tagged image1" \
     "push my.repository/myservice:llamas : echo pushed myservice1" \
+    "image inspect \* : exit 1" \
     "tag prebuilt my.repository/myservice:latest : echo tagged image2" \
     "push my.repository/myservice:latest : echo pushed myservice2" \
+    "image inspect \* : exit 1" \
     "tag prebuilt my.repository/myservice:alpacas : echo tagged image3" \
     "push my.repository/myservice:alpacas : echo pushed myservice3"
 
@@ -210,9 +214,11 @@ load '../lib/shared'
     "-f docker-compose.yml -p buildkite1111 config : echo ''" \
 
   stub docker \
+    "image inspect \* : exit 1" \
     "pull myservice1 : exit 0" \
     "tag myservice1 my.repository/myservice1 : echo tagging image1" \
     "push my.repository/myservice1 : echo pushing myservice1 image" \
+    "image inspect \* : exit 1" \
     "pull myservice2 : exit 0" \
     "tag myservice2 my.repository/myservice2:llamas : echo tagging image2" \
     "push my.repository/myservice2:llamas : echo pushing myservice2 image"

--- a/tests/push.bats
+++ b/tests/push.bats
@@ -15,14 +15,15 @@ load '../lib/shared'
   export BUILDKITE_BUILD_NUMBER=1
 
   stub buildkite-agent \
-    "meta-data exists docker-compose-plugin-built-image-tag-app : exit 1"
+    "meta-data exists docker-compose-plugin-built-image-tag-app : exit 1" \
+    "meta-data set docker-compose-plugin-built-image-tag-app \* : echo \$4 > ${BATS_TEST_TMPDIR}/build-push-metadata"
 
   stub docker-compose \
-    "-f docker-compose.yml -p buildkite1111 config : cat $PWD/tests/composefiles/docker-compose.config.v3.2.yml" \
+    "-f docker-compose.yml -p buildkite1111 config --images app : echo app-image" \
     "-f docker-compose.yml -p buildkite1111 push app : echo pushed app"
 
   stub docker \
-    "image inspect somewhere.dkr.ecr.some-region.amazonaws.com/blah : exit 0"
+    "image inspect app-image : exit 0"
 
   run "$PWD"/hooks/command
 
@@ -45,11 +46,12 @@ load '../lib/shared'
     "push my.repository/myservice:llamas : echo pushed myservice"
 
   stub docker-compose \
-    "-f docker-compose.yml -p buildkite1111 config : echo blah"
+    "-f docker-compose.yml -p buildkite1111 config --images myservice : echo ''"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 0" \
-    "meta-data get docker-compose-plugin-built-image-tag-myservice : echo myimage"
+    "meta-data get docker-compose-plugin-built-image-tag-myservice : echo myimage" \
+    "meta-data set docker-compose-plugin-built-image-tag-myservice \* : echo \$4 > ${BATS_TEST_TMPDIR}/build-push-metadata"
 
   run "$PWD"/hooks/command
 
@@ -69,7 +71,7 @@ load '../lib/shared'
   export BUILDKITE_BUILD_NUMBER=1
 
   stub docker-compose \
-    "-f docker-compose.yml -p buildkite1111 config : echo blah"
+    "-f docker-compose.yml -p buildkite1111 config --images myservice : echo ''"
 
   run "$PWD"/hooks/command
 
@@ -98,17 +100,20 @@ load '../lib/shared'
     "push my.repository/myservice:alpacas : echo pushed myservice3"
 
   stub docker-compose \
-    "-f docker-compose.yml -p buildkite1111 config : echo blah" \
-    "-f docker-compose.yml -p buildkite1111 config : echo blah" \
-    "-f docker-compose.yml -p buildkite1111 config : echo blah"
+    "-f docker-compose.yml -p buildkite1111 config --images myservice : echo ''" \
+    "-f docker-compose.yml -p buildkite1111 config --images myservice : echo ''" \
+    "-f docker-compose.yml -p buildkite1111 config --images myservice : echo ''"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 0" \
     "meta-data get docker-compose-plugin-built-image-tag-myservice : echo prebuilt" \
+    "meta-data set docker-compose-plugin-built-image-tag-myservice \* : echo \$4" \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 0" \
     "meta-data get docker-compose-plugin-built-image-tag-myservice : echo prebuilt" \
+    "meta-data set docker-compose-plugin-built-image-tag-myservice \* : echo \$4" \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 0" \
-    "meta-data get docker-compose-plugin-built-image-tag-myservice : echo prebuilt"
+    "meta-data get docker-compose-plugin-built-image-tag-myservice : echo prebuilt" \
+    "meta-data set docker-compose-plugin-built-image-tag-myservice \* : echo \$4" \
 
   run "$PWD"/hooks/command
 
@@ -135,10 +140,10 @@ load '../lib/shared'
     "meta-data exists docker-compose-plugin-built-image-tag-helper : exit 1"
 
   stub docker-compose \
-    "-f docker-compose.yml -p buildkite1111 config : cat $PWD/tests/composefiles/docker-compose.config.v3.2.yml"
+    "-f docker-compose.yml -p buildkite1111 config --images helper : echo ''"
 
   stub docker \
-    "image inspect buildkite1111_helper : exit 1"
+    "image inspect \* : exit 1"
 
   run "$PWD"/hooks/command
 
@@ -158,10 +163,10 @@ load '../lib/shared'
   export BUILDKITE_BUILD_NUMBER=1
 
   stub docker-compose \
-    "-f docker-compose.yml -p buildkite1111 config : echo blah "
+    "-f docker-compose.yml -p buildkite1111 config --images myservice1 : echo ''"
 
   stub docker \
-    "image inspect buildkite1111_myservice1 : exit 1"
+    "image inspect \* : exit 1"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice1 : exit 1"
@@ -185,8 +190,8 @@ load '../lib/shared'
   export BUILDKITE_BUILD_NUMBER=1
 
   stub docker-compose \
-    "-f docker-compose.yml -p buildkite1111 config : echo blah " \
-    "-f docker-compose.yml -p buildkite1111 config : echo blah " \
+    "-f docker-compose.yml -p buildkite1111 config --images myservice1 : echo ''" \
+    "-f docker-compose.yml -p buildkite1111 config --images myservice2 : echo ''" \
 
   stub docker \
     "pull myservice1 : exit 0" \
@@ -199,8 +204,10 @@ load '../lib/shared'
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice1 : exit 0" \
     "meta-data get docker-compose-plugin-built-image-tag-myservice1 : echo myservice1" \
+    "meta-data set docker-compose-plugin-built-image-tag-myservice1 \* : echo \$4" \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice2 : exit 0" \
-    "meta-data get docker-compose-plugin-built-image-tag-myservice2 : echo myservice2"
+    "meta-data get docker-compose-plugin-built-image-tag-myservice2 : echo myservice2" \
+    "meta-data set docker-compose-plugin-built-image-tag-myservice2 \* : echo \$4" \
 
   run "$PWD"/hooks/command
 

--- a/tests/push.bats
+++ b/tests/push.bats
@@ -5,13 +5,15 @@ load '../lib/shared.bash'
 
 # export DOCKER_STUB_DEBUG=/dev/tty
 # export BUILDKITE_AGENT_STUB_DEBUG=/dev/tty
-# export BATS_MOCK_TMPDIR=$PWD
 
-@test "Push a single service with an image in its config" {
+setup_file() {
   export BUILDKITE_JOB_ID=1111
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_PUSH=app
   export BUILDKITE_PIPELINE_SLUG=test
   export BUILDKITE_BUILD_NUMBER=1
+}
+
+@test "Push a single service with an image in its config" {
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_PUSH=app
 
   stub buildkite-agent \
     "meta-data set docker-compose-plugin-built-image-tag-app \* : echo tagged \$4"
@@ -31,10 +33,7 @@ load '../lib/shared.bash'
 }
 
 @test "Push a prebuilt image with a repository and a tag" {
-  export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_PUSH=myservice:my.repository/myservice:llamas
-  export BUILDKITE_PIPELINE_SLUG=test
-  export BUILDKITE_BUILD_NUMBER=1
 
   stub docker \
     "compose -f docker-compose.yml -p buildkite1111 config : echo ''" \
@@ -60,10 +59,6 @@ load '../lib/shared.bash'
 }
 
 @test "Push a prebuilt image with a repository and a tag in compatibility mode" {
-  export BUILDKITE_BUILD_NUMBER=1
-  export BUILDKITE_JOB_ID=1111
-  export BUILDKITE_PIPELINE_SLUG=test
-
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_PUSH=myservice:my.repository/myservice:llamas
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_COMPATIBILITY=true
 
@@ -91,10 +86,7 @@ load '../lib/shared.bash'
 }
 
 @test "Push a prebuilt image with an invalid tag" {
-  export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_PUSH=myservice:my.repository/myservice:-llamas
-  export BUILDKITE_PIPELINE_SLUG=test
-  export BUILDKITE_BUILD_NUMBER=1
 
   stub docker \
     "compose -f docker-compose.yml -p buildkite1111 config : echo blah" \
@@ -117,12 +109,9 @@ load '../lib/shared.bash'
 }
 
 @test "Push a prebuilt image to multiple tags" {
-  export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_PUSH_0=myservice:my.repository/myservice:llamas
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_PUSH_1=myservice:my.repository/myservice:latest
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_PUSH_2=myservice:my.repository/myservice:alpacas
-  export BUILDKITE_PIPELINE_SLUG=test
-  export BUILDKITE_BUILD_NUMBER=1
 
   stub docker \
     "compose -f docker-compose.yml -p buildkite1111 config : echo blah" \
@@ -166,10 +155,7 @@ load '../lib/shared.bash'
 }
 
 @test "Push a single service without prebuilt nor service image" {
-  export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_PUSH=helper:my.repository/helper:llamas
-  export BUILDKITE_PIPELINE_SLUG=test
-  export BUILDKITE_BUILD_NUMBER=1
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-helper : exit 1"
@@ -187,11 +173,8 @@ load '../lib/shared.bash'
 }
 
 @test "Push two services with pre-built images" {
-  export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_PUSH_0=myservice1:my.repository/myservice1
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_PUSH_1=myservice2:my.repository/myservice2:llamas
-  export BUILDKITE_PIPELINE_SLUG=test
-  export BUILDKITE_BUILD_NUMBER=1
 
   stub docker \
     "compose -f docker-compose.yml -p buildkite1111 config : echo blah " \
@@ -226,12 +209,9 @@ load '../lib/shared.bash'
 }
 
 @test "Push pre-built image with aliases" {
-  export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_PUSH=myservice
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD_ALIAS_0=myservice-1
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD_ALIAS_1=myservice-2
-  export BUILDKITE_PIPELINE_SLUG=test
-  export BUILDKITE_BUILD_NUMBER=1
 
   stub docker \
     "compose -f docker-compose.yml -p buildkite1111 config : echo ''" \
@@ -258,12 +238,9 @@ load '../lib/shared.bash'
 }
 
 @test "Push service with image with aliases" {
-  export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_PUSH=app
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD_ALIAS_0=myservice-1
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD_ALIAS_1=myservice-2
-  export BUILDKITE_PIPELINE_SLUG=test
-  export BUILDKITE_BUILD_NUMBER=1
 
   stub docker \
     "compose -f docker-compose.yml -p buildkite1111 config : cat ${PWD}/tests/composefiles/docker-compose.config.v3.2.yml" \

--- a/tests/run.bats
+++ b/tests/run.bats
@@ -23,7 +23,7 @@ setup_file() {
 
   stub docker-compose \
     "-f docker-compose.yml -p buildkite1111 up -d --scale myservice=0 myservice : echo ran myservice dependencies" \
-    "-f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 --rm myservice /bin/sh -e -c 'echo hello world' : echo ran myservice"
+    "-f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 -T --rm myservice /bin/sh -e -c 'echo hello world' : echo ran myservice"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 1"
@@ -47,7 +47,7 @@ setup_file() {
 
   stub docker-compose \
     "-f docker-compose.yml -p buildkite1111 up -d --scale myservice=0 myservice : echo ran myservice dependencies" \
-    "-f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 --rm myservice : echo ran myservice"
+    "-f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 -T --rm myservice : echo ran myservice"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 1"
@@ -73,7 +73,7 @@ setup_file() {
 
   stub docker-compose \
     "-f docker-compose.yml -p buildkite1111 up -d --scale myservice=0 myservice : echo ran myservice dependencies" \
-    "-f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 --workdir=/test_workdir --rm myservice : echo ran myservice"
+    "-f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 -T --workdir=/test_workdir --rm myservice : echo ran myservice"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 1"
@@ -97,7 +97,7 @@ setup_file() {
 
   stub docker-compose \
     "-f docker-compose.yml -p buildkite1111 up -d --scale myservice=0 myservice : echo ran myservice dependencies" \
-    "-f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 --rm myservice /bin/sh -e -c $'sh -c \'echo hello world\'' : echo ran myservice"
+    "-f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 -T --rm myservice /bin/sh -e -c $'sh -c \'echo hello world\'' : echo ran myservice"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 1"
@@ -123,7 +123,7 @@ cmd3"
 
   stub docker-compose \
     "-f docker-compose.yml -p buildkite1111 up -d --scale myservice=0 myservice : echo ran myservice dependencies" \
-    "-f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 --rm myservice /bin/sh -e -c $'cmd1\ncmd2\ncmd3' : echo ran myservice"
+    "-f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 -T --rm myservice /bin/sh -e -c $'cmd1\ncmd2\ncmd3' : echo ran myservice"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 1"
@@ -150,7 +150,7 @@ cmd3"
 
   stub docker-compose \
     "-f docker-compose.yml -p buildkite1111 up -d --scale myservice=0 myservice : echo ran myservice dependencies" \
-    "-f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 --rm myservice echo 'hello world' : echo ran myservice"
+    "-f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 -T --rm myservice echo 'hello world' : echo ran myservice"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 1"
@@ -180,7 +180,7 @@ cmd3"
 
   stub docker-compose \
     "-f docker-compose.yml -p buildkite1111 up -d --scale myservice=0 myservice : echo ran myservice dependencies" \
-    "-f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 -e MYENV=0 -e MYENV -e MYENV=2 -e MYENV -e ANOTHER=this\ is\ a\ long\ string\ with\ spaces\;\ and\ semi-colons --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice"
+    "-f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 -e MYENV=0 -e MYENV -e MYENV=2 -e MYENV -e ANOTHER=this\ is\ a\ long\ string\ with\ spaces\;\ and\ semi-colons -T --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 1"
@@ -205,7 +205,7 @@ cmd3"
 
   stub docker-compose \
     "-f docker-compose.yml -p buildkite1111 up -d --scale myservice=0 myservice : echo ran myservice dependencies" \
-    "-f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 --rm myservice /bin/sh -e -c 'echo hello world' : echo ran myservice"
+    "-f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 -T --rm myservice /bin/sh -e -c 'echo hello world' : echo ran myservice"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 1"
@@ -231,7 +231,7 @@ cmd3"
 
   stub docker-compose \
     "-f docker-compose.yml -p buildkite1111 up -d --scale myservice=0 myservice : echo ran myservice dependencies" \
-    "-f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 --rm myservice /bin/sh -e -c 'echo hello world' : echo ran myservice"
+    "-f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 -T --rm myservice /bin/sh -e -c 'echo hello world' : echo ran myservice"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 1"
@@ -255,7 +255,7 @@ cmd3"
   stub docker-compose \
     "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml pull myservice : echo pulled myservice" \
     "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml up -d --scale myservice=0 myservice : echo ran myservice dependencies" \
-    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice"
+    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 -T --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 0" \
@@ -286,7 +286,7 @@ cmd3"
   stub docker-compose \
     "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml pull myservice : echo pulled myservice" \
     "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml up -d --scale myservice=0 myservice : echo ran myservice dependencies" \
-    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 -e \* -e \* --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice with vars \${11} and \${13}"
+    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 -e \* -e \* -T --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice with vars \${11} and \${13}"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 0" \
@@ -316,7 +316,7 @@ cmd3"
   stub docker-compose \
     "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml pull myservice : echo pulled myservice" \
     "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml up -d --scale myservice=0 myservice : echo ran myservice dependencies" \
-    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice"
+    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 -T --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 0" \
@@ -343,7 +343,7 @@ cmd3"
   stub docker-compose \
     "-f tests/composefiles/docker-compose.v2.0.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml pull myservice : echo pulled myservice" \
     "-f tests/composefiles/docker-compose.v2.0.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml up -d --scale myservice=0 myservice : echo ran myservice dependencies" \
-    "-f tests/composefiles/docker-compose.v2.0.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice"
+    "-f tests/composefiles/docker-compose.v2.0.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 -T --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice-tests/composefiles/docker-compose.v2.0.yml : exit 0" \
@@ -371,7 +371,7 @@ export BUILDKITE_JOB_ID=1111
   stub docker-compose \
     "-f tests/composefiles/docker-compose.v2.0.yml -f tests/composefiles/docker-compose.v2.1.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml pull myservice : echo pulled myservice" \
     "-f tests/composefiles/docker-compose.v2.0.yml -f tests/composefiles/docker-compose.v2.1.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml up -d --scale myservice=0 myservice : echo pulled myservice" \
-    "-f tests/composefiles/docker-compose.v2.0.yml -f tests/composefiles/docker-compose.v2.1.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice"
+    "-f tests/composefiles/docker-compose.v2.0.yml -f tests/composefiles/docker-compose.v2.1.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 -T --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice-tests/composefiles/docker-compose.v2.0.yml-tests/composefiles/docker-compose.v2.1.yml : exit 0" \
@@ -398,7 +398,7 @@ export BUILDKITE_JOB_ID=1111
   stub docker-compose \
     "-f tests/composefiles/docker-compose.v2.0.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml pull myservice : echo pulled myservice" \
     "-f tests/composefiles/docker-compose.v2.0.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml up -d --scale myservice=0 myservice : echo ran myservice dependencies" \
-    "-f tests/composefiles/docker-compose.v2.0.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice"
+    "-f tests/composefiles/docker-compose.v2.0.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 -T --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice-tests/composefiles/docker-compose.v2.0.yml : exit 0" \
@@ -450,7 +450,7 @@ export BUILDKITE_JOB_ID=1111
     "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml pull myservice : exit 2" \
     "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml pull myservice : echo pulled myservice" \
     "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml up -d --scale myservice=0 myservice : echo started dependencies for myservice" \
-    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice"
+    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 -T --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 0" \
@@ -465,7 +465,7 @@ export BUILDKITE_JOB_ID=1111
   unstub buildkite-agent
 }
 
-@test "Run without a TTY" {
+@test "Run with a TTY" {
   export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RUN=myservice
   export BUILDKITE_PIPELINE_SLUG=test
@@ -473,12 +473,12 @@ export BUILDKITE_JOB_ID=1111
   export BUILDKITE_COMMAND=pwd
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CHECK_LINKED_CONTAINERS=false
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLEANUP=false
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_TTY=false
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_TTY=true
 
   stub docker-compose \
     "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml pull myservice : echo pulled myservice" \
     "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml up -d --scale myservice=0 myservice : echo started dependencies for myservice" \
-    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 -T --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice without tty"
+    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice without tty"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 0" \
@@ -504,7 +504,7 @@ export BUILDKITE_JOB_ID=1111
 
   stub docker-compose \
     "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml pull myservice : echo pulled myservice" \
-    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 --no-deps --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice without dependencies"
+    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 -T --no-deps --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice without dependencies"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 0" \
@@ -530,7 +530,7 @@ export BUILDKITE_JOB_ID=1111
 
   stub docker-compose \
     "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml pull myservice : echo pulled myservice" \
-    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice with dependencies"
+    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 -T --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice with dependencies"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 0" \
@@ -557,7 +557,7 @@ export BUILDKITE_JOB_ID=1111
   stub docker-compose \
     "--no-ansi -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml pull myservice : echo pulled myservice" \
     "--no-ansi -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml up -d --scale myservice=0 myservice : echo started dependencies for myservice" \
-    "--no-ansi -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice without ansi output"
+    "--no-ansi -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 -T --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice without ansi output"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 0" \
@@ -582,7 +582,7 @@ export BUILDKITE_JOB_ID=1111
 
   stub docker-compose \
     "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml up -d --scale myservice=0 myservice : echo started dependencies for myservice" \
-    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice without pull"
+    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 -T --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice without pull"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 0" \
@@ -611,7 +611,7 @@ export BUILDKITE_JOB_ID=1111
   stub docker-compose \
     "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml pull myservice : echo pulled myservice" \
     "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml up -d --scale myservice=0 myservice : echo started dependencies for myservice" \
-    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 --use-aliases --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice with use aliases output"
+    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 -T --use-aliases --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice with use aliases output"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 0" \
@@ -638,7 +638,7 @@ export BUILDKITE_JOB_ID=1111
   stub docker-compose \
     "--compatibility -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml pull myservice : echo pulled myservice" \
     "--compatibility -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml up -d --scale myservice=0 myservice : echo started dependencies for myservice" \
-    "--compatibility -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice with use aliases output"
+    "--compatibility -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 -T --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice with use aliases output"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 0" \
@@ -666,7 +666,7 @@ export BUILDKITE_JOB_ID=1111
   stub docker-compose \
     "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml pull myservice : echo pulled myservice" \
     "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml up -d --scale myservice=0 myservice : echo started dependencies for myservice" \
-    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 -v $PWD/dist:/app/dist -v $PWD/pkg:/app/pkg --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice with volumes"
+    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 -v $PWD/dist:/app/dist -v $PWD/pkg:/app/pkg -T --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice with volumes"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 0" \
@@ -693,7 +693,7 @@ export BUILDKITE_JOB_ID=1111
   stub docker-compose \
     "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml pull myservice : echo pulled myservice" \
     "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml up -d --scale myservice=0 myservice : echo started dependencies for myservice" \
-    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 -v buildkite:/buildkite --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice with volumes"
+    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 -v buildkite:/buildkite -T --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice with volumes"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 0" \
@@ -723,7 +723,7 @@ export BUILDKITE_JOB_ID=1111
   stub docker-compose \
     "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml pull myservice : echo pulled myservice" \
     "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml up -d --scale myservice=0 myservice : echo started dependencies for myservice" \
-    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 -v buildkite:/buildkite -v $PWD/dist:/app/dist --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice with volumes"
+    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 -v buildkite:/buildkite -v $PWD/dist:/app/dist -T --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice with volumes"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 0" \
@@ -756,7 +756,7 @@ export BUILDKITE_JOB_ID=1111
   stub docker-compose \
     "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml pull myservice : echo pulled myservice" \
     "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml up -d --scale myservice=0 myservice : echo started dependencies for myservice" \
-    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 -v \\\$SUPER_VARIABLE:/mnt -v /:\\\$OTHER_VARIABLE -v \\\$RELATIVE_VARIABLE:/srv --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice with volumes"
+    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 -v \\\$SUPER_VARIABLE:/mnt -v /:\\\$OTHER_VARIABLE -v \\\$RELATIVE_VARIABLE:/srv -T --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice with volumes"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 0" \
@@ -792,7 +792,7 @@ export BUILDKITE_JOB_ID=1111
   stub docker-compose \
     "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml pull myservice : echo pulled myservice" \
     "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml up -d --scale myservice=0 myservice : echo started dependencies for myservice" \
-    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 -v \\\$SUPER_VARIABLE:/mnt -v /:\\\$OTHER_VARIABLE -v \\\$RELATIVE_VARIABLE:/srv --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice with volumes"
+    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 -v \\\$SUPER_VARIABLE:/mnt -v /:\\\$OTHER_VARIABLE -v \\\$RELATIVE_VARIABLE:/srv -T --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice with volumes"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 0" \
@@ -827,7 +827,7 @@ export BUILDKITE_JOB_ID=1111
   stub docker-compose \
     "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml pull myservice : echo pulled myservice" \
     "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml up -d --scale myservice=0 myservice : echo started dependencies for myservice" \
-    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 -v /test/path:/mnt -v /:/path/tested -v $PWD/path:/srv --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice with volumes"
+    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 -v /test/path:/mnt -v /:/path/tested -v $PWD/path:/srv -T --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice with volumes"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 0" \
@@ -854,7 +854,7 @@ export BUILDKITE_JOB_ID=1111
   stub docker-compose \
     "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml pull myservice : echo pulled myservice" \
     "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml up -d --scale myservice=0 myservice : echo started dependencies for myservice" \
-    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 -v buildkite:/buildkite -v $PWD/dist:/app/dist --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice with volumes"
+    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 -v buildkite:/buildkite -v $PWD/dist:/app/dist -T --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice with volumes"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 0" \
@@ -882,7 +882,7 @@ export BUILDKITE_JOB_ID=1111
 
   stub docker-compose \
     "-f llamas1.yml -f llamas2.yml -f llamas3.yml -p buildkite1111 up -d --scale myservice=0 myservice : echo started dependencies for myservice" \
-    "-f llamas1.yml -f llamas2.yml -f llamas3.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 --rm myservice /bin/sh -e -c 'echo hello world' : echo ran myservice"
+    "-f llamas1.yml -f llamas2.yml -f llamas3.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 -T --rm myservice /bin/sh -e -c 'echo hello world' : echo ran myservice"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice-llamas1.yml-llamas2.yml-llamas3.yml : exit 1"
@@ -906,7 +906,7 @@ export BUILDKITE_JOB_ID=1111
 
   stub docker-compose \
     "-f docker-compose.yml -p buildkite1111 up -d --scale myservice=0 myservice : echo started dependencies for myservice" \
-    "-f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 --rm myservice /bin/sh -e -c 'pwd' : exit 2"
+    "-f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 -T --rm myservice /bin/sh -e -c 'pwd' : exit 2"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 1"
@@ -934,7 +934,7 @@ export BUILDKITE_JOB_ID=1111
   stub docker-compose \
     "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml pull --parallel myservice1 myservice2 : echo pulled myservice1 and myservice2" \
     "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml up -d --scale myservice1=0 myservice1 : echo started dependencies for myservice1" \
-    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice1_build_1 --rm myservice1 /bin/sh -e -c 'pwd' : echo ran myservice1"
+    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice1_build_1 -T --rm myservice1 /bin/sh -e -c 'pwd' : echo ran myservice1"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice1 : exit 0" \
@@ -963,7 +963,7 @@ export BUILDKITE_JOB_ID=1111
 
   stub docker-compose \
     "-f docker-compose.yml -p buildkite1111 up -d --scale myservice=0 myservice : echo started dependencies for myservice" \
-    "-f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 --user=1000 --rm myservice /bin/sh -e -c $'sh -c \'whoami\'' : echo ran myservice"
+    "-f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 -T --user=1000 --rm myservice /bin/sh -e -c $'sh -c \'whoami\'' : echo ran myservice"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 1"
@@ -988,7 +988,7 @@ export BUILDKITE_JOB_ID=1111
 
   stub docker-compose \
     "-f docker-compose.yml -p buildkite1111 up -d --scale myservice=0 myservice : echo started dependencies for myservice" \
-    "-f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 --user=1000:1001 --rm myservice /bin/sh -e -c $'sh -c \'whoami\'' : echo ran myservice"
+    "-f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 -T --user=1000:1001 --rm myservice /bin/sh -e -c $'sh -c \'whoami\'' : echo ran myservice"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 1"
@@ -1024,7 +1024,7 @@ export BUILDKITE_JOB_ID=1111
 }
 
 
-@test "Run without --rm" {
+@test "Run without -T --rm" {
   export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RUN=myservice
   export BUILDKITE_PIPELINE_SLUG=test
@@ -1033,6 +1033,7 @@ export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CHECK_LINKED_CONTAINERS=false
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLEANUP=false
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RM=false
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_TTY=true
 
   stub docker-compose \
     "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml pull myservice : echo pulled myservice" \
@@ -1063,7 +1064,7 @@ export BUILDKITE_JOB_ID=1111
 
   stub docker-compose \
     "-f docker-compose.yml -p buildkite1111 up -d --scale myservice=0 myservice : echo ran myservice dependencies" \
-    "-f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 --rm --entrypoint 'my custom entrypoint' myservice : echo ran myservice"
+    "-f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 -T --rm --entrypoint 'my custom entrypoint' myservice : echo ran myservice"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 1"
@@ -1088,7 +1089,7 @@ export BUILDKITE_JOB_ID=1111
 
   stub docker-compose \
     "-f docker-compose.yml -p buildkite1111 up -d --scale myservice=0 myservice : echo ran myservice dependencies" \
-    "-f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 --rm -e BUILDKITE_JOB_ID -e BUILDKITE_BUILD_ID -e BUILDKITE_AGENT_ACCESS_TOKEN -v $BATS_MOCK_TMPDIR/bin/buildkite-agent:/usr/bin/buildkite-agent myservice : echo ran myservice"
+    "-f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 -T --rm -e BUILDKITE_JOB_ID -e BUILDKITE_BUILD_ID -e BUILDKITE_AGENT_ACCESS_TOKEN -v $BATS_MOCK_TMPDIR/bin/buildkite-agent:/usr/bin/buildkite-agent myservice : echo ran myservice"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 1"
@@ -1114,7 +1115,7 @@ export BUILDKITE_JOB_ID=1111
 
   stub docker-compose \
     "-f docker-compose.yml -p buildkite1111 up -d --scale myservice=0 myservice : echo ran myservice dependencies" \
-    "-f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 --rm myservice /bin/sh -e -c 'echo hello world' : echo ran myservice"
+    "-f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 -T --rm myservice /bin/sh -e -c 'echo hello world' : echo ran myservice"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 1"
@@ -1139,7 +1140,7 @@ export BUILDKITE_JOB_ID=1111
 
   stub docker-compose \
     "-f docker-compose.yml -p buildkite1111 up -d --scale myservice=0 myservice : echo ran myservice dependencies" \
-    "-f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 -v /tmp/sample-mirror:/tmp/sample-mirror:ro --rm myservice /bin/sh -e -c 'echo hello world' : echo ran myservice"
+    "-f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 -v /tmp/sample-mirror:/tmp/sample-mirror:ro -T --rm myservice /bin/sh -e -c 'echo hello world' : echo ran myservice"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 1"
@@ -1165,7 +1166,7 @@ export BUILDKITE_JOB_ID=1111
 
   stub docker-compose \
     "-f docker-compose.yml -p buildkite1111 up -d --scale myservice=0 myservice : echo ran myservice dependencies" \
-    "-f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 --rm -e SSH_AUTH_SOCK=/ssh-agent -v /tmp/ssh_auth_sock:/ssh-agent -v /root/.ssh/known_hosts:/root/.ssh/known_hosts myservice /bin/sh -e -c 'echo hello world' : echo ran myservice"
+    "-f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 -T --rm -e SSH_AUTH_SOCK=/ssh-agent -v /tmp/ssh_auth_sock:/ssh-agent -v /root/.ssh/known_hosts:/root/.ssh/known_hosts myservice /bin/sh -e -c 'echo hello world' : echo ran myservice"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 1"
@@ -1197,7 +1198,7 @@ export BUILDKITE_JOB_ID=1111
 
   stub docker-compose \
     "-f docker-compose.yml -p buildkite1111 up -d --scale myservice=0 myservice : echo ran myservice dependencies" \
-    "-f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 --rm -e SSH_AUTH_SOCK=/ssh-agent -v /tmp/ssh_auth_sock:/ssh-agent -v /root/.ssh/known_hosts:/tmp/test/.ssh/known_hosts myservice /bin/sh -e -c 'echo hello world' : echo ran myservice"
+    "-f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 -T --rm -e SSH_AUTH_SOCK=/ssh-agent -v /tmp/ssh_auth_sock:/ssh-agent -v /root/.ssh/known_hosts:/tmp/test/.ssh/known_hosts myservice /bin/sh -e -c 'echo hello world' : echo ran myservice"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 1"
@@ -1229,7 +1230,7 @@ export BUILDKITE_JOB_ID=1111
   stub docker-compose \
     "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml pull myservice : echo pulled myservice" \
     "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml up -d --scale myservice=0 myservice : echo started dependencies for myservice" \
-    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice without mount-checkout"
+    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 -T --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice without mount-checkout"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 0" \
@@ -1256,7 +1257,7 @@ export BUILDKITE_JOB_ID=1111
   stub docker-compose \
     "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml pull myservice : echo pulled myservice" \
     "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml up -d --scale myservice=0 myservice : echo started dependencies for myservice" \
-    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 --workdir=/workdir -v $PWD:/workdir --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice with mount-checkout"
+    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 -T --workdir=/workdir -v $PWD:/workdir --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice with mount-checkout"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 0" \
@@ -1284,7 +1285,7 @@ export BUILDKITE_JOB_ID=1111
   stub docker-compose \
     "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml pull myservice : echo pulled myservice" \
     "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml up -d --scale myservice=0 myservice : echo started dependencies for myservice" \
-    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 --workdir=$BUILDKITE_PLUGIN_DOCKER_COMPOSE_WORKDIR -v $PWD:$BUILDKITE_PLUGIN_DOCKER_COMPOSE_WORKDIR --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice with mount-checkout"
+    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 -T --workdir=$BUILDKITE_PLUGIN_DOCKER_COMPOSE_WORKDIR -v $PWD:$BUILDKITE_PLUGIN_DOCKER_COMPOSE_WORKDIR --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice with mount-checkout"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 0" \
@@ -1312,7 +1313,7 @@ export BUILDKITE_JOB_ID=1111
   stub docker-compose \
     "-f docker-compose.yml -p buildkite1111 -f \* pull myservice : echo pulled myservice" \
     "-f docker-compose.yml -p buildkite1111 -f \* up -d --scale myservice=0 myservice : echo started dependencies for myservice" \
-    "-f docker-compose.yml -p buildkite1111 -f \* run --name buildkite1111_myservice_build_1 -v \* --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice with mount-checkout on \${11}"
+    "-f docker-compose.yml -p buildkite1111 -f \* run --name buildkite1111_myservice_build_1 -T -v \* --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice with mount-checkout on \${12}"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 0" \
@@ -1342,7 +1343,7 @@ export BUILDKITE_JOB_ID=1111
   stub docker-compose \
     "-f docker-compose.yml -p buildkite1111 -f \* pull myservice : echo pulled myservice" \
     "-f docker-compose.yml -p buildkite1111 -f \* up -d --scale myservice=0 myservice : echo started dependencies for myservice" \
-    "-f docker-compose.yml -p buildkite1111 -f \* run --name buildkite1111_myservice_build_1 \* -v \* --rm myservice /bin/sh -e -c 'pwd' : echo echo ran myservice with mount-checkout on \${12}"
+    "-f docker-compose.yml -p buildkite1111 -f \* run --name buildkite1111_myservice_build_1 -T \* -v \* --rm myservice /bin/sh -e -c 'pwd' : echo echo ran myservice with mount-checkout on \${13}"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 0" \
@@ -1425,7 +1426,7 @@ export BUILDKITE_JOB_ID=1111
 
   stub docker-compose \
     "-f docker-compose.yml -p buildkite1111 up --wait -d --scale myservice=0 myservice : echo ran myservice dependencies" \
-    "-f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 --rm myservice /bin/sh -e -c 'echo hello world' : echo ran myservice"
+    "-f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 -T --rm myservice /bin/sh -e -c 'echo hello world' : echo ran myservice"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 1"
@@ -1453,7 +1454,7 @@ export BUILDKITE_JOB_ID=1111
   stub docker-compose \
     "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml pull myservice : echo pulled myservice" \
     "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml up -d --scale myservice=0 myservice : echo started dependencies for myservice" \
-    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 --rm --service-ports myservice /bin/sh -e -c $'pwd' : echo ran myservice without tty"
+    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 -T --rm --service-ports myservice /bin/sh -e -c $'pwd' : echo ran myservice without tty"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : echo myimage" \
@@ -1495,7 +1496,7 @@ export BUILDKITE_JOB_ID=1111
       --label com.buildkite.step_key=${BUILDKITE_STEP_KEY} \
       --label com.buildkite.agent_name=${BUILDKITE_AGENT_NAME} \
       --label com.buildkite.agent_id=${BUILDKITE_AGENT_ID} \
-      --rm myservice /bin/sh -e -c $'pwd' : echo ran myservice"
+      -T --rm myservice /bin/sh -e -c $'pwd' : echo ran myservice"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : echo myimage" \
@@ -1521,7 +1522,7 @@ export BUILDKITE_JOB_ID=1111
 
   stub docker-compose \
     "-f docker-compose.yml -p buildkite1111 up --quiet-pull -d --scale myservice=0 myservice : echo ran myservice dependencies" \
-    "-f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 --rm myservice /bin/sh -e -c 'echo hello world' : echo ran myservice"
+    "-f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 -T --rm myservice /bin/sh -e -c 'echo hello world' : echo ran myservice"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 1"
@@ -1549,7 +1550,7 @@ export BUILDKITE_JOB_ID=1111
 
   stub docker-compose \
     "-f docker-compose.yml -p buildkite1111 up -d --scale myservice=0 myservice : echo ran myservice dependencies" \
-    "-f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 -e VAR_A -e VAR_B -e VAR_C --rm myservice /bin/sh -e -c 'echo hello world' : echo ran myservice"
+    "-f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 -e VAR_A -e VAR_B -e VAR_C -T --rm myservice /bin/sh -e -c 'echo hello world' : echo ran myservice"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 1"
@@ -1593,7 +1594,7 @@ export BUILDKITE_JOB_ID=1111
 
   stub docker-compose \
     "-f docker-compose.yml -p buildkite1111 up -d --scale myservice=0 myservice : echo ran myservice dependencies" \
-    "-f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 --rm myservice /bin/sh -e -c 'echo hello world' : echo ran myservice"
+    "-f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 -T --rm myservice /bin/sh -e -c 'echo hello world' : echo ran myservice"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 1"
@@ -1614,11 +1615,11 @@ export BUILDKITE_JOB_ID=1111
   export BUILDKITE_COMMAND="echo hello world"
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CHECK_LINKED_CONTAINERS=false
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLEANUP=false
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_COLLAPSE_RUN_LOG_GROUP=true
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_COLLAPSE_LOGS=true
 
   stub docker-compose \
     "-f docker-compose.yml -p buildkite1111 up -d --scale myservice=0 myservice : echo ran myservice dependencies" \
-    "-f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 --rm myservice /bin/sh -e -c 'echo hello world' : echo ran myservice"
+    "-f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 -T --rm myservice /bin/sh -e -c 'echo hello world' : echo ran myservice"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 1"

--- a/tests/run.bats
+++ b/tests/run.bats
@@ -12,6 +12,11 @@ setup_file() {
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RUN_LABELS="false"
 }
 
+teardown() {
+  # some test failures may leave this file around
+  rm -f docker-compose.buildkite-1-override.yml
+}
+
 @test "Run without a prebuilt image" {
   export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RUN=myservice

--- a/tests/run.bats
+++ b/tests/run.bats
@@ -9,6 +9,10 @@ load '../lib/run.bash'
 # export BATS_MOCK_TMPDIR=$PWD
 
 setup_file() {
+  export BUILDKITE_JOB_ID=1111
+  export BUILDKITE_PIPELINE_SLUG=test
+  export BUILDKITE_BUILD_NUMBER=1
+
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RUN_LABELS="false"
 }
 
@@ -18,10 +22,7 @@ teardown() {
 }
 
 @test "Run without a prebuilt image" {
-  export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RUN=myservice
-  export BUILDKITE_PIPELINE_SLUG=test
-  export BUILDKITE_BUILD_NUMBER=1
   export BUILDKITE_COMMAND="echo hello world"
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CHECK_LINKED_CONTAINERS=false
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLEANUP=false
@@ -43,10 +44,7 @@ teardown() {
 }
 
 @test "Run without a prebuilt image and an empty command" {
-  export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RUN=myservice
-  export BUILDKITE_PIPELINE_SLUG=test
-  export BUILDKITE_BUILD_NUMBER=1
   export BUILDKITE_COMMAND=""
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CHECK_LINKED_CONTAINERS=false
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLEANUP=false
@@ -68,10 +66,7 @@ teardown() {
 }
 
 @test "Run without a prebuilt image and a custom workdir" {
-  export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RUN=myservice
-  export BUILDKITE_PIPELINE_SLUG=test
-  export BUILDKITE_BUILD_NUMBER=1
   export BUILDKITE_COMMAND=""
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_WORKDIR=/test_workdir
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CHECK_LINKED_CONTAINERS=false
@@ -94,10 +89,7 @@ teardown() {
 }
 
 @test "Run without a prebuilt image with a quoted command" {
-  export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RUN=myservice
-  export BUILDKITE_PIPELINE_SLUG=test
-  export BUILDKITE_BUILD_NUMBER=1
   export BUILDKITE_COMMAND="sh -c 'echo hello world'"
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CHECK_LINKED_CONTAINERS=false
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLEANUP=false
@@ -119,10 +111,7 @@ teardown() {
 }
 
 @test "Run without a prebuilt image with a multi-line command" {
-  export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RUN=myservice
-  export BUILDKITE_PIPELINE_SLUG=test
-  export BUILDKITE_BUILD_NUMBER=1
   export BUILDKITE_COMMAND="cmd1
 cmd2
 cmd3"
@@ -146,10 +135,7 @@ cmd3"
 }
 
 @test "Run without a prebuilt image with a command config" {
-  export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RUN=myservice
-  export BUILDKITE_PIPELINE_SLUG=test
-  export BUILDKITE_BUILD_NUMBER=1
   export BUILDKITE_COMMAND=""
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_COMMAND_0=echo
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_COMMAND_1="hello world"
@@ -173,10 +159,7 @@ cmd3"
 }
 
 @test "Run without a prebuilt image with custom env" {
-  export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RUN=myservice
-  export BUILDKITE_PIPELINE_SLUG=test
-  export BUILDKITE_BUILD_NUMBER=1
   export BUILDKITE_COMMAND=pwd
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CHECK_LINKED_CONTAINERS=false
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLEANUP=false
@@ -203,11 +186,8 @@ cmd3"
 }
 
 @test "Run without a prebuilt image with no-cache" {
-  export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RUN=myservice
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_NO_CACHE=true
-  export BUILDKITE_PIPELINE_SLUG=test
-  export BUILDKITE_BUILD_NUMBER=1
   export BUILDKITE_COMMAND="echo hello world"
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CHECK_LINKED_CONTAINERS=false
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLEANUP=false
@@ -229,10 +209,7 @@ cmd3"
 }
 
 @test "Run without a prebuilt image without pulling" {
-  export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RUN=myservice
-  export BUILDKITE_PIPELINE_SLUG=test
-  export BUILDKITE_BUILD_NUMBER=1
   export BUILDKITE_COMMAND="echo hello world"
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CHECK_LINKED_CONTAINERS=false
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLEANUP=false
@@ -255,9 +232,6 @@ cmd3"
 }
 
 @test "Run with a prebuilt image and propagate environment but no BUILDKITE_ENV_FILE" {
-  export BUILDKITE_JOB_ID=1111
-  export BUILDKITE_PIPELINE_SLUG=test
-  export BUILDKITE_BUILD_NUMBER=1
   export BUILDKITE_COMMAND=pwd
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RUN=myservice
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_PROPAGATE_ENVIRONMENT=true
@@ -282,9 +256,6 @@ cmd3"
 }
 
 @test "Run with a prebuilt image and propagate environment" {
-  export BUILDKITE_JOB_ID=1111
-  export BUILDKITE_PIPELINE_SLUG=test
-  export BUILDKITE_BUILD_NUMBER=1
   export BUILDKITE_COMMAND=pwd
   export BUILDKITE_ENV_FILE=/tmp/test_env
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RUN=myservice
@@ -315,10 +286,7 @@ cmd3"
 }
 
 @test "Run with a prebuilt image" {
-  export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RUN=myservice
-  export BUILDKITE_PIPELINE_SLUG=test
-  export BUILDKITE_BUILD_NUMBER=1
   export BUILDKITE_COMMAND=pwd
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CHECK_LINKED_CONTAINERS=false
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLEANUP=false
@@ -341,11 +309,8 @@ cmd3"
 }
 
 @test "Run with a prebuilt image and custom config file" {
-  export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RUN=myservice
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CONFIG=tests/composefiles/docker-compose.v2.0.yml
-  export BUILDKITE_PIPELINE_SLUG=test
-  export BUILDKITE_BUILD_NUMBER=1
   export BUILDKITE_COMMAND=pwd
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CHECK_LINKED_CONTAINERS=false
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLEANUP=false
@@ -368,12 +333,9 @@ cmd3"
 }
 
 @test "Run with a prebuilt image and multiple custom config files" {
-export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RUN=myservice
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CONFIG_0=tests/composefiles/docker-compose.v2.0.yml
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CONFIG_1=tests/composefiles/docker-compose.v2.1.yml
-  export BUILDKITE_PIPELINE_SLUG=test
-  export BUILDKITE_BUILD_NUMBER=1
   export BUILDKITE_COMMAND=pwd
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CHECK_LINKED_CONTAINERS=false
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLEANUP=false
@@ -397,10 +359,7 @@ export BUILDKITE_JOB_ID=1111
 
 @test "Run with a prebuilt image and custom config file set from COMPOSE_FILE" {
   export COMPOSE_FILE=tests/composefiles/docker-compose.v2.0.yml
-  export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RUN=myservice
-  export BUILDKITE_PIPELINE_SLUG=test
-  export BUILDKITE_BUILD_NUMBER=1
   export BUILDKITE_COMMAND=pwd
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CHECK_LINKED_CONTAINERS=false
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLEANUP=false
@@ -423,10 +382,7 @@ export BUILDKITE_JOB_ID=1111
 }
 
 @test "Run with a single prebuilt image, no retry on failed pull" {
-  export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RUN=myservice
-  export BUILDKITE_PIPELINE_SLUG=test
-  export BUILDKITE_BUILD_NUMBER=1
   export BUILDKITE_COMMAND=pwd
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CHECK_LINKED_CONTAINERS=false
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLEANUP=false
@@ -447,10 +403,7 @@ export BUILDKITE_JOB_ID=1111
 }
 
 @test "Run with a single prebuilt image, retry on failed pull" {
-  export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RUN=myservice
-  export BUILDKITE_PIPELINE_SLUG=test
-  export BUILDKITE_BUILD_NUMBER=1
   export BUILDKITE_COMMAND=pwd
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CHECK_LINKED_CONTAINERS=false
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLEANUP=false
@@ -476,10 +429,7 @@ export BUILDKITE_JOB_ID=1111
 }
 
 @test "Run with a TTY" {
-  export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RUN=myservice
-  export BUILDKITE_PIPELINE_SLUG=test
-  export BUILDKITE_BUILD_NUMBER=1
   export BUILDKITE_COMMAND=pwd
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CHECK_LINKED_CONTAINERS=false
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLEANUP=false
@@ -503,10 +453,7 @@ export BUILDKITE_JOB_ID=1111
 }
 
 @test "Run without dependencies" {
-  export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RUN=myservice
-  export BUILDKITE_PIPELINE_SLUG=test
-  export BUILDKITE_BUILD_NUMBER=1
   export BUILDKITE_COMMAND=pwd
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CHECK_LINKED_CONTAINERS=false
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLEANUP=false
@@ -529,10 +476,7 @@ export BUILDKITE_JOB_ID=1111
 }
 
 @test "Run with dependencies but in a single step" {
-  export BUILDKITE_BUILD_NUMBER=1
   export BUILDKITE_COMMAND=pwd
-  export BUILDKITE_JOB_ID=1111
-  export BUILDKITE_PIPELINE_SLUG=test
 
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RUN=myservice
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLEANUP=false
@@ -556,10 +500,7 @@ export BUILDKITE_JOB_ID=1111
 }
 
 @test "Run without ansi output" {
-  export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RUN=myservice
-  export BUILDKITE_PIPELINE_SLUG=test
-  export BUILDKITE_BUILD_NUMBER=1
   export BUILDKITE_COMMAND=pwd
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CHECK_LINKED_CONTAINERS=false
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLEANUP=false
@@ -583,10 +524,7 @@ export BUILDKITE_JOB_ID=1111
 }
 
 @test "Run with use aliases" {
-  export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RUN=myservice
-  export BUILDKITE_PIPELINE_SLUG=test
-  export BUILDKITE_BUILD_NUMBER=1
   export BUILDKITE_COMMAND=pwd
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CHECK_LINKED_CONTAINERS=false
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLEANUP=false
@@ -611,10 +549,7 @@ export BUILDKITE_JOB_ID=1111
 
 
 @test "Run with compatibility mode" {
-  export BUILDKITE_BUILD_NUMBER=1
   export BUILDKITE_COMMAND=pwd
-  export BUILDKITE_JOB_ID=1111
-  export BUILDKITE_PIPELINE_SLUG=test
 
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RUN=myservice
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLEANUP=false
@@ -638,10 +573,7 @@ export BUILDKITE_JOB_ID=1111
 }
 
 @test "Run with a volumes option" {
-  export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RUN=myservice
-  export BUILDKITE_PIPELINE_SLUG=test
-  export BUILDKITE_BUILD_NUMBER=1
   export BUILDKITE_COMMAND=pwd
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CHECK_LINKED_CONTAINERS=false
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLEANUP=false
@@ -666,10 +598,7 @@ export BUILDKITE_JOB_ID=1111
 }
 
 @test "Run with an external volume" {
-  export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RUN=myservice
-  export BUILDKITE_PIPELINE_SLUG=test
-  export BUILDKITE_BUILD_NUMBER=1
   export BUILDKITE_COMMAND=pwd
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CHECK_LINKED_CONTAINERS=false
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLEANUP=false
@@ -696,10 +625,7 @@ export BUILDKITE_JOB_ID=1111
   # Tests introduction of extra delimiters, as would occur if
   # EXPORT BUILDKITE_DOCKER_DEFAULT_VOLUMES="new:mount; ${BUILDKITE_DOCKER_DEFAULT_VOLUMES:-}"
   # was used with no existing value
-  export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RUN=myservice
-  export BUILDKITE_PIPELINE_SLUG=test
-  export BUILDKITE_BUILD_NUMBER=1
   export BUILDKITE_COMMAND=pwd
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CHECK_LINKED_CONTAINERS=false
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLEANUP=false
@@ -723,10 +649,7 @@ export BUILDKITE_JOB_ID=1111
 }
 
 @test "Run with default volumes" {
-  export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RUN=myservice
-  export BUILDKITE_PIPELINE_SLUG=test
-  export BUILDKITE_BUILD_NUMBER=1
   export BUILDKITE_COMMAND=pwd
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CHECK_LINKED_CONTAINERS=false
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLEANUP=false
@@ -750,10 +673,7 @@ export BUILDKITE_JOB_ID=1111
 }
 
 @test "Run with multiple config files" {
-  export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RUN=myservice
-  export BUILDKITE_PIPELINE_SLUG=test
-  export BUILDKITE_BUILD_NUMBER=1
   export BUILDKITE_COMMAND="echo hello world"
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CHECK_LINKED_CONTAINERS=false
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLEANUP=false
@@ -778,10 +698,7 @@ export BUILDKITE_JOB_ID=1111
 }
 
 @test "Run with a failure should expand previous group" {
-  export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RUN=myservice
-  export BUILDKITE_PIPELINE_SLUG=test
-  export BUILDKITE_BUILD_NUMBER=1
   export BUILDKITE_COMMAND=pwd
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CHECK_LINKED_CONTAINERS=false
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLEANUP=false
@@ -803,12 +720,9 @@ export BUILDKITE_JOB_ID=1111
 }
 
 @test "Run with multiple prebuilt images and multiple pulls" {
-  export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RUN=myservice1
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_PULL_0=myservice1
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_PULL_1=myservice2
-  export BUILDKITE_PIPELINE_SLUG=test
-  export BUILDKITE_BUILD_NUMBER=1
   export BUILDKITE_COMMAND=pwd
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CHECK_LINKED_CONTAINERS=false
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLEANUP=false
@@ -834,10 +748,7 @@ export BUILDKITE_JOB_ID=1111
 }
 
 @test "Run without a prebuilt image and a custom user" {
-  export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RUN=myservice
-  export BUILDKITE_PIPELINE_SLUG=test
-  export BUILDKITE_BUILD_NUMBER=1
   export BUILDKITE_COMMAND="sh -c 'whoami'"
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CHECK_LINKED_CONTAINERS=false
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLEANUP=false
@@ -860,10 +771,7 @@ export BUILDKITE_JOB_ID=1111
 }
 
 @test "Run without a prebuilt image and a custom user and group" {
-  export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RUN=myservice
-  export BUILDKITE_PIPELINE_SLUG=test
-  export BUILDKITE_BUILD_NUMBER=1
   export BUILDKITE_COMMAND="sh -c 'whoami'"
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CHECK_LINKED_CONTAINERS=false
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLEANUP=false
@@ -886,10 +794,7 @@ export BUILDKITE_JOB_ID=1111
 }
 
 @test "Fail with custom user and propagate UIDs" {
-  export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RUN=myservice
-  export BUILDKITE_PIPELINE_SLUG=test
-  export BUILDKITE_BUILD_NUMBER=1
   export BUILDKITE_COMMAND="sh -c 'whoami'"
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CHECK_LINKED_CONTAINERS=false
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLEANUP=false
@@ -909,10 +814,7 @@ export BUILDKITE_JOB_ID=1111
 
 
 @test "Run without --rm" {
-  export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RUN=myservice
-  export BUILDKITE_PIPELINE_SLUG=test
-  export BUILDKITE_BUILD_NUMBER=1
   export BUILDKITE_COMMAND=pwd
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CHECK_LINKED_CONTAINERS=false
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLEANUP=false
@@ -936,10 +838,7 @@ export BUILDKITE_JOB_ID=1111
 }
 
 @test "Run with custom entrypoint" {
-  export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RUN=myservice
-  export BUILDKITE_PIPELINE_SLUG=test
-  export BUILDKITE_BUILD_NUMBER=1
   export BUILDKITE_COMMAND=""
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CHECK_LINKED_CONTAINERS=false
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLEANUP=false
@@ -962,10 +861,7 @@ export BUILDKITE_JOB_ID=1111
 }
 
 @test "Run with mount-buildkite-agent enabled" {
-  export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RUN=myservice
-  export BUILDKITE_PIPELINE_SLUG=test
-  export BUILDKITE_BUILD_NUMBER=1
   export BUILDKITE_COMMAND=""
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CHECK_LINKED_CONTAINERS=false
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLEANUP=false
@@ -988,10 +884,7 @@ export BUILDKITE_JOB_ID=1111
 }
 
 @test "Run with various build arguments" {
-  export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RUN=myservice
-  export BUILDKITE_PIPELINE_SLUG=test
-  export BUILDKITE_BUILD_NUMBER=1
   export BUILDKITE_COMMAND="echo hello world"
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CHECK_LINKED_CONTAINERS=false
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLEANUP=false
@@ -1015,10 +908,7 @@ export BUILDKITE_JOB_ID=1111
 }
 
 @test "Run with git-mirrors" {
-  export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RUN=myservice
-  export BUILDKITE_PIPELINE_SLUG=test
-  export BUILDKITE_BUILD_NUMBER=1
   export BUILDKITE_COMMAND="echo hello world"
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CHECK_LINKED_CONTAINERS=false
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLEANUP=false
@@ -1042,10 +932,7 @@ export BUILDKITE_JOB_ID=1111
 
 @test "Run with mount-ssh-agent" {
   export SSH_AUTH_SOCK=/tmp/ssh_auth_sock
-  export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RUN=myservice
-  export BUILDKITE_PIPELINE_SLUG=test
-  export BUILDKITE_BUILD_NUMBER=1
   export BUILDKITE_COMMAND="echo hello world"
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CHECK_LINKED_CONTAINERS=false
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLEANUP=false
@@ -1074,10 +961,7 @@ export BUILDKITE_JOB_ID=1111
 
 @test "Run with mount-ssh-agent on particular folder" {
   export SSH_AUTH_SOCK=/tmp/ssh_auth_sock
-  export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RUN=myservice
-  export BUILDKITE_PIPELINE_SLUG=test
-  export BUILDKITE_BUILD_NUMBER=1
   export BUILDKITE_COMMAND="echo hello world"
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CHECK_LINKED_CONTAINERS=false
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLEANUP=false
@@ -1105,9 +989,6 @@ export BUILDKITE_JOB_ID=1111
 }
 
 @test "Run without mount-checkout doesn't set volume" {
-  export BUILDKITE_BUILD_NUMBER=1
-  export BUILDKITE_JOB_ID=1111
-  export BUILDKITE_PIPELINE_SLUG=test
   export BUILDKITE_COMMAND=pwd
 
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RUN=myservice
@@ -1134,9 +1015,6 @@ export BUILDKITE_JOB_ID=1111
 }
 
 @test "Run with mount-checkout set to true" {
-  export BUILDKITE_BUILD_NUMBER=1
-  export BUILDKITE_JOB_ID=1111
-  export BUILDKITE_PIPELINE_SLUG=test
   export BUILDKITE_COMMAND=pwd
 
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RUN=myservice
@@ -1163,9 +1041,6 @@ export BUILDKITE_JOB_ID=1111
 }
 
 @test "Run with mount-checkout set to true with custom workdir" {
-  export BUILDKITE_BUILD_NUMBER=1
-  export BUILDKITE_JOB_ID=1111
-  export BUILDKITE_PIPELINE_SLUG=test
   export BUILDKITE_COMMAND=pwd
 
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RUN=myservice
@@ -1193,9 +1068,6 @@ export BUILDKITE_JOB_ID=1111
 }
 
 @test "Run with mount-checkout set to specific path" {
-  export BUILDKITE_BUILD_NUMBER=1
-  export BUILDKITE_JOB_ID=1111
-  export BUILDKITE_PIPELINE_SLUG=test
   export BUILDKITE_COMMAND=pwd
 
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RUN=myservice
@@ -1222,9 +1094,6 @@ export BUILDKITE_JOB_ID=1111
 }
 
 @test "Run with mount-checkout set to specific path and workdir set" {
-  export BUILDKITE_BUILD_NUMBER=1
-  export BUILDKITE_JOB_ID=1111
-  export BUILDKITE_PIPELINE_SLUG=test
   export BUILDKITE_COMMAND=pwd
 
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RUN=myservice
@@ -1253,9 +1122,6 @@ export BUILDKITE_JOB_ID=1111
 }
 
 @test "Run with mount-checkout set something else" {
-  export BUILDKITE_BUILD_NUMBER=1
-  export BUILDKITE_JOB_ID=1111
-  export BUILDKITE_PIPELINE_SLUG=test
   export BUILDKITE_COMMAND=pwd
 
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RUN=myservice
@@ -1280,9 +1146,6 @@ export BUILDKITE_JOB_ID=1111
 }
 
 @test "Run with mount-checkout set something else and workdir set" {
-  export BUILDKITE_BUILD_NUMBER=1
-  export BUILDKITE_JOB_ID=1111
-  export BUILDKITE_PIPELINE_SLUG=test
   export BUILDKITE_COMMAND=pwd
 
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RUN=myservice
@@ -1308,10 +1171,7 @@ export BUILDKITE_JOB_ID=1111
 }
 
 @test "Run waiting for dependencies" {
-  export BUILDKITE_BUILD_NUMBER=1
   export BUILDKITE_COMMAND="echo hello world"
-  export BUILDKITE_JOB_ID=1111
-  export BUILDKITE_PIPELINE_SLUG=test
 
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RUN=myservice
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CHECK_LINKED_CONTAINERS=false
@@ -1334,10 +1194,7 @@ export BUILDKITE_JOB_ID=1111
 }
 
 @test "Run with --service-ports" {
-  export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RUN=myservice
-  export BUILDKITE_PIPELINE_SLUG=test
-  export BUILDKITE_BUILD_NUMBER=1
   export BUILDKITE_COMMAND=pwd
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CHECK_LINKED_CONTAINERS=false
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLEANUP=false
@@ -1361,11 +1218,8 @@ export BUILDKITE_JOB_ID=1111
 }
 
 @test "Run with --quiet-pull" {
-  export BUILDKITE_BUILD_NUMBER=1
   export BUILDKITE_COMMAND="echo hello world"
-  export BUILDKITE_JOB_ID=1111
-  export BUILDKITE_PIPELINE_SLUG=test
-
+  
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RUN=myservice
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CHECK_LINKED_CONTAINERS=false
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_QUIET_PULL=true
@@ -1390,10 +1244,7 @@ export BUILDKITE_JOB_ID=1111
 @test "Run with a list of propagated env vars" {
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_ENV_PROPAGATION_LIST="LIST_OF_VARS"
   export LIST_OF_VARS="VAR_A VAR_B VAR_C"
-  export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RUN=myservice
-  export BUILDKITE_PIPELINE_SLUG=test
-  export BUILDKITE_BUILD_NUMBER=1
   export BUILDKITE_COMMAND="echo hello world"
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CHECK_LINKED_CONTAINERS=false
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLEANUP=false
@@ -1415,10 +1266,7 @@ export BUILDKITE_JOB_ID=1111
 
 @test "Run with a list of propagated env vars - unless you forgot to define the variable" {
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_ENV_PROPAGATION_LIST="LIST_OF_VARS"
-  export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RUN=myservice
-  export BUILDKITE_PIPELINE_SLUG=test
-  export BUILDKITE_BUILD_NUMBER=1
   export BUILDKITE_COMMAND="echo hello world"
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CHECK_LINKED_CONTAINERS=false
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLEANUP=false

--- a/tests/v1/build.bats
+++ b/tests/v1/build.bats
@@ -11,14 +11,15 @@ teardown() {
 }
 
 setup_file() {
+  export BUILDKITE_JOB_ID=1111
+  export BUILDKITE_PIPELINE_SLUG=test
+  export BUILDKITE_BUILD_NUMBER=1
+
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLI_VERSION=1
 }
 
 @test "Build without a repository" {
-  export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD=myservice
-  export BUILDKITE_PIPELINE_SLUG=test
-  export BUILDKITE_BUILD_NUMBER=1
 
   stub docker-compose \
     "-f docker-compose.yml -p buildkite1111 build --pull myservice : echo built myservice"
@@ -32,11 +33,8 @@ setup_file() {
 }
 
 @test "Build with no-cache" {
-  export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD=myservice
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_NO_CACHE=true
-  export BUILDKITE_PIPELINE_SLUG=test
-  export BUILDKITE_BUILD_NUMBER=1
 
   stub docker-compose \
     "-f docker-compose.yml -p buildkite1111 build --pull --no-cache myservice : echo built myservice"
@@ -49,11 +47,8 @@ setup_file() {
 }
 
 @test "Build with parallel" {
-  export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD=myservice
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD_PARALLEL=true
-  export BUILDKITE_PIPELINE_SLUG=test
-  export BUILDKITE_BUILD_NUMBER=1
 
   stub docker-compose \
     "-f docker-compose.yml -p buildkite1111 build --pull --parallel myservice : echo built myservice"
@@ -66,10 +61,7 @@ setup_file() {
 }
 
 @test "Build with build args" {
-  export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD=myservice
-  export BUILDKITE_PIPELINE_SLUG=test
-  export BUILDKITE_BUILD_NUMBER=1
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_ARGS_0=MYARG=0
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_ARGS_1=MYARG=1
 
@@ -84,10 +76,7 @@ setup_file() {
 }
 
 @test "Build with docker-compose and v1 is set explicitly " {
-  export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD=myservice
-  export BUILDKITE_PIPELINE_SLUG=test
-  export BUILDKITE_BUILD_NUMBER=1
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLI_VERSION=1
 
   stub docker-compose \
@@ -101,10 +90,7 @@ setup_file() {
 }
 
 @test "Build with a repository" {
-  export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD=myservice
-  export BUILDKITE_PIPELINE_SLUG=test
-  export BUILDKITE_BUILD_NUMBER=1
 
   stub docker-compose \
     "-f docker-compose.yml -p buildkite1111 build --pull myservice : echo built myservice"
@@ -119,12 +105,9 @@ setup_file() {
 
 # TODO: move this to push testing
 @test "Build with a repository and multiple build aliases" {
-  export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD=myservice
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD_ALIAS_0=myservice-1
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD_ALIAS_1=myservice-2
-  export BUILDKITE_PIPELINE_SLUG=test
-  export BUILDKITE_BUILD_NUMBER=1
 
   stub docker-compose \
     "-f docker-compose.yml -p buildkite1111 build --pull myservice : echo built myservice"
@@ -138,10 +121,7 @@ setup_file() {
 }
 
 @test "Build with a repository and push retries" {
-  export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD=myservice
-  export BUILDKITE_PIPELINE_SLUG=test
-  export BUILDKITE_BUILD_NUMBER=1
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_PUSH_RETRIES=3
 
   stub docker-compose \
@@ -156,11 +136,8 @@ setup_file() {
 }
 
 @test "Build with a custom config file" {
-  export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD=myservice
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CONFIG=tests/composefiles/docker-compose.v2.0.yml
-  export BUILDKITE_PIPELINE_SLUG=test
-  export BUILDKITE_BUILD_NUMBER=1
 
   stub docker-compose \
     "-f tests/composefiles/docker-compose.v2.0.yml -p buildkite1111 build --pull myservice : echo built myservice"
@@ -174,12 +151,9 @@ setup_file() {
 }
 
 @test "Build with a repository and multiple custom config files" {
-  export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD=myservice
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CONFIG_0=tests/composefiles/docker-compose.v2.0.yml
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CONFIG_1=tests/composefiles/docker-compose.v2.1.yml
-  export BUILDKITE_PIPELINE_SLUG=test
-  export BUILDKITE_BUILD_NUMBER=1
 
   stub docker-compose \
     "-f tests/composefiles/docker-compose.v2.0.yml -f tests/composefiles/docker-compose.v2.1.yml -p buildkite1111 build --pull myservice : echo built myservice"
@@ -193,14 +167,11 @@ setup_file() {
 }
 
 @test "Build with a repository and multiple services" {
-  export BUILDKITE_JOB_ID=1112
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD_0=myservice1
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD_1=myservice2
-  export BUILDKITE_PIPELINE_SLUG=test
-  export BUILDKITE_BUILD_NUMBER=1
 
   stub docker-compose \
-    "-f docker-compose.yml -p buildkite1112 build --pull myservice1 myservice2 : echo built all services"
+    "-f docker-compose.yml -p buildkite1111 build --pull myservice1 myservice2 : echo built all services"
 
   run "$PWD"/hooks/command
 
@@ -211,14 +182,11 @@ setup_file() {
 }
 
 @test "Build with a docker-compose v1.0 configuration file" {
-  export BUILDKITE_JOB_ID=1112
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CONFIG="tests/composefiles/docker-compose.v1.0.yml"
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD_0=helloworld
-  export BUILDKITE_PIPELINE_SLUG=test
-  export BUILDKITE_BUILD_NUMBER=1
 
   stub docker-compose \
-    "-f tests/composefiles/docker-compose.v1.0.yml -p buildkite1112 build --pull helloworld : echo built service"
+    "-f tests/composefiles/docker-compose.v1.0.yml -p buildkite1111 build --pull helloworld : echo built service"
 
   run "$PWD"/hooks/command
 
@@ -230,11 +198,8 @@ setup_file() {
 
 @test "Build with a cache-from image" {
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CONFIG="tests/composefiles/docker-compose.v3.2.yml"
-  export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD_0=helloworld
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CACHE_FROM_0=helloworld:my.repository/myservice_cache:latest
-  export BUILDKITE_PIPELINE_SLUG=test
-  export BUILDKITE_BUILD_NUMBER=1
 
   stub docker-compose \
     "-f tests/composefiles/docker-compose.v3.2.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml build --pull helloworld : echo built helloworld"
@@ -250,12 +215,9 @@ setup_file() {
 
 @test "Build with a cache-from image with no-cache also set" {
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CONFIG="tests/composefiles/docker-compose.v3.2.yml"
-  export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD_0=helloworld
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CACHE_FROM_0=helloworld:my.repository/myservice_cache:latest
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_NO_CACHE=true
-  export BUILDKITE_PIPELINE_SLUG=test
-  export BUILDKITE_BUILD_NUMBER=1
 
   stub docker-compose \
     "-f tests/composefiles/docker-compose.v3.2.yml -p buildkite1111 build --pull --no-cache helloworld : echo built helloworld"
@@ -270,11 +232,8 @@ setup_file() {
 
 @test "Build with an invalid cache-from tag" {
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CONFIG="tests/composefiles/docker-compose.v3.2.yml"
-  export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD_0=helloworld
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CACHE_FROM_0=helloworld:my.repository/myservice_cache:-latest
-  export BUILDKITE_PIPELINE_SLUG=test
-  export BUILDKITE_BUILD_NUMBER=1
 
   stub docker-compose \
     "-f tests/composefiles/docker-compose.v3.2.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml build --pull helloworld : echo built helloworld"
@@ -289,10 +248,6 @@ setup_file() {
 }
 
 @test "Build with a cache-from image with no tag" {
-  export BUILDKITE_BUILD_NUMBER=1
-  export BUILDKITE_JOB_ID=1111
-  export BUILDKITE_PIPELINE_SLUG=test
-
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD_0=helloworld
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CACHE_FROM_0=helloworld:my.repository/myservice_cache
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CONFIG="tests/composefiles/docker-compose.v3.2.yml"
@@ -311,12 +266,9 @@ setup_file() {
 
 @test "Build with several cache-from images for one service" {
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CONFIG="tests/composefiles/docker-compose.v3.2.yml"
-  export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD_0=helloworld
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CACHE_FROM_0=helloworld:my.repository/myservice_cache:branch-name
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CACHE_FROM_1=helloworld:my.repository/myservice_cache:latest
-  export BUILDKITE_PIPELINE_SLUG=test
-  export BUILDKITE_BUILD_NUMBER=1
 
   stub docker-compose \
     "-f tests/composefiles/docker-compose.v3.2.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml build --pull helloworld : echo built helloworld"
@@ -333,11 +285,8 @@ setup_file() {
 
 @test "Build with a cache-from image with hyphen" {
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CONFIG="tests/composefiles/docker-compose.v3.2.yml"
-  export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD_0=hello-world
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CACHE_FROM_0=hello-world:my.repository/my-service_cache:latest
-  export BUILDKITE_PIPELINE_SLUG=test
-  export BUILDKITE_BUILD_NUMBER=1
 
   stub docker-compose \
     "-f tests/composefiles/docker-compose.v3.2.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml build --pull hello-world : echo built hello-world"
@@ -353,11 +302,8 @@ setup_file() {
 
 @test "Build with a service name and cache-from with period" {
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CONFIG="tests/composefiles/docker-compose.v3.2.yml"
-  export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD_0=hello.world
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CACHE_FROM_0=hello.world:my.repository/my-service_cache:latest
-  export BUILDKITE_PIPELINE_SLUG=test
-  export BUILDKITE_BUILD_NUMBER=1
 
   stub docker-compose \
     "-f tests/composefiles/docker-compose.v3.2.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml build --pull \* : echo built \$9"
@@ -372,10 +318,6 @@ setup_file() {
 }
 
 @test "Build with target" {
-  export BUILDKITE_BUILD_NUMBER=1
-  export BUILDKITE_JOB_ID=1111
-  export BUILDKITE_PIPELINE_SLUG=test
-
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD=myservice
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_TARGET=intermediate
 
@@ -392,10 +334,6 @@ setup_file() {
 }
 
 @test "Build with ssh option (but no buildkit)" {
-  export BUILDKITE_BUILD_NUMBER=1
-  export BUILDKITE_JOB_ID=1111
-  export BUILDKITE_PIPELINE_SLUG=test
-
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD=myservice
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_SSH=true
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILDKIT=false
@@ -408,10 +346,6 @@ setup_file() {
 }
 
 @test "Build with ssh option as true and buildkit" {
-  export BUILDKITE_BUILD_NUMBER=1
-  export BUILDKITE_JOB_ID=1111
-  export BUILDKITE_PIPELINE_SLUG=test
-
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD=myservice
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILDKIT=true
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_SSH=true
@@ -429,10 +363,6 @@ setup_file() {
 }
 
 @test "Build with ssh option as string and buildkit" {
-  export BUILDKITE_BUILD_NUMBER=1
-  export BUILDKITE_JOB_ID=1111
-  export BUILDKITE_PIPELINE_SLUG=test
-
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD=myservice
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILDKIT=true
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_SSH=context
@@ -450,10 +380,6 @@ setup_file() {
 }
 
 @test "Build with secrets" {
-  export BUILDKITE_BUILD_NUMBER=1
-  export BUILDKITE_JOB_ID=1111
-  export BUILDKITE_PIPELINE_SLUG=test
-
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD=myservice
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_SECRETS_0='id=test,file=~/.test'
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_SECRETS_1='id=SECRET_VAR'
@@ -471,11 +397,8 @@ setup_file() {
 }
 
 @test "Build without pull" {
-  export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD=myservice
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_SKIP_PULL=true
-  export BUILDKITE_PIPELINE_SLUG=test
-  export BUILDKITE_BUILD_NUMBER=1
 
   stub docker-compose \
     "-f docker-compose.yml -p buildkite1111 build myservice : echo built myservice"

--- a/tests/v1/build.bats
+++ b/tests/v1/build.bats
@@ -18,7 +18,7 @@ setup_file() {
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLI_VERSION=1
 }
 
-@test "Build without a repository" {
+@test "Build single service" {
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD=myservice
 
   stub docker-compose \
@@ -75,66 +75,6 @@ setup_file() {
   unstub docker-compose
 }
 
-@test "Build with docker-compose and v1 is set explicitly " {
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD=myservice
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLI_VERSION=1
-
-  stub docker-compose \
-    "-f docker-compose.yml -p buildkite1111 build --pull myservice : echo built myservice"
-
-  run "$PWD"/hooks/command
-
-  assert_success
-  assert_output --partial "built myservice"
-  unstub docker-compose
-}
-
-@test "Build with a repository" {
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD=myservice
-
-  stub docker-compose \
-    "-f docker-compose.yml -p buildkite1111 build --pull myservice : echo built myservice"
-
-  run "$PWD"/hooks/command
-
-  assert_success
-  assert_output --partial "built myservice"
-
-  unstub docker-compose
-}
-
-# TODO: move this to push testing
-@test "Build with a repository and multiple build aliases" {
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD=myservice
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD_ALIAS_0=myservice-1
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD_ALIAS_1=myservice-2
-
-  stub docker-compose \
-    "-f docker-compose.yml -p buildkite1111 build --pull myservice : echo built myservice"
-
-  run "$PWD"/hooks/command
-
-  assert_success
-  assert_output --partial "built myservice"
-
-  unstub docker-compose
-}
-
-@test "Build with a repository and push retries" {
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD=myservice
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_PUSH_RETRIES=3
-
-  stub docker-compose \
-    "-f docker-compose.yml -p buildkite1111 build --pull myservice : echo built myservice"
-
-  run "$PWD"/hooks/command
-
-  assert_success
-  assert_output --partial "built myservice"
-
-  unstub docker-compose
-}
-
 @test "Build with a custom config file" {
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD=myservice
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CONFIG=tests/composefiles/docker-compose.v2.0.yml
@@ -150,7 +90,7 @@ setup_file() {
   unstub docker-compose
 }
 
-@test "Build with a repository and multiple custom config files" {
+@test "Build with multiple custom config files" {
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD=myservice
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CONFIG_0=tests/composefiles/docker-compose.v2.0.yml
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CONFIG_1=tests/composefiles/docker-compose.v2.1.yml
@@ -166,7 +106,7 @@ setup_file() {
   unstub docker-compose
 }
 
-@test "Build with a repository and multiple services" {
+@test "Build multiple services" {
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD_0=myservice1
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD_1=myservice2
 

--- a/tests/v1/push.bats
+++ b/tests/v1/push.bats
@@ -8,14 +8,15 @@ load '../../lib/shared'
 # export BUILDKITE_AGENT_STUB_DEBUG=/dev/tty
 
 setup_file() {
+  export BUILDKITE_JOB_ID=1111
+  export BUILDKITE_PIPELINE_SLUG=test
+  export BUILDKITE_BUILD_NUMBER=1
+
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLI_VERSION=1
 }
 
 @test "Push a single service with an image in its config" {
-  export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_PUSH=app
-  export BUILDKITE_PIPELINE_SLUG=test
-  export BUILDKITE_BUILD_NUMBER=1
 
   stub buildkite-agent \
     "meta-data set docker-compose-plugin-built-image-tag-app \* : echo setting metadata to \$4"
@@ -38,10 +39,7 @@ setup_file() {
 }
 
 @test "Push a prebuilt image with a repository and a tag" {
-  export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_PUSH=myservice:my.repository/myservice:llamas
-  export BUILDKITE_PIPELINE_SLUG=test
-  export BUILDKITE_BUILD_NUMBER=1
 
   stub docker \
     "pull myimage : echo pulled prebuilt image" \
@@ -70,10 +68,6 @@ setup_file() {
 }
 
 @test "Push a prebuilt image with a repository and a tag in compatibility mode" {
-  export BUILDKITE_BUILD_NUMBER=1
-  export BUILDKITE_JOB_ID=1111
-  export BUILDKITE_PIPELINE_SLUG=test
-
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_PUSH=myservice:my.repository/myservice:llamas
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_COMPATIBILITY=true
 
@@ -100,10 +94,7 @@ setup_file() {
 }
 
 @test "Push a prebuilt image with an invalid tag" {
-  export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_PUSH=myservice:my.repository/myservice:-llamas
-  export BUILDKITE_PIPELINE_SLUG=test
-  export BUILDKITE_BUILD_NUMBER=1
 
   stub docker \
     "pull prebuilt : echo 'pulled prebuilt image'" \
@@ -130,12 +121,9 @@ setup_file() {
 }
 
 @test "Push a prebuilt image to multiple tags" {
-  export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_PUSH_0=myservice:my.repository/myservice:llamas
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_PUSH_1=myservice:my.repository/myservice:latest
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_PUSH_2=myservice:my.repository/myservice:alpacas
-  export BUILDKITE_PIPELINE_SLUG=test
-  export BUILDKITE_BUILD_NUMBER=1
 
   stub docker \
     "pull prebuilt : echo pulled prebuilt image" \
@@ -182,10 +170,7 @@ setup_file() {
 }
 
 @test "Push a single service without prebuilt nor service image" {
-  export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_PUSH=helper:my.repository/helper:llamas
-  export BUILDKITE_PIPELINE_SLUG=test
-  export BUILDKITE_BUILD_NUMBER=1
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-helper : exit 1"
@@ -204,11 +189,8 @@ setup_file() {
 }
 
 @test "Push two services without pre-built nor service image (second one is never tried)" {
-  export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_PUSH_0=myservice1:my.repository/myservice1
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_PUSH_1=myservice2:my.repository/myservice2:llamas
-  export BUILDKITE_PIPELINE_SLUG=test
-  export BUILDKITE_BUILD_NUMBER=1
 
   stub docker-compose \
     "-f docker-compose.yml -p buildkite1111 config : echo ''"
@@ -227,11 +209,8 @@ setup_file() {
 }
 
 @test "Push two pre-built services with target repositories and tags" {
-  export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_PUSH_0=myservice1:my.repository/myservice1
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_PUSH_1=myservice2:my.repository/myservice2:llamas
-  export BUILDKITE_PIPELINE_SLUG=test
-  export BUILDKITE_BUILD_NUMBER=1
 
   stub docker-compose \
     "-f docker-compose.yml -p buildkite1111 config : echo ''" \
@@ -269,12 +248,9 @@ setup_file() {
 }
 
 @test "Push a pre-built service with multiple build aliases" {
-  export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_PUSH=myservice
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD_ALIAS_0=myservice-1
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD_ALIAS_1=myservice-2
-  export BUILDKITE_PIPELINE_SLUG=test
-  export BUILDKITE_BUILD_NUMBER=1
 
   stub docker-compose \
     "-f docker-compose.yml -p buildkite1111 config : cat ${PWD}/tests/composefiles/docker-compose.config.v3.2.yml" \

--- a/tests/v1/run.bats
+++ b/tests/v1/run.bats
@@ -9,6 +9,10 @@ load '../../lib/run.bash'
 # export BATS_MOCK_TMPDIR=$PWD
 
 setup_file() {
+  export BUILDKITE_JOB_ID=1111
+  export BUILDKITE_PIPELINE_SLUG=test
+  export BUILDKITE_BUILD_NUMBER=1
+
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RUN_LABELS="false"
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLI_VERSION=1
 }
@@ -19,10 +23,7 @@ teardown() {
 }
 
 @test "Run without a prebuilt image" {
-  export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RUN=myservice
-  export BUILDKITE_PIPELINE_SLUG=test
-  export BUILDKITE_BUILD_NUMBER=1
   export BUILDKITE_COMMAND="echo hello world"
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CHECK_LINKED_CONTAINERS=false
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLEANUP=false
@@ -43,10 +44,7 @@ teardown() {
 }
 
 @test "Run without a prebuilt image and an empty command" {
-  export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RUN=myservice
-  export BUILDKITE_PIPELINE_SLUG=test
-  export BUILDKITE_BUILD_NUMBER=1
   export BUILDKITE_COMMAND=""
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CHECK_LINKED_CONTAINERS=false
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLEANUP=false
@@ -68,10 +66,7 @@ teardown() {
 }
 
 @test "Run without a prebuilt image and a custom workdir" {
-  export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RUN=myservice
-  export BUILDKITE_PIPELINE_SLUG=test
-  export BUILDKITE_BUILD_NUMBER=1
   export BUILDKITE_COMMAND=""
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_WORKDIR=/test_workdir
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CHECK_LINKED_CONTAINERS=false
@@ -93,10 +88,7 @@ teardown() {
 }
 
 @test "Run without a prebuilt image with a quoted command" {
-  export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RUN=myservice
-  export BUILDKITE_PIPELINE_SLUG=test
-  export BUILDKITE_BUILD_NUMBER=1
   export BUILDKITE_COMMAND="sh -c 'echo hello world'"
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CHECK_LINKED_CONTAINERS=false
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLEANUP=false
@@ -117,10 +109,7 @@ teardown() {
 }
 
 @test "Run without a prebuilt image with a multi-line command" {
-  export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RUN=myservice
-  export BUILDKITE_PIPELINE_SLUG=test
-  export BUILDKITE_BUILD_NUMBER=1
   export BUILDKITE_COMMAND="cmd1
 cmd2
 cmd3"
@@ -144,10 +133,7 @@ cmd3"
 }
 
 @test "Run without a prebuilt image with a command config" {
-  export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RUN=myservice
-  export BUILDKITE_PIPELINE_SLUG=test
-  export BUILDKITE_BUILD_NUMBER=1
   export BUILDKITE_COMMAND=""
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_COMMAND_0=echo
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_COMMAND_1="hello world"
@@ -171,10 +157,7 @@ cmd3"
 }
 
 @test "Run without a prebuilt image with custom env" {
-  export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RUN=myservice
-  export BUILDKITE_PIPELINE_SLUG=test
-  export BUILDKITE_BUILD_NUMBER=1
   export BUILDKITE_COMMAND=pwd
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CHECK_LINKED_CONTAINERS=false
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLEANUP=false
@@ -200,11 +183,8 @@ cmd3"
 }
 
 @test "Run without a prebuilt image with no-cache" {
-  export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RUN=myservice
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_NO_CACHE=true
-  export BUILDKITE_PIPELINE_SLUG=test
-  export BUILDKITE_BUILD_NUMBER=1
   export BUILDKITE_COMMAND="echo hello world"
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CHECK_LINKED_CONTAINERS=false
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLEANUP=false
@@ -225,9 +205,6 @@ cmd3"
 }
 
 @test "Run with a prebuilt image and propagate environment but no BUILDKITE_ENV_FILE" {
-  export BUILDKITE_JOB_ID=1111
-  export BUILDKITE_PIPELINE_SLUG=test
-  export BUILDKITE_BUILD_NUMBER=1
   export BUILDKITE_COMMAND=pwd
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RUN=myservice
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_PROPAGATE_ENVIRONMENT=true
@@ -252,9 +229,6 @@ cmd3"
 }
 
 @test "Run with a prebuilt image and propagate environment" {
-  export BUILDKITE_JOB_ID=1111
-  export BUILDKITE_PIPELINE_SLUG=test
-  export BUILDKITE_BUILD_NUMBER=1
   export BUILDKITE_COMMAND=pwd
   export BUILDKITE_ENV_FILE=/tmp/test_env
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RUN=myservice
@@ -285,10 +259,7 @@ cmd3"
 }
 
 @test "Run with a prebuilt image" {
-  export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RUN=myservice
-  export BUILDKITE_PIPELINE_SLUG=test
-  export BUILDKITE_BUILD_NUMBER=1
   export BUILDKITE_COMMAND=pwd
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CHECK_LINKED_CONTAINERS=false
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLEANUP=false
@@ -311,11 +282,8 @@ cmd3"
 }
 
 @test "Run with a prebuilt image and custom config file" {
-  export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RUN=myservice
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CONFIG=tests/composefiles/docker-compose.v2.0.yml
-  export BUILDKITE_PIPELINE_SLUG=test
-  export BUILDKITE_BUILD_NUMBER=1
   export BUILDKITE_COMMAND=pwd
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CHECK_LINKED_CONTAINERS=false
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLEANUP=false
@@ -338,12 +306,9 @@ cmd3"
 }
 
 @test "Run with a prebuilt image and multiple custom config files" {
-export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RUN=myservice
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CONFIG_0=tests/composefiles/docker-compose.v2.0.yml
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CONFIG_1=tests/composefiles/docker-compose.v2.1.yml
-  export BUILDKITE_PIPELINE_SLUG=test
-  export BUILDKITE_BUILD_NUMBER=1
   export BUILDKITE_COMMAND=pwd
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CHECK_LINKED_CONTAINERS=false
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLEANUP=false
@@ -367,10 +332,7 @@ export BUILDKITE_JOB_ID=1111
 
 @test "Run with a prebuilt image and custom config file set from COMPOSE_FILE" {
   export COMPOSE_FILE=tests/composefiles/docker-compose.v2.0.yml
-  export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RUN=myservice
-  export BUILDKITE_PIPELINE_SLUG=test
-  export BUILDKITE_BUILD_NUMBER=1
   export BUILDKITE_COMMAND=pwd
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CHECK_LINKED_CONTAINERS=false
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLEANUP=false
@@ -393,10 +355,7 @@ export BUILDKITE_JOB_ID=1111
 }
 
 @test "Run with a single prebuilt image, no retry on failed pull" {
-  export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RUN=myservice
-  export BUILDKITE_PIPELINE_SLUG=test
-  export BUILDKITE_BUILD_NUMBER=1
   export BUILDKITE_COMMAND=pwd
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CHECK_LINKED_CONTAINERS=false
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLEANUP=false
@@ -417,10 +376,7 @@ export BUILDKITE_JOB_ID=1111
 }
 
 @test "Run with a single prebuilt image, retry on failed pull" {
-  export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RUN=myservice
-  export BUILDKITE_PIPELINE_SLUG=test
-  export BUILDKITE_BUILD_NUMBER=1
   export BUILDKITE_COMMAND=pwd
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CHECK_LINKED_CONTAINERS=false
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLEANUP=false
@@ -446,10 +402,7 @@ export BUILDKITE_JOB_ID=1111
 }
 
 @test "Run with a TTY" {
-  export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RUN=myservice
-  export BUILDKITE_PIPELINE_SLUG=test
-  export BUILDKITE_BUILD_NUMBER=1
   export BUILDKITE_COMMAND=pwd
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CHECK_LINKED_CONTAINERS=false
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLEANUP=false
@@ -473,10 +426,7 @@ export BUILDKITE_JOB_ID=1111
 }
 
 @test "Run without dependencies" {
-  export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RUN=myservice
-  export BUILDKITE_PIPELINE_SLUG=test
-  export BUILDKITE_BUILD_NUMBER=1
   export BUILDKITE_COMMAND=pwd
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CHECK_LINKED_CONTAINERS=false
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLEANUP=false
@@ -499,10 +449,7 @@ export BUILDKITE_JOB_ID=1111
 }
 
 @test "Run with dependencies but in a single step" {
-  export BUILDKITE_BUILD_NUMBER=1
   export BUILDKITE_COMMAND=pwd
-  export BUILDKITE_JOB_ID=1111
-  export BUILDKITE_PIPELINE_SLUG=test
 
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RUN=myservice
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLEANUP=false
@@ -525,10 +472,7 @@ export BUILDKITE_JOB_ID=1111
 }
 
 @test "Run without ansi output" {
-  export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RUN=myservice
-  export BUILDKITE_PIPELINE_SLUG=test
-  export BUILDKITE_BUILD_NUMBER=1
   export BUILDKITE_COMMAND=pwd
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CHECK_LINKED_CONTAINERS=false
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLEANUP=false
@@ -551,11 +495,7 @@ export BUILDKITE_JOB_ID=1111
   unstub buildkite-agent
 }
 
-
 @test "Run without pull" {
-  export BUILDKITE_JOB_ID=1111
-  export BUILDKITE_PIPELINE_SLUG=test
-  export BUILDKITE_BUILD_NUMBER=1
   export BUILDKITE_COMMAND=pwd
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RUN=myservice
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_SKIP_PULL=true
@@ -579,10 +519,7 @@ export BUILDKITE_JOB_ID=1111
 }
 
 @test "Run with use aliases" {
-  export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RUN=myservice
-  export BUILDKITE_PIPELINE_SLUG=test
-  export BUILDKITE_BUILD_NUMBER=1
   export BUILDKITE_COMMAND=pwd
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CHECK_LINKED_CONTAINERS=false
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLEANUP=false
@@ -606,10 +543,7 @@ export BUILDKITE_JOB_ID=1111
 }
 
 @test "Run with compatibility mode" {
-  export BUILDKITE_BUILD_NUMBER=1
   export BUILDKITE_COMMAND=pwd
-  export BUILDKITE_JOB_ID=1111
-  export BUILDKITE_PIPELINE_SLUG=test
 
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RUN=myservice
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLEANUP=false
@@ -633,10 +567,7 @@ export BUILDKITE_JOB_ID=1111
 }
 
 @test "Run with a volumes option" {
-  export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RUN=myservice
-  export BUILDKITE_PIPELINE_SLUG=test
-  export BUILDKITE_BUILD_NUMBER=1
   export BUILDKITE_COMMAND=pwd
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CHECK_LINKED_CONTAINERS=false
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLEANUP=false
@@ -661,10 +592,7 @@ export BUILDKITE_JOB_ID=1111
 }
 
 @test "Run with an external volume" {
-  export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RUN=myservice
-  export BUILDKITE_PIPELINE_SLUG=test
-  export BUILDKITE_BUILD_NUMBER=1
   export BUILDKITE_COMMAND=pwd
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CHECK_LINKED_CONTAINERS=false
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLEANUP=false
@@ -691,10 +619,7 @@ export BUILDKITE_JOB_ID=1111
   # Tests introduction of extra delimiters, as would occur if
   # EXPORT BUILDKITE_DOCKER_DEFAULT_VOLUMES="new:mount; ${BUILDKITE_DOCKER_DEFAULT_VOLUMES:-}"
   # was used with no existing value
-  export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RUN=myservice
-  export BUILDKITE_PIPELINE_SLUG=test
-  export BUILDKITE_BUILD_NUMBER=1
   export BUILDKITE_COMMAND=pwd
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CHECK_LINKED_CONTAINERS=false
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLEANUP=false
@@ -718,10 +643,7 @@ export BUILDKITE_JOB_ID=1111
 }
 
 @test "Run with volumes with variables" {
-  export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RUN=myservice
-  export BUILDKITE_PIPELINE_SLUG=test
-  export BUILDKITE_BUILD_NUMBER=1
   export BUILDKITE_COMMAND=pwd
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CHECK_LINKED_CONTAINERS=false
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLEANUP=false
@@ -750,12 +672,8 @@ export BUILDKITE_JOB_ID=1111
   unstub buildkite-agent
 }
 
-
 @test "Run with volumes with variables but option turned off" {
-  export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RUN=myservice
-  export BUILDKITE_PIPELINE_SLUG=test
-  export BUILDKITE_BUILD_NUMBER=1
   export BUILDKITE_COMMAND=pwd
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CHECK_LINKED_CONTAINERS=false
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLEANUP=false
@@ -787,10 +705,7 @@ export BUILDKITE_JOB_ID=1111
 }
 
 @test "Run with volumes with variables and option turned on" {
-  export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RUN=myservice
-  export BUILDKITE_PIPELINE_SLUG=test
-  export BUILDKITE_BUILD_NUMBER=1
   export BUILDKITE_COMMAND=pwd
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CHECK_LINKED_CONTAINERS=false
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLEANUP=true
@@ -798,7 +713,6 @@ export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_VOLUMES_0="\$SUPER_VARIABLE:/mnt"
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_VOLUMES_1="/:\$OTHER_VARIABLE"
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_VOLUMES_2="\$RELATIVE_VARIABLE:/srv"
-
 
   export SUPER_VARIABLE='/test/path'
   export OTHER_VARIABLE='/path/tested'
@@ -822,10 +736,7 @@ export BUILDKITE_JOB_ID=1111
 }
 
 @test "Run with default volumes" {
-  export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RUN=myservice
-  export BUILDKITE_PIPELINE_SLUG=test
-  export BUILDKITE_BUILD_NUMBER=1
   export BUILDKITE_COMMAND=pwd
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CHECK_LINKED_CONTAINERS=false
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLEANUP=false
@@ -849,10 +760,7 @@ export BUILDKITE_JOB_ID=1111
 }
 
 @test "Run with multiple config files" {
-  export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RUN=myservice
-  export BUILDKITE_PIPELINE_SLUG=test
-  export BUILDKITE_BUILD_NUMBER=1
   export BUILDKITE_COMMAND="echo hello world"
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CHECK_LINKED_CONTAINERS=false
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLEANUP=false
@@ -876,10 +784,7 @@ export BUILDKITE_JOB_ID=1111
 }
 
 @test "Run with a failure should expand previous group" {
-  export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RUN=myservice
-  export BUILDKITE_PIPELINE_SLUG=test
-  export BUILDKITE_BUILD_NUMBER=1
   export BUILDKITE_COMMAND=pwd
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CHECK_LINKED_CONTAINERS=false
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLEANUP=false
@@ -901,12 +806,9 @@ export BUILDKITE_JOB_ID=1111
 }
 
 @test "Run with multiple prebuilt images and multiple pulls" {
-  export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RUN=myservice1
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_PULL_0=myservice1
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_PULL_1=myservice2
-  export BUILDKITE_PIPELINE_SLUG=test
-  export BUILDKITE_BUILD_NUMBER=1
   export BUILDKITE_COMMAND=pwd
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CHECK_LINKED_CONTAINERS=false
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLEANUP=false
@@ -932,10 +834,7 @@ export BUILDKITE_JOB_ID=1111
 }
 
 @test "Run without a prebuilt image and a custom user" {
-  export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RUN=myservice
-  export BUILDKITE_PIPELINE_SLUG=test
-  export BUILDKITE_BUILD_NUMBER=1
   export BUILDKITE_COMMAND="sh -c 'whoami'"
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CHECK_LINKED_CONTAINERS=false
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLEANUP=false
@@ -957,10 +856,7 @@ export BUILDKITE_JOB_ID=1111
 }
 
 @test "Run without a prebuilt image and a custom user and group" {
-  export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RUN=myservice
-  export BUILDKITE_PIPELINE_SLUG=test
-  export BUILDKITE_BUILD_NUMBER=1
   export BUILDKITE_COMMAND="sh -c 'whoami'"
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CHECK_LINKED_CONTAINERS=false
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLEANUP=false
@@ -982,10 +878,7 @@ export BUILDKITE_JOB_ID=1111
 }
 
 @test "Fail with custom user and propagate UIDs" {
-  export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RUN=myservice
-  export BUILDKITE_PIPELINE_SLUG=test
-  export BUILDKITE_BUILD_NUMBER=1
   export BUILDKITE_COMMAND="sh -c 'whoami'"
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CHECK_LINKED_CONTAINERS=false
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLEANUP=false
@@ -1003,12 +896,8 @@ export BUILDKITE_JOB_ID=1111
   unstub buildkite-agent
 }
 
-
 @test "Run without -T --rm" {
-  export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RUN=myservice
-  export BUILDKITE_PIPELINE_SLUG=test
-  export BUILDKITE_BUILD_NUMBER=1
   export BUILDKITE_COMMAND=pwd
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CHECK_LINKED_CONTAINERS=false
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLEANUP=false
@@ -1033,10 +922,7 @@ export BUILDKITE_JOB_ID=1111
 }
 
 @test "Run with custom entrypoint" {
-  export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RUN=myservice
-  export BUILDKITE_PIPELINE_SLUG=test
-  export BUILDKITE_BUILD_NUMBER=1
   export BUILDKITE_COMMAND=""
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CHECK_LINKED_CONTAINERS=false
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLEANUP=false
@@ -1058,10 +944,7 @@ export BUILDKITE_JOB_ID=1111
 }
 
 @test "Run with mount-buildkite-agent enabled" {
-  export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RUN=myservice
-  export BUILDKITE_PIPELINE_SLUG=test
-  export BUILDKITE_BUILD_NUMBER=1
   export BUILDKITE_COMMAND=""
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CHECK_LINKED_CONTAINERS=false
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLEANUP=false
@@ -1083,10 +966,7 @@ export BUILDKITE_JOB_ID=1111
 }
 
 @test "Run with various build arguments" {
-  export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RUN=myservice
-  export BUILDKITE_PIPELINE_SLUG=test
-  export BUILDKITE_BUILD_NUMBER=1
   export BUILDKITE_COMMAND="echo hello world"
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CHECK_LINKED_CONTAINERS=false
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLEANUP=false
@@ -1109,10 +989,7 @@ export BUILDKITE_JOB_ID=1111
 }
 
 @test "Run with git-mirrors" {
-  export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RUN=myservice
-  export BUILDKITE_PIPELINE_SLUG=test
-  export BUILDKITE_BUILD_NUMBER=1
   export BUILDKITE_COMMAND="echo hello world"
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CHECK_LINKED_CONTAINERS=false
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLEANUP=false
@@ -1135,10 +1012,7 @@ export BUILDKITE_JOB_ID=1111
 
 @test "Run with mount-ssh-agent" {
   export SSH_AUTH_SOCK=/tmp/ssh_auth_sock
-  export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RUN=myservice
-  export BUILDKITE_PIPELINE_SLUG=test
-  export BUILDKITE_BUILD_NUMBER=1
   export BUILDKITE_COMMAND="echo hello world"
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CHECK_LINKED_CONTAINERS=false
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLEANUP=false
@@ -1167,10 +1041,7 @@ export BUILDKITE_JOB_ID=1111
 
 @test "Run with mount-ssh-agent on particular folder" {
   export SSH_AUTH_SOCK=/tmp/ssh_auth_sock
-  export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RUN=myservice
-  export BUILDKITE_PIPELINE_SLUG=test
-  export BUILDKITE_BUILD_NUMBER=1
   export BUILDKITE_COMMAND="echo hello world"
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CHECK_LINKED_CONTAINERS=false
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLEANUP=false
@@ -1198,10 +1069,7 @@ export BUILDKITE_JOB_ID=1111
 }
 
 @test "Run without mount-checkout doesn't set volume" {
-  export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RUN=myservice
-  export BUILDKITE_PIPELINE_SLUG=test
-  export BUILDKITE_BUILD_NUMBER=1
   export BUILDKITE_COMMAND=pwd
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CHECK_LINKED_CONTAINERS=false
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLEANUP=false
@@ -1225,10 +1093,7 @@ export BUILDKITE_JOB_ID=1111
 }
 
 @test "Run with mount-checkout set to true" {
-  export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RUN=myservice
-  export BUILDKITE_PIPELINE_SLUG=test
-  export BUILDKITE_BUILD_NUMBER=1
   export BUILDKITE_COMMAND=pwd
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CHECK_LINKED_CONTAINERS=false
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLEANUP=false
@@ -1252,10 +1117,7 @@ export BUILDKITE_JOB_ID=1111
 }
 
 @test "Run with mount-checkout set to true with custom workdir" {
-  export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RUN=myservice
-  export BUILDKITE_PIPELINE_SLUG=test
-  export BUILDKITE_BUILD_NUMBER=1
   export BUILDKITE_COMMAND=pwd
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CHECK_LINKED_CONTAINERS=false
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLEANUP=false
@@ -1280,9 +1142,6 @@ export BUILDKITE_JOB_ID=1111
 }
 
 @test "Run with mount-checkout set to specific path" {
-  export BUILDKITE_BUILD_NUMBER=1
-  export BUILDKITE_JOB_ID=1111
-  export BUILDKITE_PIPELINE_SLUG=test
   export BUILDKITE_COMMAND=pwd
 
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RUN=myservice
@@ -1309,9 +1168,6 @@ export BUILDKITE_JOB_ID=1111
 }
 
 @test "Run with mount-checkout set to specific path and workdir set" {
-  export BUILDKITE_BUILD_NUMBER=1
-  export BUILDKITE_JOB_ID=1111
-  export BUILDKITE_PIPELINE_SLUG=test
   export BUILDKITE_COMMAND=pwd
 
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RUN=myservice
@@ -1340,9 +1196,6 @@ export BUILDKITE_JOB_ID=1111
 }
 
 @test "Run with mount-checkout set something else" {
-  export BUILDKITE_BUILD_NUMBER=1
-  export BUILDKITE_JOB_ID=1111
-  export BUILDKITE_PIPELINE_SLUG=test
   export BUILDKITE_COMMAND=pwd
 
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RUN=myservice
@@ -1367,9 +1220,6 @@ export BUILDKITE_JOB_ID=1111
 }
 
 @test "Run with mount-checkout set something else and workdir set" {
-  export BUILDKITE_BUILD_NUMBER=1
-  export BUILDKITE_JOB_ID=1111
-  export BUILDKITE_PIPELINE_SLUG=test
   export BUILDKITE_COMMAND=pwd
 
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RUN=myservice
@@ -1395,11 +1245,8 @@ export BUILDKITE_JOB_ID=1111
 }
 
 @test "Run waiting for dependencies" {
-  export BUILDKITE_BUILD_NUMBER=1
   export BUILDKITE_COMMAND="echo hello world"
-  export BUILDKITE_JOB_ID=1111
-  export BUILDKITE_PIPELINE_SLUG=test
-
+  
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RUN=myservice
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CHECK_LINKED_CONTAINERS=false
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_WAIT=true
@@ -1422,10 +1269,7 @@ export BUILDKITE_JOB_ID=1111
 }
 
 @test "Run with --service-ports" {
-  export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RUN=myservice
-  export BUILDKITE_PIPELINE_SLUG=test
-  export BUILDKITE_BUILD_NUMBER=1
   export BUILDKITE_COMMAND=pwd
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CHECK_LINKED_CONTAINERS=false
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLEANUP=false
@@ -1452,12 +1296,9 @@ export BUILDKITE_JOB_ID=1111
   # Pipeline vars
   export BUILDKITE_AGENT_ID="1234"
   export BUILDKITE_AGENT_NAME="agent"
-  export BUILDKITE_BUILD_NUMBER=1
   export BUILDKITE_COMMAND=pwd
-  export BUILDKITE_JOB_ID=1111
   export BUILDKITE_LABEL="Testjob"
   export BUILDKITE_PIPELINE_NAME="label-test"
-  export BUILDKITE_PIPELINE_SLUG=test
   export BUILDKITE_STEP_KEY="test-job"
 
   # Plugin config
@@ -1491,10 +1332,7 @@ export BUILDKITE_JOB_ID=1111
 }
 
 @test "Run with --quiet-pull" {
-  export BUILDKITE_BUILD_NUMBER=1
   export BUILDKITE_COMMAND="echo hello world"
-  export BUILDKITE_JOB_ID=1111
-  export BUILDKITE_PIPELINE_SLUG=test
 
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RUN=myservice
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CHECK_LINKED_CONTAINERS=false
@@ -1520,10 +1358,7 @@ export BUILDKITE_JOB_ID=1111
 @test "Run with a list of propagated env vars" {
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_ENV_PROPAGATION_LIST="LIST_OF_VARS"
   export LIST_OF_VARS="VAR_A VAR_B VAR_C"
-  export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RUN=myservice
-  export BUILDKITE_PIPELINE_SLUG=test
-  export BUILDKITE_BUILD_NUMBER=1
   export BUILDKITE_COMMAND="echo hello world"
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CHECK_LINKED_CONTAINERS=false
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLEANUP=false
@@ -1545,10 +1380,7 @@ export BUILDKITE_JOB_ID=1111
 
 @test "Run with a list of propagated env vars - unless you forgot to define the variable" {
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_ENV_PROPAGATION_LIST="LIST_OF_VARS"
-  export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RUN=myservice
-  export BUILDKITE_PIPELINE_SLUG=test
-  export BUILDKITE_BUILD_NUMBER=1
   export BUILDKITE_COMMAND="echo hello world"
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CHECK_LINKED_CONTAINERS=false
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLEANUP=false
@@ -1564,10 +1396,7 @@ export BUILDKITE_JOB_ID=1111
 }
 
 @test "Run with expanded run log group by default" {
-  export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RUN=myservice
-  export BUILDKITE_PIPELINE_SLUG=test
-  export BUILDKITE_BUILD_NUMBER=1
   export BUILDKITE_COMMAND="echo hello world"
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CHECK_LINKED_CONTAINERS=false
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLEANUP=false
@@ -1588,10 +1417,7 @@ export BUILDKITE_JOB_ID=1111
 }
 
 @test "Run with collapsed run log group" {
-  export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RUN=myservice
-  export BUILDKITE_PIPELINE_SLUG=test
-  export BUILDKITE_BUILD_NUMBER=1
   export BUILDKITE_COMMAND="echo hello world"
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CHECK_LINKED_CONTAINERS=false
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLEANUP=false

--- a/tests/v2/build.bats
+++ b/tests/v2/build.bats
@@ -11,6 +11,11 @@ setup_file() {
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLI_VERSION=2
 }
 
+teardown() {
+  # plugin leaves override files around
+  rm -f docker-compose.buildkite*-override.yml
+}
+
 @test "Build without a repository" {
   export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD=myservice
@@ -18,13 +23,14 @@ setup_file() {
   export BUILDKITE_BUILD_NUMBER=1
 
   stub docker \
-    "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml build --pull myservice : echo built myservice"
+    "compose -f docker-compose.yml -p buildkite1111 build --pull myservice : echo built myservice"
 
   run "$PWD"/hooks/command
 
-  unstub docker
   assert_success
   assert_output --partial "built myservice"
+
+  unstub docker
 }
 
 @test "Build with no-cache" {
@@ -35,7 +41,7 @@ setup_file() {
   export BUILDKITE_BUILD_NUMBER=1
 
   stub docker \
-    "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml build --pull --no-cache myservice : echo built myservice"
+    "compose -f docker-compose.yml -p buildkite1111 build --pull --no-cache myservice : echo built myservice"
 
   run "$PWD"/hooks/command
 
@@ -52,7 +58,7 @@ setup_file() {
   export BUILDKITE_BUILD_NUMBER=1
 
   stub docker \
-    "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml build --pull --parallel myservice : echo built myservice"
+    "compose -f docker-compose.yml -p buildkite1111 build --pull --parallel myservice : echo built myservice"
 
   run "$PWD"/hooks/command
 
@@ -70,51 +76,27 @@ setup_file() {
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_ARGS_1=MYARG=1
 
   stub docker \
-    "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml build --pull --build-arg MYARG=0 --build-arg MYARG=1 myservice : echo built myservice"
+    "compose -f docker-compose.yml -p buildkite1111 build --pull --build-arg MYARG=0 --build-arg MYARG=1 myservice : echo built myservice"
 
   run "$PWD"/hooks/command
 
   assert_success
   assert_output --partial "built myservice"
   unstub docker
-}
-
-@test "Build with a repository" {
-  export BUILDKITE_JOB_ID=1111
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD=myservice
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_IMAGE_REPOSITORY=my.repository/llamas
-  export BUILDKITE_PIPELINE_SLUG=test
-  export BUILDKITE_BUILD_NUMBER=1
-
-  stub docker \
-    "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml build --pull myservice : echo built myservice" \
-    "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml push myservice : echo pushed myservice" \
-
-  stub buildkite-agent \
-    "meta-data set docker-compose-plugin-built-image-tag-myservice my.repository/llamas:test-myservice-build-1 : echo set image metadata for myservice"
-
-  run "$PWD"/hooks/command
-
-  assert_success
-  assert_output --partial "built myservice"
-  assert_output --partial "pushed myservice"
-  assert_output --partial "set image metadata for myservice"
-  unstub docker
-  unstub buildkite-agent
 }
 
 @test "Build with a repository and multiple build aliases" {
+  skip "need to be moved to push"
   export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD=myservice
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_IMAGE_REPOSITORY=my.repository/llamas
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD_ALIAS_0=myservice-1
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD_ALIAS_1=myservice-2
   export BUILDKITE_PIPELINE_SLUG=test
   export BUILDKITE_BUILD_NUMBER=1
 
   stub docker \
-    "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml build --pull myservice : echo built myservice" \
-    "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml push myservice : echo pushed myservice" \
+    "compose -f docker-compose.yml -p buildkite1111 build --pull myservice : echo built myservice" \
+    "compose -f docker-compose.yml -p buildkite1111 push myservice : echo pushed myservice" \
 
   stub buildkite-agent \
     "meta-data set docker-compose-plugin-built-image-tag-myservice my.repository/llamas:test-myservice-build-1 : echo set image metadata for myservice" \
@@ -133,56 +115,22 @@ setup_file() {
   unstub buildkite-agent
 }
 
-@test "Build with a repository and push retries" {
-  export BUILDKITE_JOB_ID=1111
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD=myservice
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_IMAGE_REPOSITORY=my.repository/llamas
-  export BUILDKITE_PIPELINE_SLUG=test
-  export BUILDKITE_BUILD_NUMBER=1
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_PUSH_RETRIES=3
-
-  stub docker \
-    "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml build --pull myservice : echo built myservice" \
-    "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml push myservice : exit 1" \
-    "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml push myservice : exit 1" \
-    "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml push myservice : echo pushed myservice" \
-
-  stub buildkite-agent \
-    "meta-data set docker-compose-plugin-built-image-tag-myservice my.repository/llamas:test-myservice-build-1 : echo set image metadata for myservice"
-
-  run "$PWD"/hooks/command
-
-  assert_success
-  assert_output --partial "built myservice"
-  assert_output --partial "pushed myservice"
-  assert_output --partial "set image metadata for myservice"
-  unstub docker
-  unstub buildkite-agent
-}
-
-@test "Build with a repository and custom config file" {
+@test "Build with a custom config file" {
   export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD=myservice
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CONFIG=tests/composefiles/docker-compose.v2.0.yml
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_IMAGE_REPOSITORY=my.repository/llamas
   export BUILDKITE_PIPELINE_SLUG=test
   export BUILDKITE_BUILD_NUMBER=1
 
   stub docker \
-    "compose -f tests/composefiles/docker-compose.v2.0.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml build --pull myservice : echo built myservice" \
-    "compose -f tests/composefiles/docker-compose.v2.0.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml push myservice : echo pushed myservice" \
-
-  stub buildkite-agent \
-    "meta-data set docker-compose-plugin-built-image-tag-myservice-tests/composefiles/docker-compose.v2.0.yml my.repository/llamas:test-myservice-build-1 : echo set image metadata for myservice"
+    "compose -f tests/composefiles/docker-compose.v2.0.yml -p buildkite1111 build --pull myservice : echo built myservice"
 
   run "$PWD"/hooks/command
 
   assert_success
   assert_output --partial "built myservice"
-  assert_output --partial "pushed myservice"
-  assert_output --partial "set image metadata for myservice"
+
   unstub docker
-  unstub buildkite-agent
 }
 
 @test "Build with a repository and multiple custom config files" {
@@ -190,65 +138,55 @@ setup_file() {
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD=myservice
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CONFIG_0=tests/composefiles/docker-compose.v2.0.yml
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CONFIG_1=tests/composefiles/docker-compose.v2.1.yml
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_IMAGE_REPOSITORY=my.repository/llamas
   export BUILDKITE_PIPELINE_SLUG=test
   export BUILDKITE_BUILD_NUMBER=1
 
   stub docker \
-    "compose -f tests/composefiles/docker-compose.v2.0.yml -f tests/composefiles/docker-compose.v2.1.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml build --pull myservice : echo built myservice" \
-    "compose -f tests/composefiles/docker-compose.v2.0.yml -f tests/composefiles/docker-compose.v2.1.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml push myservice : echo pushed myservice" \
-
-  stub buildkite-agent \
-    "meta-data set docker-compose-plugin-built-image-tag-myservice-tests/composefiles/docker-compose.v2.0.yml-tests/composefiles/docker-compose.v2.1.yml my.repository/llamas:test-myservice-build-1 : echo set image metadata for myservice"
+    "compose -f tests/composefiles/docker-compose.v2.0.yml -f tests/composefiles/docker-compose.v2.1.yml -p buildkite1111 build --pull myservice : echo built myservice"
 
   run "$PWD"/hooks/command
 
   assert_success
   assert_output --partial "built myservice"
-  assert_output --partial "pushed myservice"
-  assert_output --partial "set image metadata for myservice"
+
   unstub docker
-  unstub buildkite-agent
 }
 
 @test "Build with a repository and multiple services" {
   export BUILDKITE_JOB_ID=1112
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD_0=myservice1
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD_1=myservice2
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_IMAGE_REPOSITORY=my.repository/llamas
   export BUILDKITE_PIPELINE_SLUG=test
   export BUILDKITE_BUILD_NUMBER=1
 
   stub docker \
-    "compose -f docker-compose.yml -p buildkite1112 -f docker-compose.buildkite-1-override.yml build --pull myservice1 myservice2 : echo built all services" \
-    "compose -f docker-compose.yml -p buildkite1112 -f docker-compose.buildkite-1-override.yml push myservice1 myservice2 : echo pushed all services" \
-
-  stub buildkite-agent \
-    "meta-data set docker-compose-plugin-built-image-tag-myservice1 my.repository/llamas:test-myservice1-build-1 : echo set image metadata for myservice1" \
-    "meta-data set docker-compose-plugin-built-image-tag-myservice2 my.repository/llamas:test-myservice2-build-1 : echo set image metadata for myservice2"
+    "compose -f docker-compose.yml -p buildkite1112 build --pull myservice1 myservice2 : echo built all services"
 
   run "$PWD"/hooks/command
 
   assert_success
   assert_output --partial "built all services"
-  assert_output --partial "pushed all services"
-  assert_output --partial "set image metadata for myservice1"
-  assert_output --partial "set image metadata for myservice2"
+
   unstub docker
-  unstub buildkite-agent
 }
 
 @test "Build with a docker-compose v1.0 configuration file" {
   export BUILDKITE_JOB_ID=1112
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CONFIG="tests/composefiles/docker-compose.v1.0.yml"
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD_0=helloworld
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CACHE_FROM_0=helloworld:my.repository/myservice_cache:latest
   export BUILDKITE_PIPELINE_SLUG=test
   export BUILDKITE_BUILD_NUMBER=1
+
+  stub docker \
+    "pull my.repository/myservice_cache:latest : echo pulled cache image"
 
   run "$PWD"/hooks/command
 
   assert_failure
   assert_output --partial "Compose file versions 2.0 and above"
+
+  unstub docker
 }
 
 @test "Build with a cache-from image" {
@@ -269,6 +207,7 @@ setup_file() {
   assert_output --partial "pulled cache image"
   assert_output --partial "- my.repository/myservice_cache:latest"
   assert_output --partial "built helloworld"
+
   unstub docker
 }
 
@@ -292,6 +231,7 @@ setup_file() {
   assert_output --partial "pulled cache image"
   assert_output --partial "- my.repository:port/myservice_cache:latest"
   assert_output --partial "built helloworld"
+
   unstub docker
 }
 
@@ -304,7 +244,7 @@ setup_file() {
   export BUILDKITE_BUILD_NUMBER=1
 
   stub docker \
-    "compose -f tests/composefiles/docker-compose.v3.2.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml build --pull helloworld : echo built helloworld"
+    "compose -f tests/composefiles/docker-compose.v3.2.yml -p buildkite1111 build --pull helloworld : echo built helloworld"
 
   run "$PWD"/hooks/command
 
@@ -313,6 +253,7 @@ setup_file() {
   refute_output --partial "- my.repository/myservice_cache:-latest"
   assert_output --partial "invalid tag so it will be ignored"
   assert_output --partial "built helloworld"
+
   unstub docker
 }
 
@@ -335,6 +276,7 @@ setup_file() {
   assert_output --partial "pulled cache image"
   assert_output --partial "- my.repository/myservice_cache"
   assert_output --partial "built helloworld"
+
   unstub docker
 }
 
@@ -348,7 +290,7 @@ setup_file() {
   export BUILDKITE_BUILD_NUMBER=1
 
   stub docker \
-    "compose -f tests/composefiles/docker-compose.v3.2.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml build --pull --no-cache helloworld : echo built helloworld"
+    "compose -f tests/composefiles/docker-compose.v3.2.yml -p buildkite1111 build --pull --no-cache helloworld : echo built helloworld"
 
   run "$PWD"/hooks/command
 
@@ -356,6 +298,7 @@ setup_file() {
   refute_output --partial "pulled cache image"
   refute_output --partial "- my.repository/myservice_cache:latest"
   assert_output --partial "built helloworld"
+
   unstub docker
 }
 
@@ -379,6 +322,7 @@ setup_file() {
   assert_output --partial "- my.repository/myservice_cache:branch-name"
   refute_output --partial "- my.repository/myservice_cache:latest"
   assert_output --partial "built helloworld"
+
   unstub docker
 }
 
@@ -403,6 +347,7 @@ setup_file() {
   refute_output --partial "- my.repository/myservice_cache:branch-name"
   assert_output --partial "- my.repository/myservice_cache:latest"
   assert_output --partial "built helloworld"
+
   unstub docker
 }
 
@@ -416,7 +361,7 @@ setup_file() {
 
   stub docker \
     "pull my.repository/myservice_cache:latest : exit 1" \
-    "compose -f tests/composefiles/docker-compose.v3.2.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml build --pull helloworld : echo built helloworld"
+    "compose -f tests/composefiles/docker-compose.v3.2.yml -p buildkite1111 build --pull helloworld : echo built helloworld"
 
   run "$PWD"/hooks/command
 
@@ -424,6 +369,7 @@ setup_file() {
   assert_output --partial "my.repository/myservice_cache:latest will not be used as a cache for helloworld"
   refute_output --partial "- my.repository/myservice_cache:latest"
   assert_output --partial "built helloworld"
+
   unstub docker
 }
 
@@ -445,6 +391,7 @@ setup_file() {
   assert_output --partial "pulled cache image"
   assert_output --partial "- my.repository/my-service_cache:latest"
   assert_output --partial "built hello-world"
+
   unstub docker
 }
 
@@ -466,6 +413,7 @@ setup_file() {
   assert_output --partial "pulled cache image"
   assert_output --partial "- my.repository/my-service_cache:latest"
   assert_output --partial "built hello.world"
+
   unstub docker
 }
 
@@ -490,127 +438,8 @@ setup_file() {
   assert_output --partial "pulled cache image"
   assert_output --partial "- my.repository/myservice_cache:latest"
   assert_output --partial "built helloworld"
+
   unstub docker
-}
-
-@test "Build with a custom image-name" {
-  export BUILDKITE_JOB_ID=1111
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD=myservice
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_IMAGE_NAME=my-llamas-image
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_IMAGE_REPOSITORY=my.repository/llamas
-  export BUILDKITE_PIPELINE_SLUG=test
-  export BUILDKITE_BUILD_NUMBER=1
-
-  stub docker \
-    "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml build --pull myservice : echo built myservice" \
-    "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml push myservice : echo pushed myservice" \
-
-  stub buildkite-agent \
-    "meta-data set docker-compose-plugin-built-image-tag-myservice my.repository/llamas:my-llamas-image : echo set image metadata for myservice"
-
-  run "$PWD"/hooks/command
-
-  assert_success
-  assert_output --partial "built myservice"
-  assert_output --partial "pushed myservice"
-  assert_output --partial "set image metadata for myservice"
-  unstub docker
-  unstub buildkite-agent
-}
-
-@test "Build with an invalid image-name (start with hyphen) " {
-  export BUILDKITE_JOB_ID=1111
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD=myservice
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_IMAGE_NAME=-llamas-image
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_IMAGE_REPOSITORY=my.repository/llamas
-  export BUILDKITE_BUILD_NUMBER=1
-
-  run "$PWD"/hooks/command
-
-  assert_failure
-  assert_output --partial "-llamas-image is not a valid tag name"
-}
-
-@test "Build with an invalid image-name (start with period) " {
-  export BUILDKITE_JOB_ID=1111
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD=myservice
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_IMAGE_NAME=.llamas-image
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_IMAGE_REPOSITORY=my.repository/llamas
-  export BUILDKITE_BUILD_NUMBER=1
-
-  run "$PWD"/hooks/command
-
-  assert_failure
-  assert_output --partial ".llamas-image is not a valid tag name"
-}
-
-@test "Build with an invalid image-name (too long) " {
-  export BUILDKITE_JOB_ID=1111
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD=myservice
-  # shellcheck disable=SC2155 # numbers from 1 to 69 result in 129 characters
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_IMAGE_NAME="$(seq 69 | tr -d "\n")"
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_IMAGE_REPOSITORY=my.repository/llamas
-  export BUILDKITE_BUILD_NUMBER=1
-
-  run "$PWD"/hooks/command
-
-  assert_failure
-  assert_output --partial "is not a valid tag name"
-}
-
-@test "Build with a custom image-name and a config" {
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CONFIG="tests/composefiles/docker-compose.v3.2.yml"
-  export BUILDKITE_JOB_ID=1111
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD=myservice
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_IMAGE_NAME=my-llamas-image
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_IMAGE_REPOSITORY=my.repository/llamas
-  export BUILDKITE_PIPELINE_SLUG=test
-  export BUILDKITE_BUILD_NUMBER=1
-
-  stub docker \
-    "compose -f tests/composefiles/docker-compose.v3.2.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml build --pull myservice : echo built myservice" \
-    "compose -f tests/composefiles/docker-compose.v3.2.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml push myservice : echo pushed myservice" \
-
-  stub buildkite-agent \
-    "meta-data set docker-compose-plugin-built-image-tag-myservice-tests/composefiles/docker-compose.v3.2.yml my.repository/llamas:my-llamas-image : echo set image metadata for myservice"
-
-  run "$PWD"/hooks/command
-
-  assert_success
-  assert_output --partial "built myservice"
-  assert_output --partial "pushed myservice"
-  assert_output --partial "set image metadata for myservice"
-  unstub docker
-  unstub buildkite-agent
-}
-
-@test "Build multiple images with custom image-names" {
-  export BUILDKITE_JOB_ID=1112
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD_0=myservice1
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD_1=myservice2
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_IMAGE_NAME_0=my-llamas-image-1
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_IMAGE_NAME_1=my-llamas-image-2
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_IMAGE_REPOSITORY=my.repository/llamas
-  export BUILDKITE_PIPELINE_SLUG=test
-  export BUILDKITE_BUILD_NUMBER=1
-
-  stub docker \
-    "compose -f docker-compose.yml -p buildkite1112 -f docker-compose.buildkite-1-override.yml build --pull myservice1 myservice2 : echo built all services" \
-    "compose -f docker-compose.yml -p buildkite1112 -f docker-compose.buildkite-1-override.yml push myservice1 myservice2 : echo pushed all services" \
-
-  stub buildkite-agent \
-    "meta-data set docker-compose-plugin-built-image-tag-myservice1 my.repository/llamas:my-llamas-image-1 : echo set image metadata for myservice1" \
-    "meta-data set docker-compose-plugin-built-image-tag-myservice2 my.repository/llamas:my-llamas-image-2 : echo set image metadata for myservice2"
-
-  run "$PWD"/hooks/command
-
-  assert_success
-  assert_output --partial "built all services"
-  assert_output --partial "pushed all services"
-  assert_output --partial "set image metadata for myservice1"
-  assert_output --partial "set image metadata for myservice2"
-  unstub docker
-  unstub buildkite-agent
 }
 
 @test "Build with target" {
@@ -622,13 +451,13 @@ setup_file() {
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_TARGET=intermediate
 
   stub docker \
-    "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml build --pull --target \* \* : echo built \${12} with target \${11}"
+    "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml build --pull \* : echo built \${10}"
 
   run "$PWD"/hooks/command
 
   assert_success
   assert_output --partial "built myservice"
-  assert_output --partial "with target intermediate"
+  assert_output --partial "    target: intermediate"
 
   unstub docker
 }
@@ -642,7 +471,7 @@ setup_file() {
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_SSH=true
 
   stub docker \
-    "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml build --pull --ssh default \* : echo built \${12} with ssh"
+    "compose -f docker-compose.yml -p buildkite1111 build --pull --ssh default \* : echo built \${10} with ssh"
 
   run "$PWD"/hooks/command
 
@@ -662,7 +491,7 @@ setup_file() {
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_SSH=context
 
   stub docker \
-    "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml build --pull --ssh context \* : echo built \${12} with ssh"
+    "compose -f docker-compose.yml -p buildkite1111 build --pull --ssh context \* : echo built \${10} with ssh"
 
   run "$PWD"/hooks/command
 
@@ -683,7 +512,7 @@ setup_file() {
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_SECRETS_1='id=SECRET_VAR'
 
   stub docker \
-    "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml build --pull --secret \* --secret \* \* : echo built \${14} with secrets \${11} and \${13}"
+    "compose -f docker-compose.yml -p buildkite1111 build --pull --secret \* --secret \* \* : echo built \${12} with secrets \${9} and \${11}"
 
   run "$PWD"/hooks/command
 
@@ -702,11 +531,12 @@ setup_file() {
   export BUILDKITE_BUILD_NUMBER=1
 
   stub docker \
-    "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml build myservice : echo built myservice"
+    "compose -f docker-compose.yml -p buildkite1111 build myservice : echo built myservice"
 
   run "$PWD"/hooks/command
 
   assert_success
   assert_output --partial "built myservice"
+
   unstub docker
 }

--- a/tests/v2/build.bats
+++ b/tests/v2/build.bats
@@ -3,8 +3,8 @@
 load "${BATS_PLUGIN_PATH}/load.bash"
 load '../../lib/shared'
 
- export DOCKER_STUB_DEBUG=/dev/stdout
- export BUILDKITE_AGENT_STUB_DEBUG=/dev/stdout
+# export DOCKER_STUB_DEBUG=/dev/stdout
+# export BUILDKITE_AGENT_STUB_DEBUG=/dev/stdout
 # export BATS_MOCK_TMPDIR=$PWD
 
 setup_file() {

--- a/tests/v2/push.bats
+++ b/tests/v2/push.bats
@@ -23,7 +23,7 @@ setup_file() {
     "meta-data set docker-compose-plugin-built-image-tag-app \* : echo \$4"
 
   stub docker \
-    "compose -f docker-compose.yml -p buildkite1111 config --images app : echo somewhere.dkr.ecr.some-region.amazonaws.com/blah" \
+    "compose -f docker-compose.yml -p buildkite1111 config : cat ${PWD}/tests/composefiles/docker-compose.config.v3.2.yml" \
     "image inspect somewhere.dkr.ecr.some-region.amazonaws.com/blah : exit 0" \
     "compose -f docker-compose.yml -p buildkite1111 push app : echo pushed app"
 
@@ -42,7 +42,7 @@ setup_file() {
   export BUILDKITE_BUILD_NUMBER=1
 
   stub docker \
-    "compose -f docker-compose.yml -p buildkite1111 config --images myservice : echo ''" \
+    "compose -f docker-compose.yml -p buildkite1111 config : echo ''" \
     "pull myimage : echo pulled prebuilt image" \
     "tag myimage my.repository/myservice:llamas : echo tagged image" \
     "push my.repository/myservice:llamas : echo pushed myservice"
@@ -71,7 +71,7 @@ setup_file() {
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_COMPATIBILITY=true
 
   stub docker \
-    "compose --compatibility -f docker-compose.yml -p buildkite1111 config --images myservice : echo ''" \
+    "compose --compatibility -f docker-compose.yml -p buildkite1111 config : echo ''" \
     "pull myimage : echo pulled prebuilt image" \
     "tag myimage my.repository/myservice:llamas : echo tagged image" \
     "push my.repository/myservice:llamas : echo pushed myservice"
@@ -99,15 +99,24 @@ setup_file() {
   export BUILDKITE_BUILD_NUMBER=1
 
   stub docker \
-    "compose -f docker-compose.yml -p buildkite1111 config --images myservice : echo ''"
+    "compose -f docker-compose.yml -p buildkite1111 config : echo ''" \
+    "pull prebuilt : echo ''" \
+    "tag prebuilt \* : echo 'invalid tag'; exit 1"
+
+  stub buildkite-agent \
+    "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 0" \
+    "meta-data get docker-compose-plugin-built-image-tag-myservice : echo prebuilt" \
 
   run "$PWD"/hooks/command
 
-  assert_success
+  assert_failure
+
   refute_output --partial "pulled prebuilt image"
   refute_output --partial "tagged image"
   assert_output --partial "invalid tag"
+
   unstub docker
+  unstub buildkite-agent
 }
 
 @test "Push a prebuilt image to multiple tags" {
@@ -119,14 +128,14 @@ setup_file() {
   export BUILDKITE_BUILD_NUMBER=1
 
   stub docker \
-    "compose -f docker-compose.yml -p buildkite1111 config --images myservice : echo ''" \
+    "compose -f docker-compose.yml -p buildkite1111 config : echo ''" \
     "pull prebuilt : echo pulled prebuilt image" \
     "tag prebuilt my.repository/myservice:llamas : echo tagged image1" \
     "push my.repository/myservice:llamas : echo pushed myservice1" \
-    "compose -f docker-compose.yml -p buildkite1111 config --images myservice : echo ''" \
+    "compose -f docker-compose.yml -p buildkite1111 config : echo ''" \
     "tag prebuilt2 my.repository/myservice:latest : echo tagged image2" \
     "push my.repository/myservice:latest : echo pushed myservice2" \
-    "compose -f docker-compose.yml -p buildkite1111 config --images myservice : echo ''" \
+    "compose -f docker-compose.yml -p buildkite1111 config : echo ''" \
     "tag prebuilt3 my.repository/myservice:alpacas : echo tagged image3" \
     "push my.repository/myservice:alpacas : echo pushed myservice3"
 
@@ -166,7 +175,7 @@ setup_file() {
     "meta-data set docker-compose-plugin-built-image-tag-helper \* : echo \$4"
 
   stub docker \
-    "compose -f docker-compose.yml -p buildkite1111 config --images helper : echo buildkite1111-helper" \
+    "compose -f docker-compose.yml -p buildkite1111 config : cat ${PWD}/tests/composefiles/docker-compose.config.v3.2.yml" \
     "image inspect buildkite1111-helper : exit 0" \
     "tag buildkite1111-helper my.repository/helper:llamas : echo tagged helper" \
     "push my.repository/helper:llamas : echo pushed helper"
@@ -190,7 +199,7 @@ setup_file() {
     "meta-data exists docker-compose-plugin-built-image-tag-helper : exit 1"
 
   stub docker \
-    "compose -f docker-compose.yml -p buildkite1111 config --images helper : echo 'buildkite1111-helper'" \
+    "compose -f docker-compose.yml -p buildkite1111 config : cat ${PWD}/tests/composefiles/docker-compose.config.v3.2.yml" \
     "image inspect buildkite1111-helper : exit 1" 
 
   run "$PWD"/hooks/command
@@ -210,11 +219,11 @@ setup_file() {
   export BUILDKITE_BUILD_NUMBER=1
 
   stub docker \
-    "compose -f docker-compose.yml -p buildkite1111 config --images myservice1 : echo ''" \
+    "compose -f docker-compose.yml -p buildkite1111 config : echo ''" \
     "pull prebuilt1 : exit 0" \
     "tag prebuilt1 my.repository/myservice1 : echo tagging image1" \
     "push my.repository/myservice1 : echo pushing myservice1 image" \
-    "compose -f docker-compose.yml -p buildkite1111 config --images myservice2 : echo ''" \
+    "compose -f docker-compose.yml -p buildkite1111 config : echo ''" \
     "pull prebuilt2 : exit 0" \
     "tag prebuilt2 my.repository/myservice2:llamas : echo tagging image2" \
     "push my.repository/myservice2:llamas : echo pushing myservice2 image"

--- a/tests/v2/push.bats
+++ b/tests/v2/push.bats
@@ -19,7 +19,6 @@ setup_file() {
   export BUILDKITE_BUILD_NUMBER=1
 
   stub buildkite-agent \
-    "meta-data exists docker-compose-plugin-built-image-tag-app : exit 1" \
     "meta-data set docker-compose-plugin-built-image-tag-app \* : echo \$4"
 
   stub docker \
@@ -43,6 +42,7 @@ setup_file() {
 
   stub docker \
     "compose -f docker-compose.yml -p buildkite1111 config : echo ''" \
+    "image inspect \* : exit 1" \
     "pull myimage : echo pulled prebuilt image" \
     "tag myimage my.repository/myservice:llamas : echo tagged image" \
     "push my.repository/myservice:llamas : echo pushed myservice"
@@ -72,6 +72,7 @@ setup_file() {
 
   stub docker \
     "compose --compatibility -f docker-compose.yml -p buildkite1111 config : echo ''" \
+    "image inspect \* : exit 1" \
     "pull myimage : echo pulled prebuilt image" \
     "tag myimage my.repository/myservice:llamas : echo tagged image" \
     "push my.repository/myservice:llamas : echo pushed myservice"
@@ -100,6 +101,7 @@ setup_file() {
 
   stub docker \
     "compose -f docker-compose.yml -p buildkite1111 config : echo ''" \
+    "image inspect \* : exit 1" \
     "pull prebuilt : echo ''" \
     "tag prebuilt \* : echo 'invalid tag'; exit 1"
 
@@ -129,13 +131,16 @@ setup_file() {
 
   stub docker \
     "compose -f docker-compose.yml -p buildkite1111 config : echo ''" \
+    "image inspect \* : exit 1" \
     "pull prebuilt : echo pulled prebuilt image" \
     "tag prebuilt my.repository/myservice:llamas : echo tagged image1" \
     "push my.repository/myservice:llamas : echo pushed myservice1" \
     "compose -f docker-compose.yml -p buildkite1111 config : echo ''" \
+    "image inspect \* : exit 1" \
     "tag prebuilt2 my.repository/myservice:latest : echo tagged image2" \
     "push my.repository/myservice:latest : echo pushed myservice2" \
     "compose -f docker-compose.yml -p buildkite1111 config : echo ''" \
+    "image inspect \* : exit 1" \
     "tag prebuilt3 my.repository/myservice:alpacas : echo tagged image3" \
     "push my.repository/myservice:alpacas : echo pushed myservice3"
 
@@ -171,7 +176,6 @@ setup_file() {
   export BUILDKITE_BUILD_NUMBER=1
 
   stub buildkite-agent \
-    "meta-data exists docker-compose-plugin-built-image-tag-helper : exit 1" \
     "meta-data set docker-compose-plugin-built-image-tag-helper \* : echo \$4"
 
   stub docker \
@@ -220,10 +224,12 @@ setup_file() {
 
   stub docker \
     "compose -f docker-compose.yml -p buildkite1111 config : echo ''" \
+    "image inspect buildkite1111-myservice1 : exit 1" \
     "pull prebuilt1 : exit 0" \
     "tag prebuilt1 my.repository/myservice1 : echo tagging image1" \
     "push my.repository/myservice1 : echo pushing myservice1 image" \
     "compose -f docker-compose.yml -p buildkite1111 config : echo ''" \
+    "image inspect buildkite1111-myservice2 : exit 1" \
     "pull prebuilt2 : exit 0" \
     "tag prebuilt2 my.repository/myservice2:llamas : echo tagging image2" \
     "push my.repository/myservice2:llamas : echo pushing myservice2 image"

--- a/tests/v2/run.bats
+++ b/tests/v2/run.bats
@@ -24,7 +24,7 @@ setup_file() {
 
   stub docker \
     "compose -f docker-compose.yml -p buildkite1111 up -d --scale myservice=0 myservice : echo ran myservice dependencies" \
-    "compose -f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 --rm myservice /bin/sh -e -c 'echo hello world' : echo ran myservice"
+    "compose -f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 -T --rm myservice /bin/sh -e -c 'echo hello world' : echo ran myservice"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 1"
@@ -49,7 +49,7 @@ setup_file() {
 
   stub docker \
     "compose -f docker-compose.yml -p buildkite1111 up -d --scale myservice=0 myservice : echo ran myservice dependencies" \
-    "compose -f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 --rm myservice : echo ran myservice"
+    "compose -f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 -T --rm myservice : echo ran myservice"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 1"
@@ -75,7 +75,7 @@ setup_file() {
 
   stub docker \
     "compose -f docker-compose.yml -p buildkite1111 up -d --scale myservice=0 myservice : echo ran myservice dependencies" \
-    "compose -f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 --workdir=/test_workdir --rm myservice : echo ran myservice"
+    "compose -f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 -T --workdir=/test_workdir --rm myservice : echo ran myservice"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 1"
@@ -100,7 +100,7 @@ setup_file() {
 
   stub docker \
     "compose -f docker-compose.yml -p buildkite1111 up -d --scale myservice=0 myservice : echo ran myservice dependencies" \
-    "compose -f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 --rm myservice /bin/sh -e -c $'sh -c \'echo hello world\'' : echo ran myservice"
+    "compose -f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 -T --rm myservice /bin/sh -e -c $'sh -c \'echo hello world\'' : echo ran myservice"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 1"
@@ -127,7 +127,7 @@ cmd3"
 
   stub docker \
     "compose -f docker-compose.yml -p buildkite1111 up -d --scale myservice=0 myservice : echo ran myservice dependencies" \
-    "compose -f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 --rm myservice /bin/sh -e -c $'cmd1\ncmd2\ncmd3' : echo ran myservice"
+    "compose -f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 -T --rm myservice /bin/sh -e -c $'cmd1\ncmd2\ncmd3' : echo ran myservice"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 1"
@@ -154,7 +154,7 @@ cmd3"
 
   stub docker \
     "compose -f docker-compose.yml -p buildkite1111 up -d --scale myservice=0 myservice : echo ran myservice dependencies" \
-    "compose -f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 --rm myservice echo 'hello world' : echo ran myservice"
+    "compose -f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 -T --rm myservice echo 'hello world' : echo ran myservice"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 1"
@@ -184,7 +184,7 @@ cmd3"
 
   stub docker \
     "compose -f docker-compose.yml -p buildkite1111 up -d --scale myservice=0 myservice : echo ran myservice dependencies" \
-    "compose -f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 -e MYENV=0 -e MYENV -e MYENV=2 -e MYENV -e ANOTHER=this\ is\ a\ long\ string\ with\ spaces\;\ and\ semi-colons --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice"
+    "compose -f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 -e MYENV=0 -e MYENV -e MYENV=2 -e MYENV -e ANOTHER=this\ is\ a\ long\ string\ with\ spaces\;\ and\ semi-colons -T --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 1"
@@ -210,7 +210,7 @@ cmd3"
 
   stub docker \
     "compose -f docker-compose.yml -p buildkite1111 up -d --scale myservice=0 myservice : echo ran myservice dependencies" \
-    "compose -f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 --rm myservice /bin/sh -e -c 'echo hello world' : echo ran myservice"
+    "compose -f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 -T --rm myservice /bin/sh -e -c 'echo hello world' : echo ran myservice"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 1"
@@ -237,7 +237,7 @@ cmd3"
 
   stub docker \
     "compose -f docker-compose.yml -p buildkite1111 up -d --scale myservice=0 myservice : echo ran myservice dependencies" \
-    "compose -f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 --rm myservice /bin/sh -e -c 'echo hello world' : echo ran myservice"
+    "compose -f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 -T --rm myservice /bin/sh -e -c 'echo hello world' : echo ran myservice"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 1"
@@ -263,7 +263,7 @@ cmd3"
 
   stub docker \
     "compose -f docker-compose.yml -p buildkite1111 up -d --scale myservice=0 myservice : echo ran myservice dependencies" \
-    "compose -f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 --rm myservice /bin/sh -e -c 'echo hello world' : echo ran myservice"
+    "compose -f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 -T --rm myservice /bin/sh -e -c 'echo hello world' : echo ran myservice"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 1"
@@ -288,7 +288,7 @@ cmd3"
   stub docker \
     "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml pull myservice : echo pulled myservice" \
     "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml up -d --scale myservice=0 myservice : echo ran myservice dependencies" \
-    "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice"
+    "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 -T --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 0" \
@@ -319,7 +319,7 @@ cmd3"
   stub docker \
     "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml pull myservice : echo pulled myservice" \
     "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml up -d --scale myservice=0 myservice : echo ran myservice dependencies" \
-    "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 -e \* -e \* --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice with vars \${12} and \${14}"
+    "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 -e \* -e \* -T --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice with vars \${12} and \${14}"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 0" \
@@ -349,7 +349,7 @@ cmd3"
   stub docker \
     "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml pull myservice : echo pulled myservice" \
     "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml up -d --scale myservice=0 myservice : echo ran myservice dependencies" \
-    "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice"
+    "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 -T --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 0" \
@@ -376,7 +376,7 @@ cmd3"
   stub docker \
     "compose -f tests/composefiles/docker-compose.v2.0.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml pull myservice : echo pulled myservice" \
     "compose -f tests/composefiles/docker-compose.v2.0.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml up -d --scale myservice=0 myservice : echo ran myservice dependencies" \
-    "compose -f tests/composefiles/docker-compose.v2.0.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice"
+    "compose -f tests/composefiles/docker-compose.v2.0.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 -T --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice-tests/composefiles/docker-compose.v2.0.yml : exit 0" \
@@ -404,7 +404,7 @@ export BUILDKITE_JOB_ID=1111
   stub docker \
     "compose -f tests/composefiles/docker-compose.v2.0.yml -f tests/composefiles/docker-compose.v2.1.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml pull myservice : echo pulled myservice" \
     "compose -f tests/composefiles/docker-compose.v2.0.yml -f tests/composefiles/docker-compose.v2.1.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml up -d --scale myservice=0 myservice : echo pulled myservice" \
-    "compose -f tests/composefiles/docker-compose.v2.0.yml -f tests/composefiles/docker-compose.v2.1.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice"
+    "compose -f tests/composefiles/docker-compose.v2.0.yml -f tests/composefiles/docker-compose.v2.1.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 -T --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice-tests/composefiles/docker-compose.v2.0.yml-tests/composefiles/docker-compose.v2.1.yml : exit 0" \
@@ -431,7 +431,7 @@ export BUILDKITE_JOB_ID=1111
   stub docker \
     "compose -f tests/composefiles/docker-compose.v2.0.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml pull myservice : echo pulled myservice" \
     "compose -f tests/composefiles/docker-compose.v2.0.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml up -d --scale myservice=0 myservice : echo ran myservice dependencies" \
-    "compose -f tests/composefiles/docker-compose.v2.0.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice"
+    "compose -f tests/composefiles/docker-compose.v2.0.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 -T --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice-tests/composefiles/docker-compose.v2.0.yml : exit 0" \
@@ -483,7 +483,7 @@ export BUILDKITE_JOB_ID=1111
     "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml pull myservice : exit 2" \
     "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml pull myservice : echo pulled myservice" \
     "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml up -d --scale myservice=0 myservice : echo started dependencies for myservice" \
-    "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice"
+    "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 -T --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 0" \
@@ -498,7 +498,7 @@ export BUILDKITE_JOB_ID=1111
   unstub buildkite-agent
 }
 
-@test "Run without a TTY" {
+@test "Run with a TTY" {
   export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RUN=myservice
   export BUILDKITE_PIPELINE_SLUG=test
@@ -506,12 +506,12 @@ export BUILDKITE_JOB_ID=1111
   export BUILDKITE_COMMAND=pwd
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CHECK_LINKED_CONTAINERS=false
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLEANUP=false
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_TTY=false
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_TTY=true
 
   stub docker \
     "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml pull myservice : echo pulled myservice" \
     "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml up -d --scale myservice=0 myservice : echo started dependencies for myservice" \
-    "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 -T --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice without tty"
+    "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice without tty"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 0" \
@@ -537,7 +537,7 @@ export BUILDKITE_JOB_ID=1111
 
   stub docker \
     "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml pull myservice : echo pulled myservice" \
-    "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 --no-deps --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice without dependencies"
+    "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 -T --no-deps --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice without dependencies"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 0" \
@@ -563,7 +563,7 @@ export BUILDKITE_JOB_ID=1111
 
   stub docker \
     "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml pull myservice : echo pulled myservice" \
-    "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice with dependencies"
+    "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 -T --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice with dependencies"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 0" \
@@ -591,7 +591,7 @@ export BUILDKITE_JOB_ID=1111
   stub docker \
     "compose --no-ansi -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml pull myservice : echo pulled myservice" \
     "compose --no-ansi -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml up -d --scale myservice=0 myservice : echo started dependencies for myservice" \
-    "compose --no-ansi -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice without ansi output"
+    "compose --no-ansi -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 -T --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice without ansi output"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 0" \
@@ -618,7 +618,7 @@ export BUILDKITE_JOB_ID=1111
   stub docker \
     "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml pull myservice : echo pulled myservice" \
     "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml up -d --scale myservice=0 myservice : echo started dependencies for myservice" \
-    "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 --use-aliases --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice with use aliases output"
+    "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 -T --use-aliases --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice with use aliases output"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 0" \
@@ -646,7 +646,7 @@ export BUILDKITE_JOB_ID=1111
   stub docker \
     "compose --compatibility -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml pull myservice : echo pulled myservice" \
     "compose --compatibility -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml up -d --scale myservice=0 myservice : echo started dependencies for myservice" \
-    "compose --compatibility -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice with use aliases output"
+    "compose --compatibility -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 -T --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice with use aliases output"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 0" \
@@ -674,7 +674,7 @@ export BUILDKITE_JOB_ID=1111
   stub docker \
     "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml pull myservice : echo pulled myservice" \
     "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml up -d --scale myservice=0 myservice : echo started dependencies for myservice" \
-    "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 -v $PWD/dist:/app/dist -v $PWD/pkg:/app/pkg --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice with volumes"
+    "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 -v $PWD/dist:/app/dist -v $PWD/pkg:/app/pkg -T --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice with volumes"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 0" \
@@ -701,7 +701,7 @@ export BUILDKITE_JOB_ID=1111
   stub docker \
     "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml pull myservice : echo pulled myservice" \
     "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml up -d --scale myservice=0 myservice : echo started dependencies for myservice" \
-    "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 -v buildkite:/buildkite --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice with volumes"
+    "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 -v buildkite:/buildkite -T --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice with volumes"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 0" \
@@ -731,7 +731,7 @@ export BUILDKITE_JOB_ID=1111
   stub docker \
     "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml pull myservice : echo pulled myservice" \
     "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml up -d --scale myservice=0 myservice : echo started dependencies for myservice" \
-    "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 -v buildkite:/buildkite -v $PWD/dist:/app/dist --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice with volumes"
+    "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 -v buildkite:/buildkite -v $PWD/dist:/app/dist -T --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice with volumes"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 0" \
@@ -758,7 +758,7 @@ export BUILDKITE_JOB_ID=1111
   stub docker \
     "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml pull myservice : echo pulled myservice" \
     "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml up -d --scale myservice=0 myservice : echo started dependencies for myservice" \
-    "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 -v buildkite:/buildkite -v $PWD/dist:/app/dist --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice with volumes"
+    "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 -v buildkite:/buildkite -v $PWD/dist:/app/dist -T --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice with volumes"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 0" \
@@ -786,7 +786,7 @@ export BUILDKITE_JOB_ID=1111
 
   stub docker \
     "compose -f llamas1.yml -f llamas2.yml -f llamas3.yml -p buildkite1111 up -d --scale myservice=0 myservice : echo started dependencies for myservice" \
-    "compose -f llamas1.yml -f llamas2.yml -f llamas3.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 --rm myservice /bin/sh -e -c 'echo hello world' : echo ran myservice"
+    "compose -f llamas1.yml -f llamas2.yml -f llamas3.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 -T --rm myservice /bin/sh -e -c 'echo hello world' : echo ran myservice"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice-llamas1.yml-llamas2.yml-llamas3.yml : exit 1"
@@ -811,7 +811,7 @@ export BUILDKITE_JOB_ID=1111
 
   stub docker \
     "compose -f docker-compose.yml -p buildkite1111 up -d --scale myservice=0 myservice : echo started dependencies for myservice" \
-    "compose -f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 --rm myservice /bin/sh -e -c 'pwd' : exit 2"
+    "compose -f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 -T --rm myservice /bin/sh -e -c 'pwd' : exit 2"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 1"
@@ -839,7 +839,7 @@ export BUILDKITE_JOB_ID=1111
   stub docker \
     "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml pull --parallel myservice1 myservice2 : echo pulled myservice1 and myservice2" \
     "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml up -d --scale myservice1=0 myservice1 : echo started dependencies for myservice1" \
-    "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice1_build_1 --rm myservice1 /bin/sh -e -c 'pwd' : echo ran myservice1"
+    "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice1_build_1 -T --rm myservice1 /bin/sh -e -c 'pwd' : echo ran myservice1"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice1 : exit 0" \
@@ -868,7 +868,7 @@ export BUILDKITE_JOB_ID=1111
 
   stub docker \
     "compose -f docker-compose.yml -p buildkite1111 up -d --scale myservice=0 myservice : echo started dependencies for myservice" \
-    "compose -f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 --user=1000 --rm myservice /bin/sh -e -c $'sh -c \'whoami\'' : echo ran myservice"
+    "compose -f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 -T --user=1000 --rm myservice /bin/sh -e -c $'sh -c \'whoami\'' : echo ran myservice"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 1"
@@ -894,7 +894,7 @@ export BUILDKITE_JOB_ID=1111
 
   stub docker \
     "compose -f docker-compose.yml -p buildkite1111 up -d --scale myservice=0 myservice : echo started dependencies for myservice" \
-    "compose -f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 --user=1000:1001 --rm myservice /bin/sh -e -c $'sh -c \'whoami\'' : echo ran myservice"
+    "compose -f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 -T --user=1000:1001 --rm myservice /bin/sh -e -c $'sh -c \'whoami\'' : echo ran myservice"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 1"
@@ -944,7 +944,7 @@ export BUILDKITE_JOB_ID=1111
   stub docker \
     "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml pull myservice : echo pulled myservice" \
     "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml up -d --scale myservice=0 myservice : echo started dependencies for myservice" \
-    "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 myservice /bin/sh -e -c $'pwd' : echo ran myservice without tty"
+    "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 -T myservice /bin/sh -e -c $'pwd' : echo ran myservice without tty"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : echo myimage" \
@@ -970,7 +970,7 @@ export BUILDKITE_JOB_ID=1111
 
   stub docker \
     "compose -f docker-compose.yml -p buildkite1111 up -d --scale myservice=0 myservice : echo ran myservice dependencies" \
-    "compose -f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 --rm --entrypoint 'my custom entrypoint' myservice : echo ran myservice"
+    "compose -f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 -T --rm --entrypoint 'my custom entrypoint' myservice : echo ran myservice"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 1"
@@ -996,7 +996,7 @@ export BUILDKITE_JOB_ID=1111
 
   stub docker \
     "compose -f docker-compose.yml -p buildkite1111 up -d --scale myservice=0 myservice : echo ran myservice dependencies" \
-    "compose -f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 --rm -e BUILDKITE_JOB_ID -e BUILDKITE_BUILD_ID -e BUILDKITE_AGENT_ACCESS_TOKEN -v $BATS_MOCK_TMPDIR/bin/buildkite-agent:/usr/bin/buildkite-agent myservice : echo ran myservice"
+    "compose -f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 -T --rm -e BUILDKITE_JOB_ID -e BUILDKITE_BUILD_ID -e BUILDKITE_AGENT_ACCESS_TOKEN -v $BATS_MOCK_TMPDIR/bin/buildkite-agent:/usr/bin/buildkite-agent myservice : echo ran myservice"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 1"
@@ -1023,7 +1023,7 @@ export BUILDKITE_JOB_ID=1111
 
   stub docker \
     "compose -f docker-compose.yml -p buildkite1111 up -d --scale myservice=0 myservice : echo ran myservice dependencies" \
-    "compose -f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 --rm myservice /bin/sh -e -c 'echo hello world' : echo ran myservice"
+    "compose -f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 -T --rm myservice /bin/sh -e -c 'echo hello world' : echo ran myservice"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 1"
@@ -1049,7 +1049,7 @@ export BUILDKITE_JOB_ID=1111
 
   stub docker \
     "compose -f docker-compose.yml -p buildkite1111 up -d --scale myservice=0 myservice : echo ran myservice dependencies" \
-    "compose -f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 -v /tmp/sample-mirror:/tmp/sample-mirror:ro --rm myservice /bin/sh -e -c 'echo hello world' : echo ran myservice"
+    "compose -f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 -v /tmp/sample-mirror:/tmp/sample-mirror:ro -T --rm myservice /bin/sh -e -c 'echo hello world' : echo ran myservice"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 1"
@@ -1076,7 +1076,7 @@ export BUILDKITE_JOB_ID=1111
 
   stub docker \
     "compose -f docker-compose.yml -p buildkite1111 up -d --scale myservice=0 myservice : echo ran myservice dependencies" \
-    "compose -f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 --rm -e SSH_AUTH_SOCK=/ssh-agent -v /tmp/ssh_auth_sock:/ssh-agent -v /root/.ssh/known_hosts:/root/.ssh/known_hosts myservice /bin/sh -e -c 'echo hello world' : echo ran myservice"
+    "compose -f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 -T --rm -e SSH_AUTH_SOCK=/ssh-agent -v /tmp/ssh_auth_sock:/ssh-agent -v /root/.ssh/known_hosts:/root/.ssh/known_hosts myservice /bin/sh -e -c 'echo hello world' : echo ran myservice"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 1"
@@ -1108,7 +1108,7 @@ export BUILDKITE_JOB_ID=1111
 
   stub docker \
     "compose -f docker-compose.yml -p buildkite1111 up -d --scale myservice=0 myservice : echo ran myservice dependencies" \
-    "compose -f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 --rm -e SSH_AUTH_SOCK=/ssh-agent -v /tmp/ssh_auth_sock:/ssh-agent -v /root/.ssh/known_hosts:/tmp/test/.ssh/known_hosts myservice /bin/sh -e -c 'echo hello world' : echo ran myservice"
+    "compose -f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 -T --rm -e SSH_AUTH_SOCK=/ssh-agent -v /tmp/ssh_auth_sock:/ssh-agent -v /root/.ssh/known_hosts:/tmp/test/.ssh/known_hosts myservice /bin/sh -e -c 'echo hello world' : echo ran myservice"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 1"
@@ -1141,7 +1141,7 @@ export BUILDKITE_JOB_ID=1111
   stub docker \
     "compose -f docker-compose.yml -p buildkite1111 -f \* pull myservice : echo pulled myservice" \
     "compose -f docker-compose.yml -p buildkite1111 -f \* up -d --scale myservice=0 myservice : echo started dependencies for myservice" \
-    "compose -f docker-compose.yml -p buildkite1111 -f \* run --name buildkite1111_myservice_build_1 --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice without mount-checkout"
+    "compose -f docker-compose.yml -p buildkite1111 -f \* run --name buildkite1111_myservice_build_1 -T --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice without mount-checkout"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 0" \
@@ -1170,7 +1170,7 @@ export BUILDKITE_JOB_ID=1111
   stub docker \
     "compose -f docker-compose.yml -p buildkite1111 -f \* pull myservice : echo pulled myservice" \
     "compose -f docker-compose.yml -p buildkite1111 -f \* up -d --scale myservice=0 myservice : echo started dependencies for myservice" \
-    "compose -f docker-compose.yml -p buildkite1111 -f \* run --name buildkite1111_myservice_build_1 --workdir=/workdir -v /plugin:/workdir --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice with mount-checkout"
+    "compose -f docker-compose.yml -p buildkite1111 -f \* run --name buildkite1111_myservice_build_1 -T --workdir=/workdir -v /plugin:/workdir --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice with mount-checkout"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 0" \
@@ -1200,7 +1200,7 @@ export BUILDKITE_JOB_ID=1111
   stub docker \
     "compose -f docker-compose.yml -p buildkite1111 -f \* pull myservice : echo pulled myservice" \
     "compose -f docker-compose.yml -p buildkite1111 -f \* up -d --scale myservice=0 myservice : echo started dependencies for myservice" \
-    "compose -f docker-compose.yml -p buildkite1111 -f \* run --name buildkite1111_myservice_build_1 \* -v \* --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice with mount-checkout on \${13}"
+    "compose -f docker-compose.yml -p buildkite1111 -f \* run --name buildkite1111_myservice_build_1 -T \* -v \* --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice with mount-checkout on \${14}"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 0" \
@@ -1229,7 +1229,7 @@ export BUILDKITE_JOB_ID=1111
   stub docker \
     "compose -f docker-compose.yml -p buildkite1111 -f \* pull myservice : echo pulled myservice" \
     "compose -f docker-compose.yml -p buildkite1111 -f \* up -d --scale myservice=0 myservice : echo started dependencies for myservice" \
-    "compose -f docker-compose.yml -p buildkite1111 -f \* run --name buildkite1111_myservice_build_1 -v \* --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice with mount-checkout on \${12}"
+    "compose -f docker-compose.yml -p buildkite1111 -f \* run --name buildkite1111_myservice_build_1 -T -v \* --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice with mount-checkout on \${13}"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 0" \
@@ -1259,7 +1259,7 @@ export BUILDKITE_JOB_ID=1111
   stub docker \
     "compose -f docker-compose.yml -p buildkite1111 -f \* pull myservice : echo pulled myservice" \
     "compose -f docker-compose.yml -p buildkite1111 -f \* up -d --scale myservice=0 myservice : echo started dependencies for myservice" \
-    "compose -f docker-compose.yml -p buildkite1111 -f \* run --name buildkite1111_myservice_build_1 \* -v \* --rm myservice /bin/sh -e -c 'pwd' : echo echo ran myservice with mount-checkout on \${13}"
+    "compose -f docker-compose.yml -p buildkite1111 -f \* run --name buildkite1111_myservice_build_1 -T \* -v \* --rm myservice /bin/sh -e -c 'pwd' : echo echo ran myservice with mount-checkout on \${14}"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 0" \
@@ -1342,7 +1342,7 @@ export BUILDKITE_JOB_ID=1111
 
   stub docker \
     "compose -f docker-compose.yml -p buildkite1111 up --wait -d --scale myservice=0 myservice : echo ran myservice dependencies" \
-    "compose -f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 --rm myservice /bin/sh -e -c 'echo hello world' : echo ran myservice"
+    "compose -f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 -T --rm myservice /bin/sh -e -c 'echo hello world' : echo ran myservice"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 1"
@@ -1369,7 +1369,7 @@ export BUILDKITE_JOB_ID=1111
   stub docker \
     "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml pull myservice : echo pulled myservice" \
     "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml up -d --scale myservice=0 myservice : echo started dependencies for myservice" \
-    "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 --rm --service-ports myservice /bin/sh -e -c $'pwd' : echo ran myservice without tty"
+    "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 -T --rm --service-ports myservice /bin/sh -e -c $'pwd' : echo ran myservice without tty"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : echo myimage" \
@@ -1395,7 +1395,7 @@ export BUILDKITE_JOB_ID=1111
 
   stub docker \
     "compose -f docker-compose.yml -p buildkite1111 up --quiet-pull -d --scale myservice=0 myservice : echo ran myservice dependencies" \
-    "compose -f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 --rm myservice /bin/sh -e -c 'echo hello world' : echo ran myservice"
+    "compose -f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 -T --rm myservice /bin/sh -e -c 'echo hello world' : echo ran myservice"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 1"
@@ -1423,7 +1423,7 @@ export BUILDKITE_JOB_ID=1111
 
   stub docker \
     "compose -f docker-compose.yml -p buildkite1111 up -d --scale myservice=0 myservice : echo ran myservice dependencies" \
-    "compose -f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 -e VAR_A -e VAR_B -e VAR_C --rm myservice /bin/sh -e -c 'echo hello world' : echo ran myservice"
+    "compose -f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 -e VAR_A -e VAR_B -e VAR_C -T --rm myservice /bin/sh -e -c 'echo hello world' : echo ran myservice"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 1"

--- a/tests/v2/run.bats
+++ b/tests/v2/run.bats
@@ -13,6 +13,11 @@ setup_file() {
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RUN_LABELS="false"
 }
 
+teardown() {
+  # plugin leaves override files around
+  rm -f docker-compose.buildkite*-override.yml
+}
+
 @test "Run without a prebuilt image" {
   export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RUN=myservice

--- a/tests/v2/run.bats
+++ b/tests/v2/run.bats
@@ -23,7 +23,6 @@ setup_file() {
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLEANUP=false
 
   stub docker \
-    "compose -f docker-compose.yml -p buildkite1111 build --pull myservice : echo built myservice" \
     "compose -f docker-compose.yml -p buildkite1111 up -d --scale myservice=0 myservice : echo ran myservice dependencies" \
     "compose -f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 --rm myservice /bin/sh -e -c 'echo hello world' : echo ran myservice"
 
@@ -33,8 +32,8 @@ setup_file() {
   run "$PWD"/hooks/command
 
   assert_success
-  assert_output --partial "built myservice"
   assert_output --partial "ran myservice"
+
   unstub docker
   unstub buildkite-agent
 }
@@ -49,7 +48,6 @@ setup_file() {
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLEANUP=false
 
   stub docker \
-    "compose -f docker-compose.yml -p buildkite1111 build --pull myservice : echo built myservice" \
     "compose -f docker-compose.yml -p buildkite1111 up -d --scale myservice=0 myservice : echo ran myservice dependencies" \
     "compose -f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 --rm myservice : echo ran myservice"
 
@@ -59,8 +57,8 @@ setup_file() {
   run "$PWD"/hooks/command
 
   assert_success
-  assert_output --partial "built myservice"
   assert_output --partial "ran myservice"
+
   unstub docker
   unstub buildkite-agent
 }
@@ -76,7 +74,6 @@ setup_file() {
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLEANUP=false
 
   stub docker \
-    "compose -f docker-compose.yml -p buildkite1111 build --pull myservice : echo built myservice" \
     "compose -f docker-compose.yml -p buildkite1111 up -d --scale myservice=0 myservice : echo ran myservice dependencies" \
     "compose -f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 --workdir=/test_workdir --rm myservice : echo ran myservice"
 
@@ -86,8 +83,8 @@ setup_file() {
   run "$PWD"/hooks/command
 
   assert_success
-  assert_output --partial "built myservice"
   assert_output --partial "ran myservice"
+
   unstub docker
   unstub buildkite-agent
 }
@@ -102,7 +99,6 @@ setup_file() {
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLEANUP=false
 
   stub docker \
-    "compose -f docker-compose.yml -p buildkite1111 build --pull myservice : echo built myservice" \
     "compose -f docker-compose.yml -p buildkite1111 up -d --scale myservice=0 myservice : echo ran myservice dependencies" \
     "compose -f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 --rm myservice /bin/sh -e -c $'sh -c \'echo hello world\'' : echo ran myservice"
 
@@ -112,8 +108,8 @@ setup_file() {
   run "$PWD"/hooks/command
 
   assert_success
-  assert_output --partial "built myservice"
   assert_output --partial "ran myservice"
+
   unstub docker
   unstub buildkite-agent
 }
@@ -130,7 +126,6 @@ cmd3"
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLEANUP=false
 
   stub docker \
-    "compose -f docker-compose.yml -p buildkite1111 build --pull myservice : echo built myservice" \
     "compose -f docker-compose.yml -p buildkite1111 up -d --scale myservice=0 myservice : echo ran myservice dependencies" \
     "compose -f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 --rm myservice /bin/sh -e -c $'cmd1\ncmd2\ncmd3' : echo ran myservice"
 
@@ -140,8 +135,8 @@ cmd3"
   run "$PWD"/hooks/command
 
   assert_success
-  assert_output --partial "built myservice"
   assert_output --partial "ran myservice"
+
   unstub docker
   unstub buildkite-agent
 }
@@ -158,7 +153,6 @@ cmd3"
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLEANUP=false
 
   stub docker \
-    "compose -f docker-compose.yml -p buildkite1111 build --pull myservice : echo built myservice" \
     "compose -f docker-compose.yml -p buildkite1111 up -d --scale myservice=0 myservice : echo ran myservice dependencies" \
     "compose -f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 --rm myservice echo 'hello world' : echo ran myservice"
 
@@ -168,8 +162,8 @@ cmd3"
   run "$PWD"/hooks/command
 
   assert_success
-  assert_output --partial "built myservice"
   assert_output --partial "ran myservice"
+
   unstub docker
   unstub buildkite-agent
 }
@@ -189,7 +183,6 @@ cmd3"
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_ENVIRONMENT_2=ANOTHER="this is a long string with spaces; and semi-colons"
 
   stub docker \
-    "compose -f docker-compose.yml -p buildkite1111 build --pull myservice : echo built myservice" \
     "compose -f docker-compose.yml -p buildkite1111 up -d --scale myservice=0 myservice : echo ran myservice dependencies" \
     "compose -f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 -e MYENV=0 -e MYENV -e MYENV=2 -e MYENV -e ANOTHER=this\ is\ a\ long\ string\ with\ spaces\;\ and\ semi-colons --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice"
 
@@ -200,6 +193,7 @@ cmd3"
 
   assert_success
   assert_output --partial "ran myservice"
+
   unstub docker
   unstub buildkite-agent
 }
@@ -215,7 +209,6 @@ cmd3"
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLEANUP=false
 
   stub docker \
-    "compose -f docker-compose.yml -p buildkite1111 build --pull --no-cache myservice : echo built myservice" \
     "compose -f docker-compose.yml -p buildkite1111 up -d --scale myservice=0 myservice : echo ran myservice dependencies" \
     "compose -f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 --rm myservice /bin/sh -e -c 'echo hello world' : echo ran myservice"
 
@@ -225,8 +218,8 @@ cmd3"
   run "$PWD"/hooks/command
 
   assert_success
-  assert_output --partial "built myservice"
   assert_output --partial "ran myservice"
+
   unstub docker
   unstub buildkite-agent
 }
@@ -243,7 +236,6 @@ cmd3"
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLEANUP=false
 
   stub docker \
-    "compose -f docker-compose.yml -p buildkite1111 build --pull --build-arg MYARG=0 --build-arg MYARG=1 myservice : echo built myservice" \
     "compose -f docker-compose.yml -p buildkite1111 up -d --scale myservice=0 myservice : echo ran myservice dependencies" \
     "compose -f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 --rm myservice /bin/sh -e -c 'echo hello world' : echo ran myservice"
 
@@ -253,8 +245,8 @@ cmd3"
   run "$PWD"/hooks/command
 
   assert_success
-  assert_output --partial "built myservice"
   assert_output --partial "ran myservice"
+
   unstub docker
   unstub buildkite-agent
 }
@@ -270,7 +262,6 @@ cmd3"
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_SKIP_PULL=true
 
   stub docker \
-    "compose -f docker-compose.yml -p buildkite1111 build myservice : echo built myservice" \
     "compose -f docker-compose.yml -p buildkite1111 up -d --scale myservice=0 myservice : echo ran myservice dependencies" \
     "compose -f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 --rm myservice /bin/sh -e -c 'echo hello world' : echo ran myservice"
 
@@ -280,8 +271,8 @@ cmd3"
   run "$PWD"/hooks/command
 
   assert_success
-  assert_output --partial "built myservice"
   assert_output --partial "ran myservice"
+
   unstub docker
   unstub buildkite-agent
 }
@@ -794,7 +785,6 @@ export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CONFIG_2="llamas3.yml"
 
   stub docker \
-    "compose -f llamas1.yml -f llamas2.yml -f llamas3.yml -p buildkite1111 build --pull myservice : echo built myservice" \
     "compose -f llamas1.yml -f llamas2.yml -f llamas3.yml -p buildkite1111 up -d --scale myservice=0 myservice : echo started dependencies for myservice" \
     "compose -f llamas1.yml -f llamas2.yml -f llamas3.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 --rm myservice /bin/sh -e -c 'echo hello world' : echo ran myservice"
 
@@ -804,8 +794,8 @@ export BUILDKITE_JOB_ID=1111
   run "$PWD"/hooks/command
 
   assert_success
-  assert_output --partial "built myservice"
   assert_output --partial "ran myservice"
+
   unstub docker
   unstub buildkite-agent
 }
@@ -820,7 +810,6 @@ export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLEANUP=false
 
   stub docker \
-    "compose -f docker-compose.yml -p buildkite1111 build --pull myservice : echo built myservice" \
     "compose -f docker-compose.yml -p buildkite1111 up -d --scale myservice=0 myservice : echo started dependencies for myservice" \
     "compose -f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 --rm myservice /bin/sh -e -c 'pwd' : exit 2"
 
@@ -878,7 +867,6 @@ export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_USER="1000"
 
   stub docker \
-    "compose -f docker-compose.yml -p buildkite1111 build --pull myservice : echo built myservice" \
     "compose -f docker-compose.yml -p buildkite1111 up -d --scale myservice=0 myservice : echo started dependencies for myservice" \
     "compose -f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 --user=1000 --rm myservice /bin/sh -e -c $'sh -c \'whoami\'' : echo ran myservice"
 
@@ -888,8 +876,8 @@ export BUILDKITE_JOB_ID=1111
   run "$PWD"/hooks/command
 
   assert_success
-  assert_output --partial "built myservice"
   assert_output --partial "ran myservice"
+
   unstub docker
   unstub buildkite-agent
 }
@@ -905,7 +893,6 @@ export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_USER="1000:1001"
 
   stub docker \
-    "compose -f docker-compose.yml -p buildkite1111 build --pull myservice : echo built myservice" \
     "compose -f docker-compose.yml -p buildkite1111 up -d --scale myservice=0 myservice : echo started dependencies for myservice" \
     "compose -f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 --user=1000:1001 --rm myservice /bin/sh -e -c $'sh -c \'whoami\'' : echo ran myservice"
 
@@ -915,8 +902,8 @@ export BUILDKITE_JOB_ID=1111
   run "$PWD"/hooks/command
 
   assert_success
-  assert_output --partial "built myservice"
   assert_output --partial "ran myservice"
+
   unstub docker
   unstub buildkite-agent
 }
@@ -982,7 +969,6 @@ export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_ENTRYPOINT="my custom entrypoint"
 
   stub docker \
-    "compose -f docker-compose.yml -p buildkite1111 build --pull myservice : echo built myservice" \
     "compose -f docker-compose.yml -p buildkite1111 up -d --scale myservice=0 myservice : echo ran myservice dependencies" \
     "compose -f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 --rm --entrypoint 'my custom entrypoint' myservice : echo ran myservice"
 
@@ -992,8 +978,8 @@ export BUILDKITE_JOB_ID=1111
   run "$PWD"/hooks/command
 
   assert_success
-  assert_output --partial "built myservice"
   assert_output --partial "ran myservice"
+
   unstub docker
   unstub buildkite-agent
 }
@@ -1009,7 +995,6 @@ export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_MOUNT_BUILDKITE_AGENT=true
 
   stub docker \
-    "compose -f docker-compose.yml -p buildkite1111 build --pull myservice : echo built myservice" \
     "compose -f docker-compose.yml -p buildkite1111 up -d --scale myservice=0 myservice : echo ran myservice dependencies" \
     "compose -f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 --rm -e BUILDKITE_JOB_ID -e BUILDKITE_BUILD_ID -e BUILDKITE_AGENT_ACCESS_TOKEN -v $BATS_MOCK_TMPDIR/bin/buildkite-agent:/usr/bin/buildkite-agent myservice : echo ran myservice"
 
@@ -1019,8 +1004,8 @@ export BUILDKITE_JOB_ID=1111
   run "$PWD"/hooks/command
 
   assert_success
-  assert_output --partial "built myservice"
   assert_output --partial "ran myservice"
+
   unstub docker
   unstub buildkite-agent
 }
@@ -1037,7 +1022,6 @@ export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD_PARALLEL=true
 
   stub docker \
-    "compose -f docker-compose.yml -p buildkite1111 build --pull --no-cache --parallel myservice : echo built myservice" \
     "compose -f docker-compose.yml -p buildkite1111 up -d --scale myservice=0 myservice : echo ran myservice dependencies" \
     "compose -f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 --rm myservice /bin/sh -e -c 'echo hello world' : echo ran myservice"
 
@@ -1047,8 +1031,8 @@ export BUILDKITE_JOB_ID=1111
   run "$PWD"/hooks/command
 
   assert_success
-  assert_output --partial "built myservice"
   assert_output --partial "ran myservice"
+
   unstub docker
   unstub buildkite-agent
 }
@@ -1064,7 +1048,6 @@ export BUILDKITE_JOB_ID=1111
   export BUILDKITE_REPO_MIRROR=/tmp/sample-mirror
 
   stub docker \
-    "compose -f docker-compose.yml -p buildkite1111 build --pull myservice : echo built myservice" \
     "compose -f docker-compose.yml -p buildkite1111 up -d --scale myservice=0 myservice : echo ran myservice dependencies" \
     "compose -f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 -v /tmp/sample-mirror:/tmp/sample-mirror:ro --rm myservice /bin/sh -e -c 'echo hello world' : echo ran myservice"
 
@@ -1074,8 +1057,8 @@ export BUILDKITE_JOB_ID=1111
   run "$PWD"/hooks/command
 
   assert_success
-  assert_output --partial "built myservice"
   assert_output --partial "ran myservice"
+
   unstub docker
   unstub buildkite-agent
 }
@@ -1092,7 +1075,6 @@ export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_MOUNT_SSH_AGENT=true
 
   stub docker \
-    "compose -f docker-compose.yml -p buildkite1111 build --pull myservice : echo built myservice" \
     "compose -f docker-compose.yml -p buildkite1111 up -d --scale myservice=0 myservice : echo ran myservice dependencies" \
     "compose -f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 --rm -e SSH_AUTH_SOCK=/ssh-agent -v /tmp/ssh_auth_sock:/ssh-agent -v /root/.ssh/known_hosts:/root/.ssh/known_hosts myservice /bin/sh -e -c 'echo hello world' : echo ran myservice"
 
@@ -1107,8 +1089,8 @@ export BUILDKITE_JOB_ID=1111
   kill %1
 
   assert_success
-  assert_output --partial "built myservice"
   assert_output --partial "ran myservice"
+
   unstub docker
   unstub buildkite-agent
 }
@@ -1125,7 +1107,6 @@ export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_MOUNT_SSH_AGENT=/tmp/test
 
   stub docker \
-    "compose -f docker-compose.yml -p buildkite1111 build --pull myservice : echo built myservice" \
     "compose -f docker-compose.yml -p buildkite1111 up -d --scale myservice=0 myservice : echo ran myservice dependencies" \
     "compose -f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 --rm -e SSH_AUTH_SOCK=/ssh-agent -v /tmp/ssh_auth_sock:/ssh-agent -v /root/.ssh/known_hosts:/tmp/test/.ssh/known_hosts myservice /bin/sh -e -c 'echo hello world' : echo ran myservice"
 
@@ -1140,8 +1121,8 @@ export BUILDKITE_JOB_ID=1111
   kill %1
 
   assert_success
-  assert_output --partial "built myservice"
   assert_output --partial "ran myservice"
+
   unstub docker
   unstub buildkite-agent
 }
@@ -1360,7 +1341,6 @@ export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_WAIT=true
 
   stub docker \
-    "compose -f docker-compose.yml -p buildkite1111 build --pull myservice : echo built myservice" \
     "compose -f docker-compose.yml -p buildkite1111 up --wait -d --scale myservice=0 myservice : echo ran myservice dependencies" \
     "compose -f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 --rm myservice /bin/sh -e -c 'echo hello world' : echo ran myservice"
 
@@ -1370,7 +1350,6 @@ export BUILDKITE_JOB_ID=1111
   run "$PWD"/hooks/command
 
   assert_success
-  assert_output --partial "built myservice"
   assert_output --partial "ran myservice"
 
   unstub docker
@@ -1415,7 +1394,6 @@ export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_QUIET_PULL=true
 
   stub docker \
-    "compose -f docker-compose.yml -p buildkite1111 build --pull myservice : echo built myservice" \
     "compose -f docker-compose.yml -p buildkite1111 up --quiet-pull -d --scale myservice=0 myservice : echo ran myservice dependencies" \
     "compose -f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 --rm myservice /bin/sh -e -c 'echo hello world' : echo ran myservice"
 
@@ -1425,7 +1403,6 @@ export BUILDKITE_JOB_ID=1111
   run "$PWD"/hooks/command
 
   assert_success
-  assert_output --partial "built myservice"
   refute_output --partial "Pulling"
   assert_output --partial "ran myservice"
 
@@ -1445,7 +1422,6 @@ export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLEANUP=false
 
   stub docker \
-    "compose -f docker-compose.yml -p buildkite1111 build --pull myservice : echo built myservice" \
     "compose -f docker-compose.yml -p buildkite1111 up -d --scale myservice=0 myservice : echo ran myservice dependencies" \
     "compose -f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 -e VAR_A -e VAR_B -e VAR_C --rm myservice /bin/sh -e -c 'echo hello world' : echo ran myservice"
 
@@ -1455,7 +1431,6 @@ export BUILDKITE_JOB_ID=1111
   run "$PWD"/hooks/command
 
   assert_success
-  assert_output --partial "built myservice"
   assert_output --partial "ran myservice"
   unstub docker
   unstub buildkite-agent


### PR DESCRIPTION
Reduced the complexity of the `cache-from` option. Now it is just a pass-through to the corresponding options in docker compose. This means that:

* images will not be pulled by the plugin (docker should take care of that)
* there are no more groups
* the option format simplification makes it possible to support all formats available in the underlying docker engine