### PR TITLE
CLI v2 as default

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -22,9 +22,9 @@ steps:
     plugins:
       ${BUILDKITE_PULL_REQUEST_REPO:-$BUILDKITE_REPO}#${BUILDKITE_COMMIT}:
         run: tests
-        command: ["bats", "tests", "tests/v2"]
         # for pretty colors
         tty: true
+        command: ["bats", "tests", "tests/v1"]
 
   # The rest of the steps are integration tests
 

--- a/README.md
+++ b/README.md
@@ -606,11 +606,11 @@ The default is `on-error`.
 
 ### `cli-version` (optional, string or integer)
 
-If set to `2`, plugin will use `docker compose` to execute commands; otherwise it will default to version `1`, using `docker-compose` instead.
+If set to `1`, plugin will use `docker-compose` (that is deprecated and unsupported) to execute commands; otherwise it will default to version `2`, using `docker compose` instead.
 
 ### `buildkit` (optional, build only, boolean)
 
-Assuming you have a compatible docker installation and configuration in the agent, activating this option would setup the environment for the `docker-compose build` call to use BuildKit. Note that if you are using `cli-version` 2, you are already using buildkit by default.
+Assuming you have a compatible docker installation and configuration in the agent, activating this option would setup the environment for the `docker compose build` call to use BuildKit. Note that this should only be necessary if you are using `cli-version` 1 (version 2 already uses buildkit by default).
 
 You may want to also add `BUILDKIT_INLINE_CACHE=1` to your build arguments (`args` option in this plugin), but know that [there are known issues with it](https://github.com/moby/buildkit/issues/2274).
 

--- a/commands/build.sh
+++ b/commands/build.sh
@@ -11,7 +11,7 @@ else
   group_type="+++"
 fi
 
-if [[ "$(plugin_read_config BUILDKIT "false")" == "true" ]]; then
+if [[ "$(plugin_read_config BUILDKIT "true")" == "true" ]]; then
   export DOCKER_BUILDKIT=1
   export COMPOSE_DOCKER_CLI_BUILD=1
   export BUILDKIT_PROGRESS=plain

--- a/commands/build.sh
+++ b/commands/build.sh
@@ -95,7 +95,7 @@ while read -r line ; do
 done <<< "$(plugin_read_list SECRETS)"
 
 if [[ "$(plugin_read_config SSH "false")" != "false" ]] ; then
-  if [[ "${DOCKER_BUILDKIT:-}" != "1" && "${BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLI_VERSION:-}" != "2" ]]; then
+  if [[ "${DOCKER_BUILDKIT:-}" != "1" && "${BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLI_VERSION:-2}" != "2" ]]; then
     echo "🚨 You can not use the ssh option if you are not using buildkit"
     exit 1
   fi

--- a/lib/push.bash
+++ b/lib/push.bash
@@ -21,9 +21,9 @@ compose_image_for_service() {
 default_compose_image_for_service() {
   local service="$1"
   
-  local separator="_"
-  if [[ "$(plugin_read_config CLI_VERSION "1")" == "2" ]] && [[ "$(plugin_read_config COMPATIBILITY "false")" != "true" ]] ; then
-    separator="-"
+  local separator="-"
+  if [[ "$(plugin_read_config CLI_VERSION "2")" == "1" ]] || [[ "$(plugin_read_config COMPATIBILITY "false")" == "true" ]] ; then
+    separator="_"
   fi
 
   printf '%s%s%s\n' "$(docker_compose_project_name)" "$separator" "$service"

--- a/lib/shared.bash
+++ b/lib/shared.bash
@@ -207,7 +207,7 @@ function build_image_override_file_with_version() {
 # Runs the docker-compose command, scoped to the project, with the given arguments
 function run_docker_compose() {
   local command=(docker-compose)
-  if [[ "$(plugin_read_config CLI_VERSION "1")" == "2" ]] ; then
+  if [[ "$(plugin_read_config CLI_VERSION "2")" == "2" ]] ; then
     command=(docker compose)
   fi
 

--- a/tests/build.bats
+++ b/tests/build.bats
@@ -17,15 +17,15 @@ teardown() {
   export BUILDKITE_PIPELINE_SLUG=test
   export BUILDKITE_BUILD_NUMBER=1
 
-  stub docker-compose \
-    "-f docker-compose.yml -p buildkite1111 build --pull myservice : echo built myservice"
+  stub docker \
+    "compose -f docker-compose.yml -p buildkite1111 build --pull myservice : echo built myservice"
 
   run "$PWD"/hooks/command
 
   assert_success
   assert_output --partial "built myservice"
 
-  unstub docker-compose
+  unstub docker
 }
 
 @test "Build with no-cache" {
@@ -35,14 +35,15 @@ teardown() {
   export BUILDKITE_PIPELINE_SLUG=test
   export BUILDKITE_BUILD_NUMBER=1
 
-  stub docker-compose \
-    "-f docker-compose.yml -p buildkite1111 build --pull --no-cache myservice : echo built myservice"
+  stub docker \
+    "compose -f docker-compose.yml -p buildkite1111 build --pull --no-cache myservice : echo built myservice"
 
   run "$PWD"/hooks/command
 
   assert_success
   assert_output --partial "built myservice"
-  unstub docker-compose
+
+  unstub docker
 }
 
 @test "Build with parallel" {
@@ -52,14 +53,15 @@ teardown() {
   export BUILDKITE_PIPELINE_SLUG=test
   export BUILDKITE_BUILD_NUMBER=1
 
-  stub docker-compose \
-    "-f docker-compose.yml -p buildkite1111 build --pull --parallel myservice : echo built myservice"
+  stub docker \
+    "compose -f docker-compose.yml -p buildkite1111 build --pull --parallel myservice : echo built myservice"
 
   run "$PWD"/hooks/command
 
   assert_success
   assert_output --partial "built myservice"
-  unstub docker-compose
+
+  unstub docker
 }
 
 @test "Build with build args" {
@@ -70,14 +72,15 @@ teardown() {
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_ARGS_0=MYARG=0
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_ARGS_1=MYARG=1
 
-  stub docker-compose \
-    "-f docker-compose.yml -p buildkite1111 build --pull --build-arg MYARG=0 --build-arg MYARG=1 myservice : echo built myservice"
+  stub docker \
+    "compose -f docker-compose.yml -p buildkite1111 build --pull --build-arg MYARG=0 --build-arg MYARG=1 myservice : echo built myservice"
 
   run "$PWD"/hooks/command
 
   assert_success
   assert_output --partial "built myservice"
-  unstub docker-compose
+
+  unstub docker
 }
 
 @test "Build with docker-compose and v1 is set explicitly " {
@@ -85,37 +88,21 @@ teardown() {
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD=myservice
   export BUILDKITE_PIPELINE_SLUG=test
   export BUILDKITE_BUILD_NUMBER=1
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLI_VERSION=1
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLI_VERSION=2
 
-  stub docker-compose \
-    "-f docker-compose.yml -p buildkite1111 build --pull myservice : echo built myservice"
-
-  run "$PWD"/hooks/command
-
-  assert_success
-  assert_output --partial "built myservice"
-  unstub docker-compose
-}
-
-@test "Build with a repository" {
-  export BUILDKITE_JOB_ID=1111
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD=myservice
-  export BUILDKITE_PIPELINE_SLUG=test
-  export BUILDKITE_BUILD_NUMBER=1
-
-  stub docker-compose \
-    "-f docker-compose.yml -p buildkite1111 build --pull myservice : echo built myservice"
+  stub docker \
+    "compose -f docker-compose.yml -p buildkite1111 build --pull myservice : echo built myservice"
 
   run "$PWD"/hooks/command
 
   assert_success
   assert_output --partial "built myservice"
 
-  unstub docker-compose
+  unstub docker
 }
 
-# TODO: move this to push testing
 @test "Build with a repository and multiple build aliases" {
+  skip 'move to push'
   export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD=myservice
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD_ALIAS_0=myservice-1
@@ -123,15 +110,15 @@ teardown() {
   export BUILDKITE_PIPELINE_SLUG=test
   export BUILDKITE_BUILD_NUMBER=1
 
-  stub docker-compose \
-    "-f docker-compose.yml -p buildkite1111 build --pull myservice : echo built myservice"
+  stub docker \
+    "compose -f docker-compose.yml -p buildkite1111 build --pull myservice : echo built myservice"
 
   run "$PWD"/hooks/command
 
   assert_success
   assert_output --partial "built myservice"
 
-  unstub docker-compose
+  unstub docker
 }
 
 @test "Build with a repository and push retries" {
@@ -141,70 +128,15 @@ teardown() {
   export BUILDKITE_BUILD_NUMBER=1
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_PUSH_RETRIES=3
 
-  stub docker-compose \
-    "-f docker-compose.yml -p buildkite1111 build --pull myservice : echo built myservice"
+  stub docker \
+    "compose -f docker-compose.yml -p buildkite1111 build --pull myservice : echo built myservice"
 
   run "$PWD"/hooks/command
 
   assert_success
   assert_output --partial "built myservice"
 
-  unstub docker-compose
-}
-
-@test "Build with a repository and custom config file" {
-  export BUILDKITE_JOB_ID=1111
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD=myservice
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CONFIG=tests/composefiles/docker-compose.v2.0.yml
-  export BUILDKITE_PIPELINE_SLUG=test
-  export BUILDKITE_BUILD_NUMBER=1
-
-  stub docker-compose \
-    "-f tests/composefiles/docker-compose.v2.0.yml -p buildkite1111 build --pull myservice : echo built myservice"
-
-  run "$PWD"/hooks/command
-
-  assert_success
-  assert_output --partial "built myservice"
-
-  unstub docker-compose
-}
-
-@test "Build with a repository and multiple custom config files" {
-  export BUILDKITE_JOB_ID=1111
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD=myservice
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CONFIG_0=tests/composefiles/docker-compose.v2.0.yml
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CONFIG_1=tests/composefiles/docker-compose.v2.1.yml
-  export BUILDKITE_PIPELINE_SLUG=test
-  export BUILDKITE_BUILD_NUMBER=1
-
-  stub docker-compose \
-    "-f tests/composefiles/docker-compose.v2.0.yml -f tests/composefiles/docker-compose.v2.1.yml -p buildkite1111 build --pull myservice : echo built myservice"
-
-  run "$PWD"/hooks/command
-
-  assert_success
-  assert_output --partial "built myservice"
-
-  unstub docker-compose
-}
-
-@test "Build with a repository and multiple services" {
-  export BUILDKITE_JOB_ID=1112
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD_0=myservice1
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD_1=myservice2
-  export BUILDKITE_PIPELINE_SLUG=test
-  export BUILDKITE_BUILD_NUMBER=1
-
-  stub docker-compose \
-    "-f docker-compose.yml -p buildkite1112 build --pull myservice1 myservice2 : echo built all services"
-
-  run "$PWD"/hooks/command
-
-  assert_success
-  assert_output --partial "built all services"
-
-  unstub docker-compose
+  unstub docker
 }
 
 @test "Build with a docker-compose v1.0 configuration file" {
@@ -214,15 +146,15 @@ teardown() {
   export BUILDKITE_PIPELINE_SLUG=test
   export BUILDKITE_BUILD_NUMBER=1
 
-  stub docker-compose \
-    "-f tests/composefiles/docker-compose.v1.0.yml -p buildkite1112 build --pull helloworld : echo built service"
+  stub docker \
+    "compose -f tests/composefiles/docker-compose.v1.0.yml -p buildkite1112 build --pull helloworld : echo built service"
 
   run "$PWD"/hooks/command
 
   assert_success
   assert_output --partial "built service"
 
-  unstub docker-compose
+  unstub docker
 }
 
 @test "Build with a cache-from image" {
@@ -233,8 +165,8 @@ teardown() {
   export BUILDKITE_PIPELINE_SLUG=test
   export BUILDKITE_BUILD_NUMBER=1
 
-  stub docker-compose \
-    "-f tests/composefiles/docker-compose.v3.2.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml build --pull helloworld : echo built helloworld"
+  stub docker \
+    "compose -f tests/composefiles/docker-compose.v3.2.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml build --pull helloworld : echo built helloworld"
 
   run "$PWD"/hooks/command
 
@@ -242,7 +174,7 @@ teardown() {
   assert_output --partial "- my.repository/myservice_cache:latest"
   assert_output --partial "built helloworld"
 
-  unstub docker-compose
+  unstub docker
 }
 
 @test "Build with a cache-from image with no-cache also set" {
@@ -254,15 +186,16 @@ teardown() {
   export BUILDKITE_PIPELINE_SLUG=test
   export BUILDKITE_BUILD_NUMBER=1
 
-  stub docker-compose \
-    "-f tests/composefiles/docker-compose.v3.2.yml -p buildkite1111 build --pull --no-cache helloworld : echo built helloworld"
+  stub docker \
+    "compose -f tests/composefiles/docker-compose.v3.2.yml -p buildkite1111 build --pull --no-cache helloworld : echo built helloworld"
 
   run "$PWD"/hooks/command
 
   assert_success
   refute_output --partial "- my.repository/myservice_cache:latest"
   assert_output --partial "built helloworld"
-  unstub docker-compose
+
+  unstub docker
 }
 
 @test "Build with an invalid cache-from tag" {
@@ -273,8 +206,8 @@ teardown() {
   export BUILDKITE_PIPELINE_SLUG=test
   export BUILDKITE_BUILD_NUMBER=1
 
-  stub docker-compose \
-    "-f tests/composefiles/docker-compose.v3.2.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml build --pull helloworld : echo built helloworld"
+  stub docker \
+    "compose -f tests/composefiles/docker-compose.v3.2.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml build --pull helloworld : echo built helloworld"
 
   run "$PWD"/hooks/command
 
@@ -282,7 +215,7 @@ teardown() {
   assert_output --partial "- my.repository/myservice_cache:-latest"
   assert_output --partial "built helloworld"
 
-  unstub docker-compose
+  unstub docker
 }
 
 @test "Build with a cache-from image with no tag" {
@@ -294,8 +227,8 @@ teardown() {
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CACHE_FROM_0=helloworld:my.repository/myservice_cache
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CONFIG="tests/composefiles/docker-compose.v3.2.yml"
 
-  stub docker-compose \
-    "-f tests/composefiles/docker-compose.v3.2.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml build --pull helloworld : echo built helloworld"
+  stub docker \
+    "compose -f tests/composefiles/docker-compose.v3.2.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml build --pull helloworld : echo built helloworld"
 
   run "$PWD"/hooks/command
 
@@ -303,7 +236,7 @@ teardown() {
   assert_output --partial "- my.repository/myservice_cache"
   assert_output --partial "built helloworld"
 
-  unstub docker-compose
+  unstub docker
 }
 
 @test "Build with several cache-from images for one service" {
@@ -315,8 +248,8 @@ teardown() {
   export BUILDKITE_PIPELINE_SLUG=test
   export BUILDKITE_BUILD_NUMBER=1
 
-  stub docker-compose \
-    "-f tests/composefiles/docker-compose.v3.2.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml build --pull helloworld : echo built helloworld"
+  stub docker \
+    "compose -f tests/composefiles/docker-compose.v3.2.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml build --pull helloworld : echo built helloworld"
 
   run "$PWD"/hooks/command
 
@@ -325,7 +258,7 @@ teardown() {
   assert_output --partial "- my.repository/myservice_cache:latest"
   assert_output --partial "built helloworld"
 
-  unstub docker-compose
+  unstub docker
 }
 
 @test "Build with a cache-from image with hyphen" {
@@ -336,8 +269,8 @@ teardown() {
   export BUILDKITE_PIPELINE_SLUG=test
   export BUILDKITE_BUILD_NUMBER=1
 
-  stub docker-compose \
-    "-f tests/composefiles/docker-compose.v3.2.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml build --pull hello-world : echo built hello-world"
+  stub docker \
+    "compose -f tests/composefiles/docker-compose.v3.2.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml build --pull hello-world : echo built hello-world"
 
   run "$PWD"/hooks/command
 
@@ -345,7 +278,7 @@ teardown() {
   assert_output --partial "- my.repository/my-service_cache:latest"
   assert_output --partial "built hello-world"
 
-  unstub docker-compose
+  unstub docker
 }
 
 @test "Build with a service name and cache-from with period" {
@@ -356,8 +289,8 @@ teardown() {
   export BUILDKITE_PIPELINE_SLUG=test
   export BUILDKITE_BUILD_NUMBER=1
 
-  stub docker-compose \
-    "-f tests/composefiles/docker-compose.v3.2.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml build --pull \* : echo built \$9"
+  stub docker \
+    "compose -f tests/composefiles/docker-compose.v3.2.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml build --pull \* : echo built \${10}}"
 
   run "$PWD"/hooks/command
 
@@ -365,7 +298,7 @@ teardown() {
   assert_output --partial "- my.repository/my-service_cache:latest"
   assert_output --partial "built hello.world"
 
-  unstub docker-compose
+  unstub docker
 }
 
 @test "Build with target" {
@@ -376,8 +309,8 @@ teardown() {
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD=myservice
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_TARGET=intermediate
 
-  stub docker-compose \
-    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml build --pull \* : echo built \${9}"
+  stub docker \
+    "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml build --pull \* : echo built \${10}"
 
   run "$PWD"/hooks/command
 
@@ -385,7 +318,7 @@ teardown() {
   assert_output --partial "built myservice"
   assert_output --partial "    target: intermediate"
 
-  unstub docker-compose
+  unstub docker
 }
 
 @test "Build with ssh option (but no buildkit)" {
@@ -395,6 +328,7 @@ teardown() {
 
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD=myservice
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_SSH=true
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILDKIT=false
 
   run "$PWD"/hooks/command
 
@@ -412,8 +346,8 @@ teardown() {
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILDKIT=true
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_SSH=true
 
-  stub docker-compose \
-    "-f docker-compose.yml -p buildkite1111 build --pull --ssh default \* : echo built \${9} with ssh"
+  stub docker \
+    "compose -f docker-compose.yml -p buildkite1111 build --pull --ssh default \* : echo built \${10} with ssh"
 
   run "$PWD"/hooks/command
 
@@ -421,7 +355,7 @@ teardown() {
   assert_output --partial "built myservice"
   assert_output --partial "with ssh"
 
-  unstub docker-compose
+  unstub docker
 }
 
 @test "Build with ssh option as string and buildkit" {
@@ -433,8 +367,8 @@ teardown() {
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILDKIT=true
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_SSH=context
 
-  stub docker-compose \
-    "-f docker-compose.yml -p buildkite1111 build --pull --ssh context \* : echo built \${9} with ssh"
+  stub docker \
+    "compose -f docker-compose.yml -p buildkite1111 build --pull --ssh context \* : echo built \${10} with ssh"
 
   run "$PWD"/hooks/command
 
@@ -442,7 +376,7 @@ teardown() {
   assert_output --partial "built myservice"
   assert_output --partial "with ssh"
 
-  unstub docker-compose
+  unstub docker
 }
 
 @test "Build with secrets" {
@@ -454,8 +388,8 @@ teardown() {
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_SECRETS_0='id=test,file=~/.test'
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_SECRETS_1='id=SECRET_VAR'
 
-  stub docker-compose \
-    "-f docker-compose.yml -p buildkite1111 build --pull --secret \* --secret \* \* : echo built \${11} with secrets \${8} and \${10}"
+  stub docker \
+    "compose -f docker-compose.yml -p buildkite1111 build --pull --secret \* --secret \* \* : echo built \${12} with secrets \${9} and \${11}"
 
   run "$PWD"/hooks/command
 
@@ -463,7 +397,7 @@ teardown() {
   assert_output --partial "built myservice"
   assert_output --partial "with secrets id=test,file=~/.test and id=SECRET_VAR"
 
-  unstub docker-compose
+  unstub docker
 }
 
 @test "Build without pull" {
@@ -473,12 +407,13 @@ teardown() {
   export BUILDKITE_PIPELINE_SLUG=test
   export BUILDKITE_BUILD_NUMBER=1
 
-  stub docker-compose \
-    "-f docker-compose.yml -p buildkite1111 build myservice : echo built myservice"
+  stub docker \
+    "compose -f docker-compose.yml -p buildkite1111 build myservice : echo built myservice"
 
   run "$PWD"/hooks/command
 
   assert_success
   assert_output --partial "built myservice"
-  unstub docker-compose
+
+  unstub docker
 }

--- a/tests/build.bats
+++ b/tests/build.bats
@@ -292,11 +292,16 @@ teardown() {
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_SSH=true
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILDKIT=false
 
+  stub docker \
+    "compose -f docker-compose.yml -p buildkite1111 build --pull --ssh default \* : echo built \${10} with ssh"
+
   run "$PWD"/hooks/command
 
-  assert_failure
-  assert_output --partial "You can not use the ssh option if you are not using buildkit"
-  refute_output --partial "built myservice"
+  assert_success
+  assert_output --partial "built myservice"
+  assert_output --partial "with ssh"
+
+  unstub docker
 }
 
 @test "Build with ssh option as true and buildkit" {

--- a/tests/cleanup.bats
+++ b/tests/cleanup.bats
@@ -16,14 +16,15 @@ load '../lib/run'
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CHECK_LINKED_CONTAINERS=false
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLEANUP=true
 
-  stub docker-compose \
-    "-f docker-compose.yml -p buildkite1111 kill : echo killing containers" \
-    "-f docker-compose.yml -p buildkite1111 rm --force -v : echo removing stopped containers" \
-    "-f docker-compose.yml -p buildkite1111 down --remove-orphans --volumes : echo removing everything"
+  stub docker \
+    "compose -f docker-compose.yml -p buildkite1111 kill : echo killing containers" \
+    "compose -f docker-compose.yml -p buildkite1111 rm --force -v : echo removing stopped containers" \
+    "compose -f docker-compose.yml -p buildkite1111 down --remove-orphans --volumes : echo removing everything"
 
   run "$PWD"/hooks/pre-exit
 
   assert_success
   assert_output --partial "Cleaning up after docker-compose"
-  unstub docker-compose
+
+  unstub docker
 }

--- a/tests/docker-compose-images.bats
+++ b/tests/docker-compose-images.bats
@@ -12,39 +12,39 @@ setup() {
 }
 
 @test "Image for compose service with an image in config" {
-  stub docker-compose \
-    "-f docker-compose.yml -p buildkite config : cat $PWD/tests/composefiles/docker-compose.config.v3.2.yml"
+  stub docker \
+    "compose -f docker-compose.yml -p buildkite config : cat $PWD/tests/composefiles/docker-compose.config.v3.2.yml"
 
   run compose_image_for_service "app"
 
   assert_success
   assert_output "somewhere.dkr.ecr.some-region.amazonaws.com/blah"
 
-  unstub docker-compose
+  unstub docker
 }
 
 @test "Image for compose service with a service with hyphens in the name" {
-  stub docker-compose \
-    "-f docker-compose.yml -p buildkite config : cat $PWD/tests/composefiles/docker-compose.config.with.hyphens.yml"
+  stub docker \
+    "compose -f docker-compose.yml -p buildkite config : cat $PWD/tests/composefiles/docker-compose.config.with.hyphens.yml"
 
   run compose_image_for_service "foo-db"
 
   assert_success
   assert_output "postgres:9.4"
 
-  unstub docker-compose
+  unstub docker
 }
 
 @test "Image for compose service without an image in config" {
-  stub docker-compose \
-    "-f docker-compose.yml -p buildkite config : cat $PWD/tests/composefiles/docker-compose.config.v3.2.yml"
+  stub docker \
+    "compose -f docker-compose.yml -p buildkite config : cat $PWD/tests/composefiles/docker-compose.config.v3.2.yml"
 
   run compose_image_for_service "helper"
 
   assert_success
   assert_output "buildkite_helper"
 
-  unstub docker-compose
+  unstub docker
 }
 
 @test "Image for compose v2 service without an image in config" {
@@ -79,13 +79,13 @@ setup() {
 @test "Image for compose service without an image in config using compatibility" {
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_COMPATIBILITY=true
 
-  stub docker-compose \
-    "--compatibility -f docker-compose.yml -p buildkite config : cat $PWD/tests/composefiles/docker-compose.config.v3.2.yml"
+  stub docker \
+    "compose --compatibility -f docker-compose.yml -p buildkite config : cat $PWD/tests/composefiles/docker-compose.config.v3.2.yml"
 
   run compose_image_for_service "helper"
 
   assert_success
   assert_output "buildkite_helper"
 
-  unstub docker-compose
+  unstub docker
 }

--- a/tests/docker-compose-images.bats
+++ b/tests/docker-compose-images.bats
@@ -42,38 +42,23 @@ setup() {
   run compose_image_for_service "helper"
 
   assert_success
-  assert_output "buildkite_helper"
-
-  unstub docker
-}
-
-@test "Image for compose v2 service without an image in config" {
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLI_VERSION=2
-
-  stub docker \
-    "compose -f docker-compose.yml -p buildkite config : cat $PWD/tests/composefiles/docker-compose.config.v3.2.yml"
-
-  run compose_image_for_service "helper"
-
-  assert_success
   assert_output "buildkite-helper"
 
   unstub docker
 }
 
-@test "Image for compose v2 service without an image in config using compatibility" {
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLI_VERSION=2
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_COMPATIBILITY=true
+@test "Image for compose v1 service without an image in config" {
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLI_VERSION=1
 
-  stub docker \
-    "compose --compatibility -f docker-compose.yml -p buildkite config : cat $PWD/tests/composefiles/docker-compose.config.v3.2.yml"
+  stub docker-compose \
+    "-f docker-compose.yml -p buildkite config : cat $PWD/tests/composefiles/docker-compose.config.v3.2.yml"
 
   run compose_image_for_service "helper"
 
   assert_success
   assert_output "buildkite_helper"
 
-  unstub docker
+  unstub docker-compose
 }
 
 @test "Image for compose service without an image in config using compatibility" {
@@ -88,4 +73,19 @@ setup() {
   assert_output "buildkite_helper"
 
   unstub docker
+}
+
+@test "Image for compose v1 service without an image in config using compatibility" {
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLI_VERSION=1
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_COMPATIBILITY=true
+
+  stub docker-compose \
+    "--compatibility -f docker-compose.yml -p buildkite config : cat $PWD/tests/composefiles/docker-compose.config.v3.2.yml"
+
+  run compose_image_for_service "helper"
+
+  assert_success
+  assert_output "buildkite_helper"
+
+  unstub docker-compose
 }

--- a/tests/docker-compose-verbosity.bats
+++ b/tests/docker-compose-verbosity.bats
@@ -7,38 +7,41 @@ load '../lib/run'
 # export DOCKER_COMPOSE_STUB_DEBUG=/dev/tty
 
 @test "docker-compose verbosity config unset" {
-  stub docker-compose \
-    "-f docker-compose.yml -p buildkite run tests : echo ran without verbose flag"
+  stub docker \
+    "compose -f docker-compose.yml -p buildkite run tests : echo ran without verbose flag"
 
   run run_docker_compose run tests
 
   assert_success
   assert_output --partial "ran without verbose flag"
-  unstub docker-compose
+
+  unstub docker
 }
 
 @test "docker-compose verbosity config set to 'true'" {
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_VERBOSE="true"
 
-  stub docker-compose \
-    "--verbose -f docker-compose.yml -p buildkite run tests : echo ran with verbose flag"
+  stub docker \
+    "compose --verbose -f docker-compose.yml -p buildkite run tests : echo ran with verbose flag"
 
   run run_docker_compose run tests
 
   assert_success
   assert_output --partial "ran with verbose flag"
-  unstub docker-compose
+
+  unstub docker
 }
 
 @test "docker-compose verbosity config set to 'false'" {
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_VERBOSE="false"
 
-  stub docker-compose \
-    "-f docker-compose.yml -p buildkite run tests : echo ran without verbose flag"
+  stub docker \
+    "compose -f docker-compose.yml -p buildkite run tests : echo ran without verbose flag"
 
   run run_docker_compose run tests
 
   assert_success
   assert_output --partial "ran without verbose flag"
-  unstub docker-compose
+
+  unstub docker
 }

--- a/tests/multiple-commands.bats
+++ b/tests/multiple-commands.bats
@@ -67,7 +67,7 @@ teardown() {
   assert_success
 
   assert_output --partial "Building services myservice"
-  assert_output --partial "Using service image buildkite12_myservice from Docker Compose config"
+  assert_output --partial "Using service image buildkite12-myservice from Docker Compose config"
   assert_output --partial "Pushing images for myservice"
 
   unstub docker
@@ -82,7 +82,7 @@ teardown() {
     "compose -f docker-compose.yml -p buildkite12 up -d --scale myservice=0 myservice : echo ran dependencies" \
     "compose -f docker-compose.yml -p buildkite12 run --name buildkite12_myservice_build_1 -T --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice" \
     "compose -f docker-compose.yml -p buildkite12 config : echo ''" \
-    "image inspect buildkite12_myservice : exit 1"
+    "image inspect \* : exit 1"
   
   # these make sure that the image is not pre-built
   stub buildkite-agent \
@@ -140,7 +140,7 @@ teardown() {
     "compose -f docker-compose.yml -p buildkite12 -f docker-compose.buildkite-1-override.yml up -d --scale myservice=0 myservice : echo ran dependencies" \
     "compose -f docker-compose.yml -p buildkite12 -f docker-compose.buildkite-1-override.yml run --name buildkite12_myservice_build_1 -T --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice" \
     "compose -f docker-compose.yml -p buildkite12 config : echo ''" \
-    "image inspect buildkite12_myservice : exit 1" \
+    "image inspect \* : exit 1" \
     "pull myservice-tag : echo pulled pre-built image" \
     "compose -f docker-compose.yml -p buildkite12 push myservice : echo pushed myservice"
   

--- a/tests/multiple-commands.bats
+++ b/tests/multiple-commands.bats
@@ -5,7 +5,6 @@ load '../lib/shared'
 load '../lib/metadata'
 
 # export DOCKER_STUB_DEBUG=/dev/tty
-# export DOCKER_COMPOSE_STUB_DEBUG=/dev/tty
 # export BUILDKITE_AGENT_STUB_DEBUG=/dev/tty
 # export BATS_MOCK_TMPDIR=$PWD
 
@@ -30,10 +29,10 @@ teardown() {
   # necessary for build
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_IMAGE_REPOSITORY=my.repository/llamas
 
-  stub docker-compose \
-    "-f docker-compose.yml -p buildkite12 build --pull myservice : echo built myservice" \
-    "-f docker-compose.yml -p buildkite12 up -d --scale myservice=0 myservice : echo ran dependencies" \
-    "-f docker-compose.yml -p buildkite12 run --name buildkite12_myservice_build_1 -T --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice"
+  stub docker \
+    "compose -f docker-compose.yml -p buildkite12 build --pull myservice : echo built myservice" \
+    "compose -f docker-compose.yml -p buildkite12 up -d --scale myservice=0 myservice : echo ran dependencies" \
+    "compose -f docker-compose.yml -p buildkite12 run --name buildkite12_myservice_build_1 -T --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : test -f /tmp/build-run-metadata"
@@ -45,7 +44,7 @@ teardown() {
   assert_output --partial "Starting dependencies"
   assert_output --partial "ran myservice" 
 
-  unstub docker-compose
+  unstub docker
   unstub buildkite-agent
 }
 
@@ -56,17 +55,15 @@ teardown() {
   # necessary for build
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_IMAGE_REPOSITORY=my.repository/llamas
 
-  stub docker-compose \
-    "-f docker-compose.yml -p buildkite12 build --pull myservice : echo built myservice" \
-    "-f docker-compose.yml -p buildkite12 config : echo ''" \
-    "-f docker-compose.yml -p buildkite12 push myservice : echo pushed myservice"
+  stub docker \
+    "compose -f docker-compose.yml -p buildkite12 build --pull myservice : echo built myservice" \
+    "compose -f docker-compose.yml -p buildkite12 config : echo ''" \
+    "image inspect buildkite12_myservice : echo existing-image" \
+    "compose -f docker-compose.yml -p buildkite12 push myservice : echo pushed myservice"
   
   # these commands simulate metadata for a specific value by using an intermediate-file
   stub buildkite-agent \
      "meta-data set docker-compose-plugin-built-image-tag-myservice \* : echo \$4 > /tmp/build-push-metadata"
-
-  stub docker \
-     "image inspect buildkite12_myservice : echo existing-image"
 
   run "$PWD"/hooks/command
 
@@ -77,7 +74,6 @@ teardown() {
   assert_output --partial "Pushing images for myservice"
 
   unstub docker
-  unstub docker-compose
   unstub buildkite-agent
 }
 
@@ -85,10 +81,11 @@ teardown() {
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RUN=myservice
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_PUSH=myservice
 
-  stub docker-compose \
-    "-f docker-compose.yml -p buildkite12 up -d --scale myservice=0 myservice : echo ran dependencies" \
-    "-f docker-compose.yml -p buildkite12 run --name buildkite12_myservice_build_1 -T --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice" \
-    "-f docker-compose.yml -p buildkite12 config : echo ''" 
+  stub docker \
+    "compose -f docker-compose.yml -p buildkite12 up -d --scale myservice=0 myservice : echo ran dependencies" \
+    "compose -f docker-compose.yml -p buildkite12 run --name buildkite12_myservice_build_1 -T --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice" \
+    "compose -f docker-compose.yml -p buildkite12 config : echo ''" \
+    "image inspect buildkite12_myservice : exit 1"
   
   # these make sure that the image is not pre-built
   stub buildkite-agent \
@@ -104,7 +101,7 @@ teardown() {
   assert_output --partial "ran myservice" 
   assert_output --partial "No prebuilt-image nor service image found for service to push"
 
-  unstub docker-compose
+  unstub docker
   unstub buildkite-agent
 }
 
@@ -112,14 +109,12 @@ teardown() {
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RUN=myservice
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_PUSH=myservice
 
-  stub docker-compose \
-    "-f docker-compose.yml -p buildkite12 up -d --scale myservice=0 myservice : echo ran dependencies" \
-    "-f docker-compose.yml -p buildkite12 run --name buildkite12_myservice_build_1 -T --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice" \
-    "-f docker-compose.yml -p buildkite12 config : echo ''" \
-    "-f docker-compose.yml -p buildkite12 push myservice : echo pushed myservice"
-     
   stub docker \
-    "image inspect \* : echo found image \$3"
+    "compose -f docker-compose.yml -p buildkite12 up -d --scale myservice=0 myservice : echo ran dependencies" \
+    "compose -f docker-compose.yml -p buildkite12 run --name buildkite12_myservice_build_1 -T --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice" \
+    "compose -f docker-compose.yml -p buildkite12 config : echo ''" \
+    "image inspect \* : echo found image \$3" \
+    "compose -f docker-compose.yml -p buildkite12 push myservice : echo pushed myservice"
 
   # these make sure that the image is not pre-built
   stub buildkite-agent \
@@ -136,7 +131,6 @@ teardown() {
   assert_output --partial "Using service image"
 
   unstub docker
-  unstub docker-compose
   unstub buildkite-agent
 }
 
@@ -144,12 +138,14 @@ teardown() {
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RUN=myservice
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_PUSH=myservice
 
-  stub docker-compose \
-    "-f docker-compose.yml -p buildkite12 -f docker-compose.buildkite-1-override.yml pull myservice : echo pulled myservice" \
-    "-f docker-compose.yml -p buildkite12 -f docker-compose.buildkite-1-override.yml up -d --scale myservice=0 myservice : echo ran dependencies" \
-    "-f docker-compose.yml -p buildkite12 -f docker-compose.buildkite-1-override.yml run --name buildkite12_myservice_build_1 -T --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice" \
-    "-f docker-compose.yml -p buildkite12 config : echo ''" \
-    "-f docker-compose.yml -p buildkite12 push myservice : echo pushed myservice"
+  stub docker \
+    "compose -f docker-compose.yml -p buildkite12 -f docker-compose.buildkite-1-override.yml pull myservice : echo pulled myservice" \
+    "compose -f docker-compose.yml -p buildkite12 -f docker-compose.buildkite-1-override.yml up -d --scale myservice=0 myservice : echo ran dependencies" \
+    "compose -f docker-compose.yml -p buildkite12 -f docker-compose.buildkite-1-override.yml run --name buildkite12_myservice_build_1 -T --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice" \
+    "compose -f docker-compose.yml -p buildkite12 config : echo ''" \
+    "image inspect buildkite12_myservice : exit 1" \
+    "pull myservice-tag : echo pulled pre-built image" \
+    "compose -f docker-compose.yml -p buildkite12 push myservice : echo pushed myservice"
   
   # these make sure that the image is not pre-built
   stub buildkite-agent \
@@ -158,10 +154,6 @@ teardown() {
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 0" \
     "meta-data get docker-compose-plugin-built-image-tag-myservice : echo myservice-tag" \
     "meta-data set docker-compose-plugin-built-image-tag-myservice \* : set pre-built image metadata to \$4"
-
-  stub docker \
-    "image inspect buildkite12_myservice : exit 1" \
-    "pull myservice-tag : echo pulled pre-built image"
 
   run "$PWD"/hooks/command
 
@@ -175,6 +167,5 @@ teardown() {
   assert_output --partial "Pushing images for myservice" 
 
   unstub docker
-  unstub docker-compose
   unstub buildkite-agent
 }

--- a/tests/multiple-commands.bats
+++ b/tests/multiple-commands.bats
@@ -52,18 +52,15 @@ teardown() {
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD=myservice
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_PUSH=myservice
 
-  # necessary for build
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_IMAGE_REPOSITORY=my.repository/llamas
-
   stub docker \
     "compose -f docker-compose.yml -p buildkite12 build --pull myservice : echo built myservice" \
     "compose -f docker-compose.yml -p buildkite12 config : echo ''" \
-    "image inspect buildkite12_myservice : echo existing-image" \
+    "image inspect \* : echo existing-image" \
     "compose -f docker-compose.yml -p buildkite12 push myservice : echo pushed myservice"
-  
+
   # these commands simulate metadata for a specific value by using an intermediate-file
   stub buildkite-agent \
-     "meta-data set docker-compose-plugin-built-image-tag-myservice \* : echo \$4 > /tmp/build-push-metadata"
+    "meta-data set docker-compose-plugin-built-image-tag-myservice \* : echo \$4 > /tmp/build-push-metadata"
 
   run "$PWD"/hooks/command
 

--- a/tests/output.bats
+++ b/tests/output.bats
@@ -30,11 +30,9 @@ setup_file() {
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 1" \
     "artifact upload docker-compose-logs/\*.log : exit 0"
 
-  stub docker-compose \
-    "-f docker-compose.yml -p buildkite1111 up -d --scale myservice=0 myservice : echo ran myservice dependencies" \
-    "-f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 -T --rm myservice echo 'hello world' : echo ran myservice command"
-
   stub docker \
+    "compose -f docker-compose.yml -p buildkite1111 up -d --scale myservice=0 myservice : echo ran myservice dependencies" \
+    "compose -f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 -T --rm myservice echo 'hello world' : echo ran myservice command" \
     "ps -a --filter label=com.docker.compose.project=buildkite1111 -q : cat tests/fixtures/id-multiple-services.txt" \
     "inspect -f {{if\ ne\ 0\ .State.ExitCode}}{{.Name}}.{{.State.ExitCode}}{{\ end\ }} 456456 789789 : echo 456456.1" \
     "ps -a --filter label=com.docker.compose.project=buildkite1111 --format \* : cat tests/fixtures/service-id-exit-multiple-services-failed.txt" \
@@ -50,8 +48,8 @@ setup_file() {
   assert_output --partial "ran myservice dependencies"
   assert_output --partial "ran myservice command"
   assert_output --partial "Some containers had non-zero exit codes"
+
   unstub buildkite-agent
-  unstub docker-compose
   unstub docker
 }
 
@@ -73,10 +71,8 @@ setup_file() {
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 1" \
     "artifact upload docker-compose-logs/\*.log : exit 0"
 
-  stub docker-compose \
-    "-f docker-compose.yml -p buildkite1111 up -d --scale myservice=0 myservice : exit 1" \
-
   stub docker \
+    "compose -f docker-compose.yml -p buildkite1111 up -d --scale myservice=0 myservice : exit 1" \
     "ps -a --filter label=com.docker.compose.project=buildkite1111 -q : cat tests/fixtures/id-multiple-services.txt" \
     "inspect -f {{if\ ne\ 0\ .State.ExitCode}}{{.Name}}.{{.State.ExitCode}}{{\ end\ }} 456456 789789 : echo 456456.1" \
     "ps -a --filter label=com.docker.compose.project=buildkite1111 --format \* : cat tests/fixtures/service-id-exit-multiple-services-failed.txt" \
@@ -91,8 +87,8 @@ setup_file() {
   assert_failure
   assert_output --partial "Failed to start dependencies"
   assert_output --partial "Some containers had non-zero exit codes"
+
   unstub buildkite-agent
-  unstub docker-compose
   unstub docker
 }
 
@@ -112,11 +108,9 @@ setup_file() {
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 1" \
 
-  stub docker-compose \
-    "-f docker-compose.yml -p buildkite1111 up -d --scale myservice=0 myservice : echo ran myservice dependencies" \
-    "-f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 -T --rm myservice echo 'hello world' : echo ran myservice command"
-
   stub docker \
+    "compose -f docker-compose.yml -p buildkite1111 up -d --scale myservice=0 myservice : echo ran myservice dependencies" \
+    "compose -f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 -T --rm myservice echo 'hello world' : echo ran myservice command" \
     "ps -a --filter label=com.docker.compose.project=buildkite1111 -q : cat tests/fixtures/id-multiple-services.txt" \
     "inspect -f {{if\ ne\ 0\ .State.ExitCode}}{{.Name}}.{{.State.ExitCode}}{{\ end\ }} 456456 789789 : echo" \
     "ps -a --filter label=com.docker.compose.project=buildkite1111 --format \* : cat tests/fixtures/id-service-multiple-services.txt" \
@@ -129,8 +123,8 @@ setup_file() {
   assert_output --partial "ran myservice dependencies"
   assert_output --partial "ran myservice command"
   refute_output --partial "Some containers had non-zero exit codes"
+
   unstub docker
-  unstub docker-compose
   unstub buildkite-agent
 }
 
@@ -153,11 +147,9 @@ setup_file() {
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 1" \
 
-  stub docker-compose \
-    "-f docker-compose.yml -p buildkite1111 up -d --scale myservice=0 myservice : echo ran myservice dependencies" \
-    "-f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 -T --rm myservice echo 'hello world' : echo ran myservice command"
-
   stub docker \
+    "compose -f docker-compose.yml -p buildkite1111 up -d --scale myservice=0 myservice : echo ran myservice dependencies" \
+    "compose -f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 -T --rm myservice echo 'hello world' : echo ran myservice command" \
     "ps -a --filter label=com.docker.compose.project=buildkite1111 -q : echo" \
     "ps -a --filter label=com.docker.compose.project=buildkite1111 --format '{{.ID}}\\t{{.Label \"com.docker.compose.service\"}}' : cat tests/fixtures/id-service-no-services.txt"
 
@@ -167,7 +159,7 @@ setup_file() {
   assert_output --partial "ran myservice dependencies"
   assert_output --partial "ran myservice command"
   refute_output --partial "Uploading linked container logs"
+
   unstub docker
-  unstub docker-compose
   unstub buildkite-agent
 }

--- a/tests/plugin-config.bats
+++ b/tests/plugin-config.bats
@@ -1,7 +1,7 @@
 #!/usr/bin/env bats
 
 load "${BATS_PLUGIN_PATH}/load.bash"
-load '../lib/shared'
+load '../lib/shared.bash'
 
 @test "Read existing config without default" {
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RUN=llamas

--- a/tests/project-name.bats
+++ b/tests/project-name.bats
@@ -1,7 +1,7 @@
 #!/usr/bin/env bats
 
 load "${BATS_PLUGIN_PATH}/load.bash"
-load '../lib/shared'
+load '../lib/shared.bash'
 
 @test "Project name comes from BUILDKITE_JOB_ID" {
   export BUILDKITE_JOB_ID=11111-1111-11111-11111

--- a/tests/push.bats
+++ b/tests/push.bats
@@ -1,9 +1,8 @@
 #!/usr/bin/env bats
 
 load "${BATS_PLUGIN_PATH}/load.bash"
-load '../lib/shared'
+load '../lib/shared.bash'
 
-# export DOCKER_COMPOSE_STUB_DEBUG=/dev/tty
 # export DOCKER_STUB_DEBUG=/dev/tty
 # export BUILDKITE_AGENT_STUB_DEBUG=/dev/tty
 # export BATS_MOCK_TMPDIR=$PWD
@@ -15,23 +14,20 @@ load '../lib/shared'
   export BUILDKITE_BUILD_NUMBER=1
 
   stub buildkite-agent \
-    "meta-data set docker-compose-plugin-built-image-tag-app \* : echo setting metadata to \$4"
-
-  stub docker-compose \
-    "-f docker-compose.yml -p buildkite1111 config : cat ${PWD}/tests/composefiles/docker-compose.config.v3.2.yml" \
-    "-f docker-compose.yml -p buildkite1111 push app : echo pushed app"
+    "meta-data set docker-compose-plugin-built-image-tag-app \* : echo tagged \$4"
 
   stub docker \
-    "image inspect \* : exit 0"
+    "compose -f docker-compose.yml -p buildkite1111 config : cat $PWD/tests/composefiles/docker-compose.config.v3.2.yml" \
+    "image inspect somewhere.dkr.ecr.some-region.amazonaws.com/blah : exit 0" \
+    "compose -f docker-compose.yml -p buildkite1111 push app : echo pushed app"
 
   run "$PWD"/hooks/command
 
   assert_success
   assert_output --partial "pushed app"
 
-  unstub docker-compose
-  unstub buildkite-agent
   unstub docker
+  unstub buildkite-agent
 }
 
 @test "Push a prebuilt image with a repository and a tag" {
@@ -41,18 +37,16 @@ load '../lib/shared'
   export BUILDKITE_BUILD_NUMBER=1
 
   stub docker \
+    "compose -f docker-compose.yml -p buildkite1111 config : echo ''" \
     "image inspect \* : exit 1" \
     "pull myimage : echo pulled prebuilt image" \
     "tag myimage my.repository/myservice:llamas : echo tagged image" \
     "push my.repository/myservice:llamas : echo pushed myservice"
 
-  stub docker-compose \
-    "-f docker-compose.yml -p buildkite1111 config : echo ''"
-
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 0" \
     "meta-data get docker-compose-plugin-built-image-tag-myservice : echo myimage" \
-    "meta-data set docker-compose-plugin-built-image-tag-myservice \* : echo \$4 > ${BATS_TEST_TMPDIR}/build-push-metadata"
+    "meta-data set docker-compose-plugin-built-image-tag-myservice \* : echo tagged \$4"
 
   run "$PWD"/hooks/command
 
@@ -61,7 +55,37 @@ load '../lib/shared'
   assert_output --partial "tagged image"
   assert_output --partial "pushed myservice"
 
-  unstub docker-compose
+  unstub docker
+  unstub buildkite-agent
+}
+
+@test "Push a prebuilt image with a repository and a tag in compatibility mode" {
+  export BUILDKITE_BUILD_NUMBER=1
+  export BUILDKITE_JOB_ID=1111
+  export BUILDKITE_PIPELINE_SLUG=test
+
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_PUSH=myservice:my.repository/myservice:llamas
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_COMPATIBILITY=true
+
+  stub docker \
+    "compose --compatibility -f docker-compose.yml -p buildkite1111 config : echo blah" \
+    "image inspect \* : exit 1" \
+    "pull myimage : echo pulled prebuilt image" \
+    "tag myimage my.repository/myservice:llamas : echo tagged image" \
+    "push my.repository/myservice:llamas : echo pushed myservice"
+
+  stub buildkite-agent \
+    "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 0" \
+    "meta-data get docker-compose-plugin-built-image-tag-myservice : echo myimage" \
+    "meta-data set docker-compose-plugin-built-image-tag-myservice \* : echo tagged \$4"
+
+  run "$PWD"/hooks/command
+
+  assert_success
+  assert_output --partial "pulled prebuilt image"
+  assert_output --partial "tagged image"
+  assert_output --partial "pushed myservice"
+
   unstub docker
   unstub buildkite-agent
 }
@@ -72,28 +96,23 @@ load '../lib/shared'
   export BUILDKITE_PIPELINE_SLUG=test
   export BUILDKITE_BUILD_NUMBER=1
 
-
   stub docker \
+    "compose -f docker-compose.yml -p buildkite1111 config : echo blah" \
     "image inspect \* : exit 1" \
-    "pull prebuilt : echo 'pulled prebuilt image'" \
-    "tag prebuilt \* : echo 'invalid tag'; exit 1"
-
-  stub docker-compose \
-    "-f docker-compose.yml -p buildkite1111 config : echo ''"
+    "pull myimage : echo pulled prebuilt image" \
+    "tag myimage my.repository/myservice:-llamas : exit 1" \
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 0" \
-    "meta-data get docker-compose-plugin-built-image-tag-myservice : echo prebuilt" \
+    "meta-data get docker-compose-plugin-built-image-tag-myservice : echo myimage"
 
   run "$PWD"/hooks/command
 
   assert_failure
   assert_output --partial "Pulling pre-built service"
   refute_output --partial "tagged image"
-  assert_output --partial "invalid tag"
 
   unstub docker
-  unstub docker-compose
   unstub buildkite-agent
 }
 
@@ -106,32 +125,30 @@ load '../lib/shared'
   export BUILDKITE_BUILD_NUMBER=1
 
   stub docker \
+    "compose -f docker-compose.yml -p buildkite1111 config : echo blah" \
     "image inspect \* : exit 1" \
     "pull prebuilt : echo pulled prebuilt image" \
     "tag prebuilt my.repository/myservice:llamas : echo tagged image1" \
     "push my.repository/myservice:llamas : echo pushed myservice1" \
+    "compose -f docker-compose.yml -p buildkite1111 config : echo blah" \
     "image inspect \* : exit 1" \
-    "tag prebuilt my.repository/myservice:latest : echo tagged image2" \
+    "tag prebuilt2 my.repository/myservice:latest : echo tagged image2" \
     "push my.repository/myservice:latest : echo pushed myservice2" \
+    "compose -f docker-compose.yml -p buildkite1111 config : echo blah" \
     "image inspect \* : exit 1" \
-    "tag prebuilt my.repository/myservice:alpacas : echo tagged image3" \
+    "tag prebuilt3 my.repository/myservice:alpacas : echo tagged image3" \
     "push my.repository/myservice:alpacas : echo pushed myservice3"
-
-  stub docker-compose \
-    "-f docker-compose.yml -p buildkite1111 config : echo ''" \
-    "-f docker-compose.yml -p buildkite1111 config : echo ''" \
-    "-f docker-compose.yml -p buildkite1111 config : echo ''"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 0" \
     "meta-data get docker-compose-plugin-built-image-tag-myservice : echo prebuilt" \
-    "meta-data set docker-compose-plugin-built-image-tag-myservice \* : echo \$4" \
+    "meta-data set docker-compose-plugin-built-image-tag-myservice \* : echo tagged \$4" \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 0" \
-    "meta-data get docker-compose-plugin-built-image-tag-myservice : echo prebuilt" \
-    "meta-data set docker-compose-plugin-built-image-tag-myservice \* : echo \$4" \
+    "meta-data get docker-compose-plugin-built-image-tag-myservice : echo prebuilt2" \
+    "meta-data set docker-compose-plugin-built-image-tag-myservice \* : echo tagged \$4" \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 0" \
-    "meta-data get docker-compose-plugin-built-image-tag-myservice : echo prebuilt" \
-    "meta-data set docker-compose-plugin-built-image-tag-myservice \* : echo \$4" \
+    "meta-data get docker-compose-plugin-built-image-tag-myservice : echo prebuilt3" \
+    "meta-data set docker-compose-plugin-built-image-tag-myservice \* : echo tagged \$4"
 
   run "$PWD"/hooks/command
 
@@ -144,12 +161,36 @@ load '../lib/shared'
   assert_output --partial "tagged image3"
   assert_output --partial "pushed myservice3"
 
-  unstub docker-compose
   unstub docker
   unstub buildkite-agent
 }
 
-@test "Push a single service without pre-built nor service image" {
+@test "Push a single service with service image" {
+  export BUILDKITE_JOB_ID=1111
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_PUSH=helper:my.repository/helper:llamas
+  export BUILDKITE_PIPELINE_SLUG=test
+  export BUILDKITE_BUILD_NUMBER=1
+
+  stub buildkite-agent \
+    "meta-data set docker-compose-plugin-built-image-tag-helper \* : echo tagged \$4"
+
+  stub docker \
+    "compose -f docker-compose.yml -p buildkite1111 config : cat $PWD/tests/composefiles/docker-compose.config.v3.2.yml" \
+    "image inspect buildkite1111_helper : exit 0" \
+    "tag buildkite1111_helper my.repository/helper:llamas : echo tagged helper" \
+    "push my.repository/helper:llamas : echo pushed helper"
+
+  run "$PWD"/hooks/command
+
+  assert_success
+  assert_output --partial "tagged helper"
+  assert_output --partial "pushed helper"
+
+  unstub docker
+  unstub buildkite-agent
+}
+
+@test "Push a single service without prebuilt nor service image" {
   export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_PUSH=helper:my.repository/helper:llamas
   export BUILDKITE_PIPELINE_SLUG=test
@@ -158,78 +199,45 @@ load '../lib/shared'
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-helper : exit 1"
 
-  stub docker-compose \
-    "-f docker-compose.yml -p buildkite1111 config : echo ''"
-
   stub docker \
-    "image inspect \* : exit 1"
+    "compose -f docker-compose.yml -p buildkite1111 config : cat $PWD/tests/composefiles/docker-compose.config.v3.2.yml" \
+    "image inspect buildkite1111_helper : exit 1" 
 
   run "$PWD"/hooks/command
 
   assert_failure
-
   assert_output --partial 'No prebuilt-image nor service image found for service to push'
 
-  unstub docker-compose
   unstub docker
   unstub buildkite-agent
 }
 
-@test "Push two services without pre-built nor service image (second one is never tried)" {
+@test "Push two services with pre-built images" {
   export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_PUSH_0=myservice1:my.repository/myservice1
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_PUSH_1=myservice2:my.repository/myservice2:llamas
   export BUILDKITE_PIPELINE_SLUG=test
   export BUILDKITE_BUILD_NUMBER=1
 
-  stub docker-compose \
-    "-f docker-compose.yml -p buildkite1111 config : echo ''"
-
   stub docker \
-    "image inspect \* : exit 1"
-
-  stub buildkite-agent \
-    "meta-data exists docker-compose-plugin-built-image-tag-myservice1 : exit 1"
-
-  run "$PWD"/hooks/command
-
-  assert_failure
-
-  assert_output --partial 'No prebuilt-image nor service image found for service to push'
-
-  unstub docker-compose
-  unstub buildkite-agent
-  unstub docker
-}
-
-@test "Push two pre-built services with target repositories and tags" {
-  export BUILDKITE_JOB_ID=1111
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_PUSH_0=myservice1:my.repository/myservice1
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_PUSH_1=myservice2:my.repository/myservice2:llamas
-  export BUILDKITE_PIPELINE_SLUG=test
-  export BUILDKITE_BUILD_NUMBER=1
-
-  stub docker-compose \
-    "-f docker-compose.yml -p buildkite1111 config : echo ''" \
-    "-f docker-compose.yml -p buildkite1111 config : echo ''" \
-
-  stub docker \
-    "image inspect \* : exit 1" \
-    "pull myservice1 : exit 0" \
-    "tag myservice1 my.repository/myservice1 : echo tagging image1" \
+    "compose -f docker-compose.yml -p buildkite1111 config : echo blah " \
+    "image inspect buildkite1111_myservice1 : exit 1" \
+    "pull prebuilt1 : exit 0" \
+    "tag prebuilt1 my.repository/myservice1 : echo tagging image1" \
     "push my.repository/myservice1 : echo pushing myservice1 image" \
-    "image inspect \* : exit 1" \
-    "pull myservice2 : exit 0" \
-    "tag myservice2 my.repository/myservice2:llamas : echo tagging image2" \
+    "compose -f docker-compose.yml -p buildkite1111 config : echo blah " \
+    "image inspect buildkite1111_myservice2 : exit 1" \
+    "pull prebuilt2 : exit 0" \
+    "tag prebuilt2 my.repository/myservice2:llamas : echo tagging image2" \
     "push my.repository/myservice2:llamas : echo pushing myservice2 image"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice1 : exit 0" \
-    "meta-data get docker-compose-plugin-built-image-tag-myservice1 : echo myservice1" \
-    "meta-data set docker-compose-plugin-built-image-tag-myservice1 \* : echo \$4" \
+    "meta-data get docker-compose-plugin-built-image-tag-myservice1 : echo prebuilt1" \
+    "meta-data set docker-compose-plugin-built-image-tag-myservice1 \* : echo tagged \$4" \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice2 : exit 0" \
-    "meta-data get docker-compose-plugin-built-image-tag-myservice2 : echo myservice2" \
-    "meta-data set docker-compose-plugin-built-image-tag-myservice2 \* : echo \$4" \
+    "meta-data get docker-compose-plugin-built-image-tag-myservice2 : echo prebuilt2" \
+    "meta-data set docker-compose-plugin-built-image-tag-myservice2 \* : echo tagged \$4"
 
   run "$PWD"/hooks/command
 
@@ -239,7 +247,6 @@ load '../lib/shared'
   assert_output --partial "tagging image2"
   assert_output --partial "pushing myservice2 image"
 
-  unstub docker-compose
-  unstub buildkite-agent
   unstub docker
+  unstub buildkite-agent
 }

--- a/tests/push.bats
+++ b/tests/push.bats
@@ -176,8 +176,8 @@ load '../lib/shared.bash'
 
   stub docker \
     "compose -f docker-compose.yml -p buildkite1111 config : cat $PWD/tests/composefiles/docker-compose.config.v3.2.yml" \
-    "image inspect buildkite1111_helper : exit 0" \
-    "tag buildkite1111_helper my.repository/helper:llamas : echo tagged helper" \
+    "image inspect buildkite1111-helper : exit 0" \
+    "tag buildkite1111-helper my.repository/helper:llamas : echo tagged helper" \
     "push my.repository/helper:llamas : echo pushed helper"
 
   run "$PWD"/hooks/command
@@ -201,7 +201,7 @@ load '../lib/shared.bash'
 
   stub docker \
     "compose -f docker-compose.yml -p buildkite1111 config : cat $PWD/tests/composefiles/docker-compose.config.v3.2.yml" \
-    "image inspect buildkite1111_helper : exit 1" 
+    "image inspect buildkite1111-helper : exit 1" 
 
   run "$PWD"/hooks/command
 
@@ -221,12 +221,12 @@ load '../lib/shared.bash'
 
   stub docker \
     "compose -f docker-compose.yml -p buildkite1111 config : echo blah " \
-    "image inspect buildkite1111_myservice1 : exit 1" \
+    "image inspect buildkite1111-myservice1 : exit 1" \
     "pull prebuilt1 : exit 0" \
     "tag prebuilt1 my.repository/myservice1 : echo tagging image1" \
     "push my.repository/myservice1 : echo pushing myservice1 image" \
     "compose -f docker-compose.yml -p buildkite1111 config : echo blah " \
-    "image inspect buildkite1111_myservice2 : exit 1" \
+    "image inspect buildkite1111-myservice2 : exit 1" \
     "pull prebuilt2 : exit 0" \
     "tag prebuilt2 my.repository/myservice2:llamas : echo tagging image2" \
     "push my.repository/myservice2:llamas : echo pushing myservice2 image"

--- a/tests/run.bats
+++ b/tests/run.bats
@@ -26,9 +26,9 @@ teardown() {
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CHECK_LINKED_CONTAINERS=false
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLEANUP=false
 
-  stub docker-compose \
-    "-f docker-compose.yml -p buildkite1111 up -d --scale myservice=0 myservice : echo ran myservice dependencies" \
-    "-f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 -T --rm myservice /bin/sh -e -c 'echo hello world' : echo ran myservice"
+  stub docker \
+    "compose -f docker-compose.yml -p buildkite1111 up -d --scale myservice=0 myservice : echo ran myservice dependencies" \
+    "compose -f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 --rm myservice /bin/sh -e -c 'echo hello world' : echo ran myservice"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 1"
@@ -37,7 +37,8 @@ teardown() {
 
   assert_success
   assert_output --partial "ran myservice"
-  unstub docker-compose
+
+  unstub docker
   unstub buildkite-agent
 }
 
@@ -50,9 +51,9 @@ teardown() {
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CHECK_LINKED_CONTAINERS=false
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLEANUP=false
 
-  stub docker-compose \
-    "-f docker-compose.yml -p buildkite1111 up -d --scale myservice=0 myservice : echo ran myservice dependencies" \
-    "-f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 -T --rm myservice : echo ran myservice"
+  stub docker \
+    "compose -f docker-compose.yml -p buildkite1111 up -d --scale myservice=0 myservice : echo ran myservice dependencies" \
+    "compose -f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 --rm myservice : echo ran myservice"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 1"
@@ -60,9 +61,9 @@ teardown() {
   run "$PWD"/hooks/command
 
   assert_success
-  refute_output --partial "The Docker Compose Plugin does not correctly support step-level array commands"
   assert_output --partial "ran myservice"
-  unstub docker-compose
+
+  unstub docker
   unstub buildkite-agent
 }
 
@@ -76,9 +77,9 @@ teardown() {
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CHECK_LINKED_CONTAINERS=false
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLEANUP=false
 
-  stub docker-compose \
-    "-f docker-compose.yml -p buildkite1111 up -d --scale myservice=0 myservice : echo ran myservice dependencies" \
-    "-f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 -T --workdir=/test_workdir --rm myservice : echo ran myservice"
+  stub docker \
+    "compose -f docker-compose.yml -p buildkite1111 up -d --scale myservice=0 myservice : echo ran myservice dependencies" \
+    "compose -f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 --workdir=/test_workdir --rm myservice : echo ran myservice"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 1"
@@ -87,7 +88,8 @@ teardown() {
 
   assert_success
   assert_output --partial "ran myservice"
-  unstub docker-compose
+
+  unstub docker
   unstub buildkite-agent
 }
 
@@ -100,9 +102,9 @@ teardown() {
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CHECK_LINKED_CONTAINERS=false
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLEANUP=false
 
-  stub docker-compose \
-    "-f docker-compose.yml -p buildkite1111 up -d --scale myservice=0 myservice : echo ran myservice dependencies" \
-    "-f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 -T --rm myservice /bin/sh -e -c $'sh -c \'echo hello world\'' : echo ran myservice"
+  stub docker \
+    "compose -f docker-compose.yml -p buildkite1111 up -d --scale myservice=0 myservice : echo ran myservice dependencies" \
+    "compose -f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 --rm myservice /bin/sh -e -c $'sh -c \'echo hello world\'' : echo ran myservice"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 1"
@@ -111,7 +113,8 @@ teardown() {
 
   assert_success
   assert_output --partial "ran myservice"
-  unstub docker-compose
+
+  unstub docker
   unstub buildkite-agent
 }
 
@@ -126,9 +129,9 @@ cmd3"
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CHECK_LINKED_CONTAINERS=false
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLEANUP=false
 
-  stub docker-compose \
-    "-f docker-compose.yml -p buildkite1111 up -d --scale myservice=0 myservice : echo ran myservice dependencies" \
-    "-f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 -T --rm myservice /bin/sh -e -c $'cmd1\ncmd2\ncmd3' : echo ran myservice"
+  stub docker \
+    "compose -f docker-compose.yml -p buildkite1111 up -d --scale myservice=0 myservice : echo ran myservice dependencies" \
+    "compose -f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 --rm myservice /bin/sh -e -c $'cmd1\ncmd2\ncmd3' : echo ran myservice"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 1"
@@ -136,9 +139,9 @@ cmd3"
   run "$PWD"/hooks/command
 
   assert_success
-  assert_output --partial "The Docker Compose Plugin does not correctly support step-level array commands"
   assert_output --partial "ran myservice"
-  unstub docker-compose
+
+  unstub docker
   unstub buildkite-agent
 }
 
@@ -153,9 +156,9 @@ cmd3"
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CHECK_LINKED_CONTAINERS=false
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLEANUP=false
 
-  stub docker-compose \
-    "-f docker-compose.yml -p buildkite1111 up -d --scale myservice=0 myservice : echo ran myservice dependencies" \
-    "-f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 -T --rm myservice echo 'hello world' : echo ran myservice"
+  stub docker \
+    "compose -f docker-compose.yml -p buildkite1111 up -d --scale myservice=0 myservice : echo ran myservice dependencies" \
+    "compose -f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 --rm myservice echo 'hello world' : echo ran myservice"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 1"
@@ -163,9 +166,9 @@ cmd3"
   run "$PWD"/hooks/command
 
   assert_success
-  refute_output --partial "The Docker Compose Plugin does not correctly support step-level array commands"
   assert_output --partial "ran myservice"
-  unstub docker-compose
+
+  unstub docker
   unstub buildkite-agent
 }
 
@@ -183,9 +186,9 @@ cmd3"
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_ENVIRONMENT_1=MYENV
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_ENVIRONMENT_2=ANOTHER="this is a long string with spaces; and semi-colons"
 
-  stub docker-compose \
-    "-f docker-compose.yml -p buildkite1111 up -d --scale myservice=0 myservice : echo ran myservice dependencies" \
-    "-f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 -e MYENV=0 -e MYENV -e MYENV=2 -e MYENV -e ANOTHER=this\ is\ a\ long\ string\ with\ spaces\;\ and\ semi-colons -T --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice"
+  stub docker \
+    "compose -f docker-compose.yml -p buildkite1111 up -d --scale myservice=0 myservice : echo ran myservice dependencies" \
+    "compose -f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 -e MYENV=0 -e MYENV -e MYENV=2 -e MYENV -e ANOTHER=this\ is\ a\ long\ string\ with\ spaces\;\ and\ semi-colons --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 1"
@@ -194,7 +197,8 @@ cmd3"
 
   assert_success
   assert_output --partial "ran myservice"
-  unstub docker-compose
+
+  unstub docker
   unstub buildkite-agent
 }
 
@@ -208,9 +212,9 @@ cmd3"
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CHECK_LINKED_CONTAINERS=false
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLEANUP=false
 
-  stub docker-compose \
-    "-f docker-compose.yml -p buildkite1111 up -d --scale myservice=0 myservice : echo ran myservice dependencies" \
-    "-f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 -T --rm myservice /bin/sh -e -c 'echo hello world' : echo ran myservice"
+  stub docker \
+    "compose -f docker-compose.yml -p buildkite1111 up -d --scale myservice=0 myservice : echo ran myservice dependencies" \
+    "compose -f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 --rm myservice /bin/sh -e -c 'echo hello world' : echo ran myservice"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 1"
@@ -219,7 +223,8 @@ cmd3"
 
   assert_success
   assert_output --partial "ran myservice"
-  unstub docker-compose
+
+  unstub docker
   unstub buildkite-agent
 }
 
@@ -234,9 +239,9 @@ cmd3"
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CHECK_LINKED_CONTAINERS=false
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLEANUP=false
 
-  stub docker-compose \
-    "-f docker-compose.yml -p buildkite1111 up -d --scale myservice=0 myservice : echo ran myservice dependencies" \
-    "-f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 -T --rm myservice /bin/sh -e -c 'echo hello world' : echo ran myservice"
+  stub docker \
+    "compose -f docker-compose.yml -p buildkite1111 up -d --scale myservice=0 myservice : echo ran myservice dependencies" \
+    "compose -f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 --rm myservice /bin/sh -e -c 'echo hello world' : echo ran myservice"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 1"
@@ -245,7 +250,34 @@ cmd3"
 
   assert_success
   assert_output --partial "ran myservice"
-  unstub docker-compose
+
+  unstub docker
+  unstub buildkite-agent
+}
+
+@test "Run without a prebuilt image without pulling" {
+  export BUILDKITE_JOB_ID=1111
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RUN=myservice
+  export BUILDKITE_PIPELINE_SLUG=test
+  export BUILDKITE_BUILD_NUMBER=1
+  export BUILDKITE_COMMAND="echo hello world"
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CHECK_LINKED_CONTAINERS=false
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLEANUP=false
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_SKIP_PULL=true
+
+  stub docker \
+    "compose -f docker-compose.yml -p buildkite1111 up -d --scale myservice=0 myservice : echo ran myservice dependencies" \
+    "compose -f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 --rm myservice /bin/sh -e -c 'echo hello world' : echo ran myservice"
+
+  stub buildkite-agent \
+    "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 1"
+
+  run "$PWD"/hooks/command
+
+  assert_success
+  assert_output --partial "ran myservice"
+
+  unstub docker
   unstub buildkite-agent
 }
 
@@ -257,10 +289,10 @@ cmd3"
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RUN=myservice
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_PROPAGATE_ENVIRONMENT=true
 
-  stub docker-compose \
-    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml pull myservice : echo pulled myservice" \
-    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml up -d --scale myservice=0 myservice : echo ran myservice dependencies" \
-    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 -T --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice"
+  stub docker \
+    "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml pull myservice : echo pulled myservice" \
+    "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml up -d --scale myservice=0 myservice : echo ran myservice dependencies" \
+    "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 0" \
@@ -272,7 +304,7 @@ cmd3"
   assert_output --partial "Running /bin/sh -e -c 'pwd' in service myservice"
   assert_output --partial "Not propagating environment variables to container"
 
-  unstub docker-compose
+  unstub docker
   unstub buildkite-agent
 }
 
@@ -288,10 +320,10 @@ cmd3"
   echo "VAR0=1" > "${BUILDKITE_ENV_FILE}"
   echo "VAR2=lalala" >> "${BUILDKITE_ENV_FILE}"
 
-  stub docker-compose \
-    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml pull myservice : echo pulled myservice" \
-    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml up -d --scale myservice=0 myservice : echo ran myservice dependencies" \
-    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 -e \* -e \* -T --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice with vars \${11} and \${13}"
+  stub docker \
+    "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml pull myservice : echo pulled myservice" \
+    "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml up -d --scale myservice=0 myservice : echo ran myservice dependencies" \
+    "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 -e \* -e \* --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice with vars \${12} and \${14}"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 0" \
@@ -303,7 +335,7 @@ cmd3"
   assert_output --partial "Running /bin/sh -e -c 'pwd' in service myservice"
   assert_output --partial "ran myservice with vars VAR0 and VAR2"
 
-  unstub docker-compose
+  unstub docker
   unstub buildkite-agent
 
   rm "${BUILDKITE_ENV_FILE}"
@@ -318,10 +350,10 @@ cmd3"
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CHECK_LINKED_CONTAINERS=false
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLEANUP=false
 
-  stub docker-compose \
-    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml pull myservice : echo pulled myservice" \
-    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml up -d --scale myservice=0 myservice : echo ran myservice dependencies" \
-    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 -T --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice"
+  stub docker \
+    "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml pull myservice : echo pulled myservice" \
+    "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml up -d --scale myservice=0 myservice : echo ran myservice dependencies" \
+    "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 0" \
@@ -331,7 +363,7 @@ cmd3"
 
   assert_success
   assert_output --partial "ran myservice"
-  unstub docker-compose
+  unstub docker
   unstub buildkite-agent
 }
 
@@ -345,10 +377,10 @@ cmd3"
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CHECK_LINKED_CONTAINERS=false
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLEANUP=false
 
-  stub docker-compose \
-    "-f tests/composefiles/docker-compose.v2.0.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml pull myservice : echo pulled myservice" \
-    "-f tests/composefiles/docker-compose.v2.0.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml up -d --scale myservice=0 myservice : echo ran myservice dependencies" \
-    "-f tests/composefiles/docker-compose.v2.0.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 -T --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice"
+  stub docker \
+    "compose -f tests/composefiles/docker-compose.v2.0.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml pull myservice : echo pulled myservice" \
+    "compose -f tests/composefiles/docker-compose.v2.0.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml up -d --scale myservice=0 myservice : echo ran myservice dependencies" \
+    "compose -f tests/composefiles/docker-compose.v2.0.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice-tests/composefiles/docker-compose.v2.0.yml : exit 0" \
@@ -358,7 +390,7 @@ cmd3"
 
   assert_success
   assert_output --partial "ran myservice"
-  unstub docker-compose
+  unstub docker
   unstub buildkite-agent
 }
 
@@ -373,10 +405,10 @@ export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CHECK_LINKED_CONTAINERS=false
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLEANUP=false
 
-  stub docker-compose \
-    "-f tests/composefiles/docker-compose.v2.0.yml -f tests/composefiles/docker-compose.v2.1.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml pull myservice : echo pulled myservice" \
-    "-f tests/composefiles/docker-compose.v2.0.yml -f tests/composefiles/docker-compose.v2.1.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml up -d --scale myservice=0 myservice : echo pulled myservice" \
-    "-f tests/composefiles/docker-compose.v2.0.yml -f tests/composefiles/docker-compose.v2.1.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 -T --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice"
+  stub docker \
+    "compose -f tests/composefiles/docker-compose.v2.0.yml -f tests/composefiles/docker-compose.v2.1.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml pull myservice : echo pulled myservice" \
+    "compose -f tests/composefiles/docker-compose.v2.0.yml -f tests/composefiles/docker-compose.v2.1.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml up -d --scale myservice=0 myservice : echo pulled myservice" \
+    "compose -f tests/composefiles/docker-compose.v2.0.yml -f tests/composefiles/docker-compose.v2.1.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice-tests/composefiles/docker-compose.v2.0.yml-tests/composefiles/docker-compose.v2.1.yml : exit 0" \
@@ -386,7 +418,7 @@ export BUILDKITE_JOB_ID=1111
 
   assert_success
   assert_output --partial "ran myservice"
-  unstub docker-compose
+  unstub docker
   unstub buildkite-agent
 }
 
@@ -400,10 +432,10 @@ export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CHECK_LINKED_CONTAINERS=false
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLEANUP=false
 
-  stub docker-compose \
-    "-f tests/composefiles/docker-compose.v2.0.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml pull myservice : echo pulled myservice" \
-    "-f tests/composefiles/docker-compose.v2.0.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml up -d --scale myservice=0 myservice : echo ran myservice dependencies" \
-    "-f tests/composefiles/docker-compose.v2.0.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 -T --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice"
+  stub docker \
+    "compose -f tests/composefiles/docker-compose.v2.0.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml pull myservice : echo pulled myservice" \
+    "compose -f tests/composefiles/docker-compose.v2.0.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml up -d --scale myservice=0 myservice : echo ran myservice dependencies" \
+    "compose -f tests/composefiles/docker-compose.v2.0.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice-tests/composefiles/docker-compose.v2.0.yml : exit 0" \
@@ -413,7 +445,7 @@ export BUILDKITE_JOB_ID=1111
 
   assert_success
   assert_output --partial "ran myservice"
-  unstub docker-compose
+  unstub docker
   unstub buildkite-agent
 }
 
@@ -426,8 +458,8 @@ export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CHECK_LINKED_CONTAINERS=false
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLEANUP=false
 
-  stub docker-compose \
-    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml pull myservice : exit 2"
+  stub docker \
+    "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml pull myservice : exit 2"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 0" \
@@ -437,7 +469,7 @@ export BUILDKITE_JOB_ID=1111
 
   assert_failure
   assert_output --partial "Exited with 2"
-  unstub docker-compose
+  unstub docker
   unstub buildkite-agent
 }
 
@@ -451,11 +483,11 @@ export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLEANUP=false
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_PULL_RETRIES=3
 
-  stub docker-compose \
-    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml pull myservice : exit 2" \
-    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml pull myservice : echo pulled myservice" \
-    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml up -d --scale myservice=0 myservice : echo started dependencies for myservice" \
-    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 -T --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice"
+  stub docker \
+    "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml pull myservice : exit 2" \
+    "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml pull myservice : echo pulled myservice" \
+    "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml up -d --scale myservice=0 myservice : echo started dependencies for myservice" \
+    "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 0" \
@@ -466,11 +498,11 @@ export BUILDKITE_JOB_ID=1111
   assert_success
   assert_output --partial "pulled myservice"
   assert_output --partial "ran myservice"
-  unstub docker-compose
+  unstub docker
   unstub buildkite-agent
 }
 
-@test "Run with a TTY" {
+@test "Run without a TTY" {
   export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RUN=myservice
   export BUILDKITE_PIPELINE_SLUG=test
@@ -478,12 +510,12 @@ export BUILDKITE_JOB_ID=1111
   export BUILDKITE_COMMAND=pwd
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CHECK_LINKED_CONTAINERS=false
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLEANUP=false
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_TTY=true
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_TTY=false
 
-  stub docker-compose \
-    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml pull myservice : echo pulled myservice" \
-    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml up -d --scale myservice=0 myservice : echo started dependencies for myservice" \
-    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice without tty"
+  stub docker \
+    "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml pull myservice : echo pulled myservice" \
+    "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml up -d --scale myservice=0 myservice : echo started dependencies for myservice" \
+    "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 -T --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice without tty"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 0" \
@@ -493,7 +525,7 @@ export BUILDKITE_JOB_ID=1111
 
   assert_success
   assert_output --partial "ran myservice without tty"
-  unstub docker-compose
+  unstub docker
   unstub buildkite-agent
 }
 
@@ -507,9 +539,9 @@ export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLEANUP=false
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_DEPENDENCIES=false
 
-  stub docker-compose \
-    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml pull myservice : echo pulled myservice" \
-    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 -T --no-deps --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice without dependencies"
+  stub docker \
+    "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml pull myservice : echo pulled myservice" \
+    "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 --no-deps --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice without dependencies"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 0" \
@@ -519,7 +551,7 @@ export BUILDKITE_JOB_ID=1111
 
   assert_success
   assert_output --partial "ran myservice without dependencies"
-  unstub docker-compose
+  unstub docker
   unstub buildkite-agent
 }
 
@@ -533,9 +565,9 @@ export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLEANUP=false
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_PRE_RUN_DEPENDENCIES=false
 
-  stub docker-compose \
-    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml pull myservice : echo pulled myservice" \
-    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 -T --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice with dependencies"
+  stub docker \
+    "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml pull myservice : echo pulled myservice" \
+    "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice with dependencies"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 0" \
@@ -545,7 +577,8 @@ export BUILDKITE_JOB_ID=1111
 
   assert_success
   assert_output --partial "ran myservice with dependencies"
-  unstub docker-compose
+
+  unstub docker
   unstub buildkite-agent
 }
 
@@ -559,10 +592,10 @@ export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLEANUP=false
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_ANSI=false
 
-  stub docker-compose \
-    "--no-ansi -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml pull myservice : echo pulled myservice" \
-    "--no-ansi -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml up -d --scale myservice=0 myservice : echo started dependencies for myservice" \
-    "--no-ansi -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 -T --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice without ansi output"
+  stub docker \
+    "compose --no-ansi -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml pull myservice : echo pulled myservice" \
+    "compose --no-ansi -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml up -d --scale myservice=0 myservice : echo started dependencies for myservice" \
+    "compose --no-ansi -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice without ansi output"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 0" \
@@ -572,34 +605,7 @@ export BUILDKITE_JOB_ID=1111
 
   assert_success
   assert_output --partial "ran myservice without ansi output"
-  unstub docker-compose
-  unstub buildkite-agent
-}
-
-
-@test "Run without pull" {
-  export BUILDKITE_JOB_ID=1111
-  export BUILDKITE_PIPELINE_SLUG=test
-  export BUILDKITE_BUILD_NUMBER=1
-  export BUILDKITE_COMMAND=pwd
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RUN=myservice
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_SKIP_PULL=true
-
-  stub docker-compose \
-    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml up -d --scale myservice=0 myservice : echo started dependencies for myservice" \
-    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 -T --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice without pull"
-
-  stub buildkite-agent \
-    "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 0" \
-    "meta-data get docker-compose-plugin-built-image-tag-myservice : echo myimage"
-
-  run "$PWD"/hooks/command
-
-  assert_success
-  assert_output --partial "Running /bin/sh -e -c 'pwd' in service myservice"
-  assert_output --partial "ran myservice without pull"
-  
-  unstub docker-compose
+  unstub docker
   unstub buildkite-agent
 }
 
@@ -613,10 +619,10 @@ export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLEANUP=false
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_USE_ALIASES=true
 
-  stub docker-compose \
-    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml pull myservice : echo pulled myservice" \
-    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml up -d --scale myservice=0 myservice : echo started dependencies for myservice" \
-    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 -T --use-aliases --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice with use aliases output"
+  stub docker \
+    "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml pull myservice : echo pulled myservice" \
+    "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml up -d --scale myservice=0 myservice : echo started dependencies for myservice" \
+    "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 --use-aliases --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice with use aliases output"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 0" \
@@ -626,9 +632,10 @@ export BUILDKITE_JOB_ID=1111
 
   assert_success
   assert_output --partial "ran myservice with use aliases output"
-  unstub docker-compose
+  unstub docker
   unstub buildkite-agent
 }
+
 
 @test "Run with compatibility mode" {
   export BUILDKITE_BUILD_NUMBER=1
@@ -640,10 +647,10 @@ export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLEANUP=false
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_COMPATIBILITY=true
 
-  stub docker-compose \
-    "--compatibility -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml pull myservice : echo pulled myservice" \
-    "--compatibility -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml up -d --scale myservice=0 myservice : echo started dependencies for myservice" \
-    "--compatibility -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 -T --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice with use aliases output"
+  stub docker \
+    "compose --compatibility -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml pull myservice : echo pulled myservice" \
+    "compose --compatibility -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml up -d --scale myservice=0 myservice : echo started dependencies for myservice" \
+    "compose --compatibility -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice with use aliases output"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 0" \
@@ -653,7 +660,7 @@ export BUILDKITE_JOB_ID=1111
 
   assert_success
   assert_output --partial "ran myservice with use aliases output"
-  unstub docker-compose
+  unstub docker
   unstub buildkite-agent
 }
 
@@ -668,10 +675,10 @@ export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_VOLUMES_0="./dist:/app/dist"
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_VOLUMES_1="./pkg:/app/pkg"
 
-  stub docker-compose \
-    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml pull myservice : echo pulled myservice" \
-    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml up -d --scale myservice=0 myservice : echo started dependencies for myservice" \
-    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 -v $PWD/dist:/app/dist -v $PWD/pkg:/app/pkg -T --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice with volumes"
+  stub docker \
+    "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml pull myservice : echo pulled myservice" \
+    "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml up -d --scale myservice=0 myservice : echo started dependencies for myservice" \
+    "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 -v $PWD/dist:/app/dist -v $PWD/pkg:/app/pkg --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice with volumes"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 0" \
@@ -681,7 +688,7 @@ export BUILDKITE_JOB_ID=1111
 
   assert_success
   assert_output --partial "ran myservice with volumes"
-  unstub docker-compose
+  unstub docker
   unstub buildkite-agent
 }
 
@@ -695,10 +702,10 @@ export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLEANUP=false
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_VOLUMES="buildkite:/buildkite"
 
-  stub docker-compose \
-    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml pull myservice : echo pulled myservice" \
-    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml up -d --scale myservice=0 myservice : echo started dependencies for myservice" \
-    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 -v buildkite:/buildkite -T --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice with volumes"
+  stub docker \
+    "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml pull myservice : echo pulled myservice" \
+    "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml up -d --scale myservice=0 myservice : echo started dependencies for myservice" \
+    "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 -v buildkite:/buildkite --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice with volumes"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 0" \
@@ -708,7 +715,7 @@ export BUILDKITE_JOB_ID=1111
 
   assert_success
   assert_output --partial "ran myservice with volumes"
-  unstub docker-compose
+  unstub docker
   unstub buildkite-agent
 }
 
@@ -725,10 +732,10 @@ export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLEANUP=false
   export BUILDKITE_DOCKER_DEFAULT_VOLUMES="buildkite:/buildkite; ./dist:/app/dist;; ;   ;"
 
-  stub docker-compose \
-    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml pull myservice : echo pulled myservice" \
-    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml up -d --scale myservice=0 myservice : echo started dependencies for myservice" \
-    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 -v buildkite:/buildkite -v $PWD/dist:/app/dist -T --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice with volumes"
+  stub docker \
+    "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml pull myservice : echo pulled myservice" \
+    "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml up -d --scale myservice=0 myservice : echo started dependencies for myservice" \
+    "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 -v buildkite:/buildkite -v $PWD/dist:/app/dist --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice with volumes"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 0" \
@@ -738,111 +745,7 @@ export BUILDKITE_JOB_ID=1111
 
   assert_success
   assert_output --partial "ran myservice with volumes"
-  unstub docker-compose
-  unstub buildkite-agent
-}
-
-@test "Run with volumes with variables" {
-  export BUILDKITE_JOB_ID=1111
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RUN=myservice
-  export BUILDKITE_PIPELINE_SLUG=test
-  export BUILDKITE_BUILD_NUMBER=1
-  export BUILDKITE_COMMAND=pwd
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CHECK_LINKED_CONTAINERS=false
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLEANUP=false
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_VOLUMES_0="\$SUPER_VARIABLE:/mnt"
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_VOLUMES_1="/:\$OTHER_VARIABLE"
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_VOLUMES_2="\$RELATIVE_VARIABLE:/srv"
-
-  export SUPER_VARIABLE='/test/path'
-  export OTHER_VARIABLE='/path/tested'
-  export RELATIVE_VARIABLE='./path'
-
-  stub docker-compose \
-    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml pull myservice : echo pulled myservice" \
-    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml up -d --scale myservice=0 myservice : echo started dependencies for myservice" \
-    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 -v \\\$SUPER_VARIABLE:/mnt -v /:\\\$OTHER_VARIABLE -v \\\$RELATIVE_VARIABLE:/srv -T --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice with volumes"
-
-  stub buildkite-agent \
-    "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 0" \
-    "meta-data get docker-compose-plugin-built-image-tag-myservice : echo myimage"
-
-  run "$PWD"/hooks/command
-
-  assert_success
-  assert_output --partial "ran myservice with volumes"
-  unstub docker-compose
-  unstub buildkite-agent
-}
-
-
-@test "Run with volumes with variables but option turned off" {
-  export BUILDKITE_JOB_ID=1111
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RUN=myservice
-  export BUILDKITE_PIPELINE_SLUG=test
-  export BUILDKITE_BUILD_NUMBER=1
-  export BUILDKITE_COMMAND=pwd
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CHECK_LINKED_CONTAINERS=false
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLEANUP=false
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_EXPAND_VOLUME_VARS=false
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_VOLUMES_0="\$SUPER_VARIABLE:/mnt"
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_VOLUMES_1="/:\$OTHER_VARIABLE"
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_VOLUMES_2="\$RELATIVE_VARIABLE:/srv"
-
-
-  export SUPER_VARIABLE='/test/path'
-  export OTHER_VARIABLE='/path/tested'
-  export RELATIVE_VARIABLE='./path'
-
-  stub docker-compose \
-    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml pull myservice : echo pulled myservice" \
-    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml up -d --scale myservice=0 myservice : echo started dependencies for myservice" \
-    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 -v \\\$SUPER_VARIABLE:/mnt -v /:\\\$OTHER_VARIABLE -v \\\$RELATIVE_VARIABLE:/srv -T --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice with volumes"
-
-  stub buildkite-agent \
-    "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 0" \
-    "meta-data get docker-compose-plugin-built-image-tag-myservice : echo myimage"
-
-  run "$PWD"/hooks/command
-
-  assert_success
-  assert_output --partial "ran myservice with volumes"
-  unstub docker-compose
-  unstub buildkite-agent
-}
-
-@test "Run with volumes with variables and option turned on" {
-  export BUILDKITE_JOB_ID=1111
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RUN=myservice
-  export BUILDKITE_PIPELINE_SLUG=test
-  export BUILDKITE_BUILD_NUMBER=1
-  export BUILDKITE_COMMAND=pwd
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CHECK_LINKED_CONTAINERS=false
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLEANUP=true
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_EXPAND_VOLUME_VARS=true
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_VOLUMES_0="\$SUPER_VARIABLE:/mnt"
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_VOLUMES_1="/:\$OTHER_VARIABLE"
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_VOLUMES_2="\$RELATIVE_VARIABLE:/srv"
-
-
-  export SUPER_VARIABLE='/test/path'
-  export OTHER_VARIABLE='/path/tested'
-  export RELATIVE_VARIABLE='./path'
-
-  stub docker-compose \
-    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml pull myservice : echo pulled myservice" \
-    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml up -d --scale myservice=0 myservice : echo started dependencies for myservice" \
-    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 -v /test/path:/mnt -v /:/path/tested -v $PWD/path:/srv -T --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice with volumes"
-
-  stub buildkite-agent \
-    "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 0" \
-    "meta-data get docker-compose-plugin-built-image-tag-myservice : echo myimage"
-
-  run "$PWD"/hooks/command
-
-  assert_success
-  assert_output --partial "ran myservice with volumes"
-  unstub docker-compose
+  unstub docker
   unstub buildkite-agent
 }
 
@@ -856,10 +759,10 @@ export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLEANUP=false
   export BUILDKITE_DOCKER_DEFAULT_VOLUMES="buildkite:/buildkite;./dist:/app/dist"
 
-  stub docker-compose \
-    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml pull myservice : echo pulled myservice" \
-    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml up -d --scale myservice=0 myservice : echo started dependencies for myservice" \
-    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 -v buildkite:/buildkite -v $PWD/dist:/app/dist -T --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice with volumes"
+  stub docker \
+    "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml pull myservice : echo pulled myservice" \
+    "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml up -d --scale myservice=0 myservice : echo started dependencies for myservice" \
+    "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 -v buildkite:/buildkite -v $PWD/dist:/app/dist --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice with volumes"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 0" \
@@ -869,7 +772,7 @@ export BUILDKITE_JOB_ID=1111
 
   assert_success
   assert_output --partial "ran myservice with volumes"
-  unstub docker-compose
+  unstub docker
   unstub buildkite-agent
 }
 
@@ -885,9 +788,9 @@ export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CONFIG_1="llamas2.yml"
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CONFIG_2="llamas3.yml"
 
-  stub docker-compose \
-    "-f llamas1.yml -f llamas2.yml -f llamas3.yml -p buildkite1111 up -d --scale myservice=0 myservice : echo started dependencies for myservice" \
-    "-f llamas1.yml -f llamas2.yml -f llamas3.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 -T --rm myservice /bin/sh -e -c 'echo hello world' : echo ran myservice"
+  stub docker \
+    "compose -f llamas1.yml -f llamas2.yml -f llamas3.yml -p buildkite1111 up -d --scale myservice=0 myservice : echo started dependencies for myservice" \
+    "compose -f llamas1.yml -f llamas2.yml -f llamas3.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 --rm myservice /bin/sh -e -c 'echo hello world' : echo ran myservice"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice-llamas1.yml-llamas2.yml-llamas3.yml : exit 1"
@@ -896,7 +799,8 @@ export BUILDKITE_JOB_ID=1111
 
   assert_success
   assert_output --partial "ran myservice"
-  unstub docker-compose
+
+  unstub docker
   unstub buildkite-agent
 }
 
@@ -909,9 +813,9 @@ export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CHECK_LINKED_CONTAINERS=false
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLEANUP=false
 
-  stub docker-compose \
-    "-f docker-compose.yml -p buildkite1111 up -d --scale myservice=0 myservice : echo started dependencies for myservice" \
-    "-f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 -T --rm myservice /bin/sh -e -c 'pwd' : exit 2"
+  stub docker \
+    "compose -f docker-compose.yml -p buildkite1111 up -d --scale myservice=0 myservice : echo started dependencies for myservice" \
+    "compose -f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 --rm myservice /bin/sh -e -c 'pwd' : exit 2"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 1"
@@ -921,7 +825,7 @@ export BUILDKITE_JOB_ID=1111
   assert_failure
   assert_output --partial "^^^ +++"
   assert_output --partial "Failed to run command, exited with 2"
-  unstub docker-compose
+  unstub docker
   unstub buildkite-agent
 }
 
@@ -936,10 +840,10 @@ export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CHECK_LINKED_CONTAINERS=false
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLEANUP=false
 
-  stub docker-compose \
-    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml pull --parallel myservice1 myservice2 : echo pulled myservice1 and myservice2" \
-    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml up -d --scale myservice1=0 myservice1 : echo started dependencies for myservice1" \
-    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice1_build_1 -T --rm myservice1 /bin/sh -e -c 'pwd' : echo ran myservice1"
+  stub docker \
+    "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml pull --parallel myservice1 myservice2 : echo pulled myservice1 and myservice2" \
+    "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml up -d --scale myservice1=0 myservice1 : echo started dependencies for myservice1" \
+    "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice1_build_1 --rm myservice1 /bin/sh -e -c 'pwd' : echo ran myservice1"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice1 : exit 0" \
@@ -952,7 +856,7 @@ export BUILDKITE_JOB_ID=1111
   assert_success
   assert_output --partial "pulled myservice1 and myservice2"
   assert_output --partial "ran myservice1"
-  unstub docker-compose
+  unstub docker
   unstub buildkite-agent
 }
 
@@ -966,9 +870,9 @@ export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLEANUP=false
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_USER="1000"
 
-  stub docker-compose \
-    "-f docker-compose.yml -p buildkite1111 up -d --scale myservice=0 myservice : echo started dependencies for myservice" \
-    "-f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 -T --user=1000 --rm myservice /bin/sh -e -c $'sh -c \'whoami\'' : echo ran myservice"
+  stub docker \
+    "compose -f docker-compose.yml -p buildkite1111 up -d --scale myservice=0 myservice : echo started dependencies for myservice" \
+    "compose -f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 --user=1000 --rm myservice /bin/sh -e -c $'sh -c \'whoami\'' : echo ran myservice"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 1"
@@ -977,7 +881,8 @@ export BUILDKITE_JOB_ID=1111
 
   assert_success
   assert_output --partial "ran myservice"
-  unstub docker-compose
+
+  unstub docker
   unstub buildkite-agent
 }
 
@@ -991,9 +896,9 @@ export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLEANUP=false
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_USER="1000:1001"
 
-  stub docker-compose \
-    "-f docker-compose.yml -p buildkite1111 up -d --scale myservice=0 myservice : echo started dependencies for myservice" \
-    "-f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 -T --user=1000:1001 --rm myservice /bin/sh -e -c $'sh -c \'whoami\'' : echo ran myservice"
+  stub docker \
+    "compose -f docker-compose.yml -p buildkite1111 up -d --scale myservice=0 myservice : echo started dependencies for myservice" \
+    "compose -f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 --user=1000:1001 --rm myservice /bin/sh -e -c $'sh -c \'whoami\'' : echo ran myservice"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 1"
@@ -1002,7 +907,8 @@ export BUILDKITE_JOB_ID=1111
 
   assert_success
   assert_output --partial "ran myservice"
-  unstub docker-compose
+
+  unstub docker
   unstub buildkite-agent
 }
 
@@ -1029,7 +935,7 @@ export BUILDKITE_JOB_ID=1111
 }
 
 
-@test "Run without -T --rm" {
+@test "Run without --rm" {
   export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RUN=myservice
   export BUILDKITE_PIPELINE_SLUG=test
@@ -1038,12 +944,11 @@ export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CHECK_LINKED_CONTAINERS=false
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLEANUP=false
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RM=false
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_TTY=true
 
-  stub docker-compose \
-    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml pull myservice : echo pulled myservice" \
-    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml up -d --scale myservice=0 myservice : echo started dependencies for myservice" \
-    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 myservice /bin/sh -e -c $'pwd' : echo ran myservice without tty"
+  stub docker \
+    "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml pull myservice : echo pulled myservice" \
+    "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml up -d --scale myservice=0 myservice : echo started dependencies for myservice" \
+    "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 myservice /bin/sh -e -c $'pwd' : echo ran myservice without tty"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : echo myimage" \
@@ -1053,7 +958,7 @@ export BUILDKITE_JOB_ID=1111
 
   assert_success
   assert_output --partial "ran myservice without tty"
-  unstub docker-compose
+  unstub docker
   unstub buildkite-agent
 }
 
@@ -1067,9 +972,9 @@ export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLEANUP=false
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_ENTRYPOINT="my custom entrypoint"
 
-  stub docker-compose \
-    "-f docker-compose.yml -p buildkite1111 up -d --scale myservice=0 myservice : echo ran myservice dependencies" \
-    "-f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 -T --rm --entrypoint 'my custom entrypoint' myservice : echo ran myservice"
+  stub docker \
+    "compose -f docker-compose.yml -p buildkite1111 up -d --scale myservice=0 myservice : echo ran myservice dependencies" \
+    "compose -f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 --rm --entrypoint 'my custom entrypoint' myservice : echo ran myservice"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 1"
@@ -1078,7 +983,8 @@ export BUILDKITE_JOB_ID=1111
 
   assert_success
   assert_output --partial "ran myservice"
-  unstub docker-compose
+
+  unstub docker
   unstub buildkite-agent
 }
 
@@ -1092,9 +998,9 @@ export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLEANUP=false
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_MOUNT_BUILDKITE_AGENT=true
 
-  stub docker-compose \
-    "-f docker-compose.yml -p buildkite1111 up -d --scale myservice=0 myservice : echo ran myservice dependencies" \
-    "-f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 -T --rm -e BUILDKITE_JOB_ID -e BUILDKITE_BUILD_ID -e BUILDKITE_AGENT_ACCESS_TOKEN -v $BATS_MOCK_TMPDIR/bin/buildkite-agent:/usr/bin/buildkite-agent myservice : echo ran myservice"
+  stub docker \
+    "compose -f docker-compose.yml -p buildkite1111 up -d --scale myservice=0 myservice : echo ran myservice dependencies" \
+    "compose -f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 --rm -e BUILDKITE_JOB_ID -e BUILDKITE_BUILD_ID -e BUILDKITE_AGENT_ACCESS_TOKEN -v $BATS_MOCK_TMPDIR/bin/buildkite-agent:/usr/bin/buildkite-agent myservice : echo ran myservice"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 1"
@@ -1103,7 +1009,8 @@ export BUILDKITE_JOB_ID=1111
 
   assert_success
   assert_output --partial "ran myservice"
-  unstub docker-compose
+
+  unstub docker
   unstub buildkite-agent
 }
 
@@ -1118,9 +1025,9 @@ export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_NO_CACHE=true
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD_PARALLEL=true
 
-  stub docker-compose \
-    "-f docker-compose.yml -p buildkite1111 up -d --scale myservice=0 myservice : echo ran myservice dependencies" \
-    "-f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 -T --rm myservice /bin/sh -e -c 'echo hello world' : echo ran myservice"
+  stub docker \
+    "compose -f docker-compose.yml -p buildkite1111 up -d --scale myservice=0 myservice : echo ran myservice dependencies" \
+    "compose -f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 --rm myservice /bin/sh -e -c 'echo hello world' : echo ran myservice"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 1"
@@ -1129,7 +1036,8 @@ export BUILDKITE_JOB_ID=1111
 
   assert_success
   assert_output --partial "ran myservice"
-  unstub docker-compose
+
+  unstub docker
   unstub buildkite-agent
 }
 
@@ -1143,9 +1051,9 @@ export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLEANUP=false
   export BUILDKITE_REPO_MIRROR=/tmp/sample-mirror
 
-  stub docker-compose \
-    "-f docker-compose.yml -p buildkite1111 up -d --scale myservice=0 myservice : echo ran myservice dependencies" \
-    "-f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 -v /tmp/sample-mirror:/tmp/sample-mirror:ro -T --rm myservice /bin/sh -e -c 'echo hello world' : echo ran myservice"
+  stub docker \
+    "compose -f docker-compose.yml -p buildkite1111 up -d --scale myservice=0 myservice : echo ran myservice dependencies" \
+    "compose -f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 -v /tmp/sample-mirror:/tmp/sample-mirror:ro --rm myservice /bin/sh -e -c 'echo hello world' : echo ran myservice"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 1"
@@ -1154,7 +1062,8 @@ export BUILDKITE_JOB_ID=1111
 
   assert_success
   assert_output --partial "ran myservice"
-  unstub docker-compose
+
+  unstub docker
   unstub buildkite-agent
 }
 
@@ -1169,9 +1078,9 @@ export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLEANUP=false
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_MOUNT_SSH_AGENT=true
 
-  stub docker-compose \
-    "-f docker-compose.yml -p buildkite1111 up -d --scale myservice=0 myservice : echo ran myservice dependencies" \
-    "-f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 -T --rm -e SSH_AUTH_SOCK=/ssh-agent -v /tmp/ssh_auth_sock:/ssh-agent -v /root/.ssh/known_hosts:/root/.ssh/known_hosts myservice /bin/sh -e -c 'echo hello world' : echo ran myservice"
+  stub docker \
+    "compose -f docker-compose.yml -p buildkite1111 up -d --scale myservice=0 myservice : echo ran myservice dependencies" \
+    "compose -f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 --rm -e SSH_AUTH_SOCK=/ssh-agent -v /tmp/ssh_auth_sock:/ssh-agent -v /root/.ssh/known_hosts:/root/.ssh/known_hosts myservice /bin/sh -e -c 'echo hello world' : echo ran myservice"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 1"
@@ -1181,12 +1090,12 @@ export BUILDKITE_JOB_ID=1111
 
   run "$PWD"/hooks/command
 
-  assert_success
-
   kill %1
 
+  assert_success
   assert_output --partial "ran myservice"
-  unstub docker-compose
+
+  unstub docker
   unstub buildkite-agent
 }
 
@@ -1201,9 +1110,9 @@ export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLEANUP=false
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_MOUNT_SSH_AGENT=/tmp/test
 
-  stub docker-compose \
-    "-f docker-compose.yml -p buildkite1111 up -d --scale myservice=0 myservice : echo ran myservice dependencies" \
-    "-f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 -T --rm -e SSH_AUTH_SOCK=/ssh-agent -v /tmp/ssh_auth_sock:/ssh-agent -v /root/.ssh/known_hosts:/tmp/test/.ssh/known_hosts myservice /bin/sh -e -c 'echo hello world' : echo ran myservice"
+  stub docker \
+    "compose -f docker-compose.yml -p buildkite1111 up -d --scale myservice=0 myservice : echo ran myservice dependencies" \
+    "compose -f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 --rm -e SSH_AUTH_SOCK=/ssh-agent -v /tmp/ssh_auth_sock:/ssh-agent -v /root/.ssh/known_hosts:/tmp/test/.ssh/known_hosts myservice /bin/sh -e -c 'echo hello world' : echo ran myservice"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 1"
@@ -1213,29 +1122,30 @@ export BUILDKITE_JOB_ID=1111
 
   run "$PWD"/hooks/command
 
-  assert_success
-
   kill %1
 
+  assert_success
   assert_output --partial "ran myservice"
-  unstub docker-compose
+
+  unstub docker
   unstub buildkite-agent
 }
 
 @test "Run without mount-checkout doesn't set volume" {
-  export BUILDKITE_JOB_ID=1111
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RUN=myservice
-  export BUILDKITE_PIPELINE_SLUG=test
   export BUILDKITE_BUILD_NUMBER=1
+  export BUILDKITE_JOB_ID=1111
+  export BUILDKITE_PIPELINE_SLUG=test
   export BUILDKITE_COMMAND=pwd
+
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RUN=myservice
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CHECK_LINKED_CONTAINERS=false
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLEANUP=false
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_MOUNT_CHECKOUT=false
 
-  stub docker-compose \
-    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml pull myservice : echo pulled myservice" \
-    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml up -d --scale myservice=0 myservice : echo started dependencies for myservice" \
-    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 -T --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice without mount-checkout"
+  stub docker \
+    "compose -f docker-compose.yml -p buildkite1111 -f \* pull myservice : echo pulled myservice" \
+    "compose -f docker-compose.yml -p buildkite1111 -f \* up -d --scale myservice=0 myservice : echo started dependencies for myservice" \
+    "compose -f docker-compose.yml -p buildkite1111 -f \* run --name buildkite1111_myservice_build_1 --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice without mount-checkout"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 0" \
@@ -1245,24 +1155,26 @@ export BUILDKITE_JOB_ID=1111
 
   assert_success
   assert_output --partial "ran myservice without mount-checkout"
-  unstub docker-compose
+
+  unstub docker
   unstub buildkite-agent
 }
 
 @test "Run with mount-checkout set to true" {
-  export BUILDKITE_JOB_ID=1111
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RUN=myservice
-  export BUILDKITE_PIPELINE_SLUG=test
   export BUILDKITE_BUILD_NUMBER=1
+  export BUILDKITE_JOB_ID=1111
+  export BUILDKITE_PIPELINE_SLUG=test
   export BUILDKITE_COMMAND=pwd
+
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RUN=myservice
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CHECK_LINKED_CONTAINERS=false
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLEANUP=false
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_MOUNT_CHECKOUT=true
 
-  stub docker-compose \
-    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml pull myservice : echo pulled myservice" \
-    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml up -d --scale myservice=0 myservice : echo started dependencies for myservice" \
-    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 -T --workdir=/workdir -v $PWD:/workdir --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice with mount-checkout"
+  stub docker \
+    "compose -f docker-compose.yml -p buildkite1111 -f \* pull myservice : echo pulled myservice" \
+    "compose -f docker-compose.yml -p buildkite1111 -f \* up -d --scale myservice=0 myservice : echo started dependencies for myservice" \
+    "compose -f docker-compose.yml -p buildkite1111 -f \* run --name buildkite1111_myservice_build_1 --workdir=/workdir -v /plugin:/workdir --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice with mount-checkout"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 0" \
@@ -1272,25 +1184,27 @@ export BUILDKITE_JOB_ID=1111
 
   assert_success
   assert_output --partial "ran myservice with mount-checkout"
-  unstub docker-compose
+
+  unstub docker
   unstub buildkite-agent
 }
 
 @test "Run with mount-checkout set to true with custom workdir" {
-  export BUILDKITE_JOB_ID=1111
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RUN=myservice
-  export BUILDKITE_PIPELINE_SLUG=test
   export BUILDKITE_BUILD_NUMBER=1
+  export BUILDKITE_JOB_ID=1111
+  export BUILDKITE_PIPELINE_SLUG=test
   export BUILDKITE_COMMAND=pwd
+
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RUN=myservice
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CHECK_LINKED_CONTAINERS=false
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLEANUP=false
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_MOUNT_CHECKOUT=true
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_WORKDIR="/custom_workdir"
 
-  stub docker-compose \
-    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml pull myservice : echo pulled myservice" \
-    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml up -d --scale myservice=0 myservice : echo started dependencies for myservice" \
-    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 -T --workdir=$BUILDKITE_PLUGIN_DOCKER_COMPOSE_WORKDIR -v $PWD:$BUILDKITE_PLUGIN_DOCKER_COMPOSE_WORKDIR --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice with mount-checkout"
+  stub docker \
+    "compose -f docker-compose.yml -p buildkite1111 -f \* pull myservice : echo pulled myservice" \
+    "compose -f docker-compose.yml -p buildkite1111 -f \* up -d --scale myservice=0 myservice : echo started dependencies for myservice" \
+    "compose -f docker-compose.yml -p buildkite1111 -f \* run --name buildkite1111_myservice_build_1 \* -v \* --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice with mount-checkout on \${13}"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 0" \
@@ -1299,8 +1213,9 @@ export BUILDKITE_JOB_ID=1111
   run "$PWD"/hooks/command
 
   assert_success
-  assert_output --partial "ran myservice with mount-checkout"
-  unstub docker-compose
+  assert_output --partial "ran myservice with mount-checkout on /plugin:/custom_workdir"
+
+  unstub docker
   unstub buildkite-agent
 }
 
@@ -1315,10 +1230,10 @@ export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLEANUP=false
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_MOUNT_CHECKOUT="/special"
 
-  stub docker-compose \
-    "-f docker-compose.yml -p buildkite1111 -f \* pull myservice : echo pulled myservice" \
-    "-f docker-compose.yml -p buildkite1111 -f \* up -d --scale myservice=0 myservice : echo started dependencies for myservice" \
-    "-f docker-compose.yml -p buildkite1111 -f \* run --name buildkite1111_myservice_build_1 -T -v \* --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice with mount-checkout on \${12}"
+  stub docker \
+    "compose -f docker-compose.yml -p buildkite1111 -f \* pull myservice : echo pulled myservice" \
+    "compose -f docker-compose.yml -p buildkite1111 -f \* up -d --scale myservice=0 myservice : echo started dependencies for myservice" \
+    "compose -f docker-compose.yml -p buildkite1111 -f \* run --name buildkite1111_myservice_build_1 -v \* --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice with mount-checkout on \${12}"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 0" \
@@ -1329,7 +1244,7 @@ export BUILDKITE_JOB_ID=1111
   assert_success
   assert_output --partial "ran myservice with mount-checkout on /plugin:/special"
 
-  unstub docker-compose
+  unstub docker
   unstub buildkite-agent
 }
 
@@ -1345,10 +1260,10 @@ export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_MOUNT_CHECKOUT="/special"
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_WORKDIR="/custom_workdir"
 
-  stub docker-compose \
-    "-f docker-compose.yml -p buildkite1111 -f \* pull myservice : echo pulled myservice" \
-    "-f docker-compose.yml -p buildkite1111 -f \* up -d --scale myservice=0 myservice : echo started dependencies for myservice" \
-    "-f docker-compose.yml -p buildkite1111 -f \* run --name buildkite1111_myservice_build_1 -T \* -v \* --rm myservice /bin/sh -e -c 'pwd' : echo echo ran myservice with mount-checkout on \${13}"
+  stub docker \
+    "compose -f docker-compose.yml -p buildkite1111 -f \* pull myservice : echo pulled myservice" \
+    "compose -f docker-compose.yml -p buildkite1111 -f \* up -d --scale myservice=0 myservice : echo started dependencies for myservice" \
+    "compose -f docker-compose.yml -p buildkite1111 -f \* run --name buildkite1111_myservice_build_1 \* -v \* --rm myservice /bin/sh -e -c 'pwd' : echo echo ran myservice with mount-checkout on \${13}"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 0" \
@@ -1360,7 +1275,7 @@ export BUILDKITE_JOB_ID=1111
   assert_output --partial "ran myservice with mount-checkout on /plugin:/special"
   assert_output --partial "--workdir=/custom_workdir"
 
-  unstub docker-compose
+  unstub docker
   unstub buildkite-agent
 }
 
@@ -1375,8 +1290,8 @@ export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLEANUP=false
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_MOUNT_CHECKOUT="not_absolute"
 
-  stub docker-compose \
-    "-f docker-compose.yml -p buildkite1111 -f \* pull myservice : echo pulled myservice"
+  stub docker \
+    "compose -f docker-compose.yml -p buildkite1111 -f \* pull myservice : echo pulled myservice"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 0" \
@@ -1387,7 +1302,7 @@ export BUILDKITE_JOB_ID=1111
   assert_failure
   assert_output --partial "mount-checkout should be either true or an absolute path to use as a mountpoint"
 
-  unstub docker-compose
+  unstub docker
   unstub buildkite-agent
 }
 
@@ -1403,8 +1318,8 @@ export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_MOUNT_CHECKOUT="not-absolute"
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_WORKDIR="/custom_workdir"
 
-  stub docker-compose \
-    "-f docker-compose.yml -p buildkite1111 -f \* pull myservice : echo pulled myservice"
+  stub docker \
+    "compose -f docker-compose.yml -p buildkite1111 -f \* pull myservice : echo pulled myservice"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 0" \
@@ -1415,7 +1330,7 @@ export BUILDKITE_JOB_ID=1111
   assert_failure
   assert_output --partial "mount-checkout should be either true or an absolute path to use as a mountpoint"
 
-  unstub docker-compose
+  unstub docker
   unstub buildkite-agent
 }
 
@@ -1429,9 +1344,9 @@ export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CHECK_LINKED_CONTAINERS=false
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_WAIT=true
 
-  stub docker-compose \
-    "-f docker-compose.yml -p buildkite1111 up --wait -d --scale myservice=0 myservice : echo ran myservice dependencies" \
-    "-f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 -T --rm myservice /bin/sh -e -c 'echo hello world' : echo ran myservice"
+  stub docker \
+    "compose -f docker-compose.yml -p buildkite1111 up --wait -d --scale myservice=0 myservice : echo ran myservice dependencies" \
+    "compose -f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 --rm myservice /bin/sh -e -c 'echo hello world' : echo ran myservice"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 1"
@@ -1439,10 +1354,9 @@ export BUILDKITE_JOB_ID=1111
   run "$PWD"/hooks/command
 
   assert_success
-  assert_output --partial "Starting dependencies"
   assert_output --partial "ran myservice"
 
-  unstub docker-compose
+  unstub docker
   unstub buildkite-agent
 }
 
@@ -1456,10 +1370,10 @@ export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLEANUP=false
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_SERVICE_PORTS=true
 
-  stub docker-compose \
-    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml pull myservice : echo pulled myservice" \
-    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml up -d --scale myservice=0 myservice : echo started dependencies for myservice" \
-    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 -T --rm --service-ports myservice /bin/sh -e -c $'pwd' : echo ran myservice without tty"
+  stub docker \
+    "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml pull myservice : echo pulled myservice" \
+    "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml up -d --scale myservice=0 myservice : echo started dependencies for myservice" \
+    "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 --rm --service-ports myservice /bin/sh -e -c $'pwd' : echo ran myservice without tty"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : echo myimage" \
@@ -1469,49 +1383,7 @@ export BUILDKITE_JOB_ID=1111
 
   assert_success
   assert_output --partial "ran myservice without tty"
-  unstub docker-compose
-  unstub buildkite-agent
-}
-
-@test "Run with Docker labels" {
-  # Pipeline vars
-  export BUILDKITE_AGENT_ID="1234"
-  export BUILDKITE_AGENT_NAME="agent"
-  export BUILDKITE_BUILD_NUMBER=1
-  export BUILDKITE_COMMAND=pwd
-  export BUILDKITE_JOB_ID=1111
-  export BUILDKITE_LABEL="Testjob"
-  export BUILDKITE_PIPELINE_NAME="label-test"
-  export BUILDKITE_PIPELINE_SLUG=test
-  export BUILDKITE_STEP_KEY="test-job"
-
-  # Plugin config
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RUN=myservice
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RUN_LABELS="true"
-
-  stub docker-compose \
-    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml pull myservice : echo pulled myservice" \
-    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml up -d --scale myservice=0 myservice : echo started dependencies for myservice" \
-    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 \
-      --label com.buildkite.pipeline_name=${BUILDKITE_PIPELINE_NAME} \
-      --label com.buildkite.pipeline_slug=${BUILDKITE_PIPELINE_SLUG} \
-      --label com.buildkite.build_number=${BUILDKITE_BUILD_NUMBER} \
-      --label com.buildkite.job_id=${BUILDKITE_JOB_ID} \
-      --label com.buildkite.job_label=${BUILDKITE_LABEL} \
-      --label com.buildkite.step_key=${BUILDKITE_STEP_KEY} \
-      --label com.buildkite.agent_name=${BUILDKITE_AGENT_NAME} \
-      --label com.buildkite.agent_id=${BUILDKITE_AGENT_ID} \
-      -T --rm myservice /bin/sh -e -c $'pwd' : echo ran myservice"
-
-  stub buildkite-agent \
-    "meta-data exists docker-compose-plugin-built-image-tag-myservice : echo myimage" \
-    "meta-data get docker-compose-plugin-built-image-tag-myservice : echo myimage"
-
-  run "$PWD"/hooks/command
-
-  assert_success
-  assert_output --partial "ran myservice"
-  unstub docker-compose
+  unstub docker
   unstub buildkite-agent
 }
 
@@ -1525,9 +1397,9 @@ export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CHECK_LINKED_CONTAINERS=false
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_QUIET_PULL=true
 
-  stub docker-compose \
-    "-f docker-compose.yml -p buildkite1111 up --quiet-pull -d --scale myservice=0 myservice : echo ran myservice dependencies" \
-    "-f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 -T --rm myservice /bin/sh -e -c 'echo hello world' : echo ran myservice"
+  stub docker \
+    "compose -f docker-compose.yml -p buildkite1111 up --quiet-pull -d --scale myservice=0 myservice : echo ran myservice dependencies" \
+    "compose -f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 --rm myservice /bin/sh -e -c 'echo hello world' : echo ran myservice"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 1"
@@ -1538,7 +1410,7 @@ export BUILDKITE_JOB_ID=1111
   refute_output --partial "Pulling"
   assert_output --partial "ran myservice"
 
-  unstub docker-compose
+  unstub docker
   unstub buildkite-agent
 }
 
@@ -1553,9 +1425,9 @@ export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CHECK_LINKED_CONTAINERS=false
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLEANUP=false
 
-  stub docker-compose \
-    "-f docker-compose.yml -p buildkite1111 up -d --scale myservice=0 myservice : echo ran myservice dependencies" \
-    "-f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 -e VAR_A -e VAR_B -e VAR_C -T --rm myservice /bin/sh -e -c 'echo hello world' : echo ran myservice"
+  stub docker \
+    "compose -f docker-compose.yml -p buildkite1111 up -d --scale myservice=0 myservice : echo ran myservice dependencies" \
+    "compose -f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 -e VAR_A -e VAR_B -e VAR_C --rm myservice /bin/sh -e -c 'echo hello world' : echo ran myservice"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 1"
@@ -1564,7 +1436,7 @@ export BUILDKITE_JOB_ID=1111
 
   assert_success
   assert_output --partial "ran myservice"
-  unstub docker-compose
+  unstub docker
   unstub buildkite-agent
 }
 
@@ -1585,54 +1457,5 @@ export BUILDKITE_JOB_ID=1111
 
   assert_failure
   assert_output --partial "env-propagation-list desired, but LIST_OF_VARS is not defined!"
-  unstub buildkite-agent
-}
-
-@test "Run with expanded run log group by default" {
-  export BUILDKITE_JOB_ID=1111
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RUN=myservice
-  export BUILDKITE_PIPELINE_SLUG=test
-  export BUILDKITE_BUILD_NUMBER=1
-  export BUILDKITE_COMMAND="echo hello world"
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CHECK_LINKED_CONTAINERS=false
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLEANUP=false
-
-  stub docker-compose \
-    "-f docker-compose.yml -p buildkite1111 up -d --scale myservice=0 myservice : echo ran myservice dependencies" \
-    "-f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 -T --rm myservice /bin/sh -e -c 'echo hello world' : echo ran myservice"
-
-  stub buildkite-agent \
-    "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 1"
-
-  run "$PWD"/hooks/command
-
-  assert_success
-  assert_output --partial "+++ :docker: Running /bin/sh -e -c 'echo hello world' in service myservice"
-  unstub docker-compose
-  unstub buildkite-agent
-}
-
-@test "Run with collapsed run log group" {
-  export BUILDKITE_JOB_ID=1111
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RUN=myservice
-  export BUILDKITE_PIPELINE_SLUG=test
-  export BUILDKITE_BUILD_NUMBER=1
-  export BUILDKITE_COMMAND="echo hello world"
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CHECK_LINKED_CONTAINERS=false
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLEANUP=false
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_COLLAPSE_LOGS=true
-
-  stub docker-compose \
-    "-f docker-compose.yml -p buildkite1111 up -d --scale myservice=0 myservice : echo ran myservice dependencies" \
-    "-f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 -T --rm myservice /bin/sh -e -c 'echo hello world' : echo ran myservice"
-
-  stub buildkite-agent \
-    "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 1"
-
-  run "$PWD"/hooks/command
-
-  assert_success
-  assert_output --partial "--- :docker: Running /bin/sh -e -c 'echo hello world' in service myservice"
-  unstub docker-compose
   unstub buildkite-agent
 }

--- a/tests/run.bats
+++ b/tests/run.bats
@@ -1,8 +1,8 @@
 #!/usr/bin/env bats
 
 load "${BATS_PLUGIN_PATH}/load.bash"
-load '../lib/shared'
-load '../lib/run'
+load '../lib/shared.bash'
+load '../lib/run.bash'
 
 # export DOCKER_COMPOSE_STUB_DEBUG=/dev/tty
 # export BUILDKITE_AGENT_STUB_DEBUG=/dev/tty
@@ -13,8 +13,8 @@ setup_file() {
 }
 
 teardown() {
-  # some test failures may leave this file around
-  rm -f docker-compose.buildkite-1-override.yml
+  # plugin leaves override files around
+  rm -f docker-compose.buildkite*-override.yml
 }
 
 @test "Run without a prebuilt image" {
@@ -28,7 +28,7 @@ teardown() {
 
   stub docker \
     "compose -f docker-compose.yml -p buildkite1111 up -d --scale myservice=0 myservice : echo ran myservice dependencies" \
-    "compose -f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 --rm myservice /bin/sh -e -c 'echo hello world' : echo ran myservice"
+    "compose -f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 -T --rm myservice /bin/sh -e -c 'echo hello world' : echo ran myservice"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 1"
@@ -53,7 +53,7 @@ teardown() {
 
   stub docker \
     "compose -f docker-compose.yml -p buildkite1111 up -d --scale myservice=0 myservice : echo ran myservice dependencies" \
-    "compose -f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 --rm myservice : echo ran myservice"
+    "compose -f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 -T --rm myservice : echo ran myservice"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 1"
@@ -79,7 +79,7 @@ teardown() {
 
   stub docker \
     "compose -f docker-compose.yml -p buildkite1111 up -d --scale myservice=0 myservice : echo ran myservice dependencies" \
-    "compose -f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 --workdir=/test_workdir --rm myservice : echo ran myservice"
+    "compose -f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 -T --workdir=/test_workdir --rm myservice : echo ran myservice"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 1"
@@ -104,7 +104,7 @@ teardown() {
 
   stub docker \
     "compose -f docker-compose.yml -p buildkite1111 up -d --scale myservice=0 myservice : echo ran myservice dependencies" \
-    "compose -f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 --rm myservice /bin/sh -e -c $'sh -c \'echo hello world\'' : echo ran myservice"
+    "compose -f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 -T --rm myservice /bin/sh -e -c $'sh -c \'echo hello world\'' : echo ran myservice"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 1"
@@ -131,7 +131,7 @@ cmd3"
 
   stub docker \
     "compose -f docker-compose.yml -p buildkite1111 up -d --scale myservice=0 myservice : echo ran myservice dependencies" \
-    "compose -f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 --rm myservice /bin/sh -e -c $'cmd1\ncmd2\ncmd3' : echo ran myservice"
+    "compose -f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 -T --rm myservice /bin/sh -e -c $'cmd1\ncmd2\ncmd3' : echo ran myservice"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 1"
@@ -158,7 +158,7 @@ cmd3"
 
   stub docker \
     "compose -f docker-compose.yml -p buildkite1111 up -d --scale myservice=0 myservice : echo ran myservice dependencies" \
-    "compose -f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 --rm myservice echo 'hello world' : echo ran myservice"
+    "compose -f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 -T --rm myservice echo 'hello world' : echo ran myservice"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 1"
@@ -188,7 +188,7 @@ cmd3"
 
   stub docker \
     "compose -f docker-compose.yml -p buildkite1111 up -d --scale myservice=0 myservice : echo ran myservice dependencies" \
-    "compose -f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 -e MYENV=0 -e MYENV -e MYENV=2 -e MYENV -e ANOTHER=this\ is\ a\ long\ string\ with\ spaces\;\ and\ semi-colons --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice"
+    "compose -f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 -e MYENV=0 -e MYENV -e MYENV=2 -e MYENV -e ANOTHER=this\ is\ a\ long\ string\ with\ spaces\;\ and\ semi-colons -T --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 1"
@@ -214,7 +214,7 @@ cmd3"
 
   stub docker \
     "compose -f docker-compose.yml -p buildkite1111 up -d --scale myservice=0 myservice : echo ran myservice dependencies" \
-    "compose -f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 --rm myservice /bin/sh -e -c 'echo hello world' : echo ran myservice"
+    "compose -f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 -T --rm myservice /bin/sh -e -c 'echo hello world' : echo ran myservice"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 1"
@@ -241,7 +241,7 @@ cmd3"
 
   stub docker \
     "compose -f docker-compose.yml -p buildkite1111 up -d --scale myservice=0 myservice : echo ran myservice dependencies" \
-    "compose -f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 --rm myservice /bin/sh -e -c 'echo hello world' : echo ran myservice"
+    "compose -f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 -T --rm myservice /bin/sh -e -c 'echo hello world' : echo ran myservice"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 1"
@@ -267,7 +267,7 @@ cmd3"
 
   stub docker \
     "compose -f docker-compose.yml -p buildkite1111 up -d --scale myservice=0 myservice : echo ran myservice dependencies" \
-    "compose -f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 --rm myservice /bin/sh -e -c 'echo hello world' : echo ran myservice"
+    "compose -f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 -T --rm myservice /bin/sh -e -c 'echo hello world' : echo ran myservice"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 1"
@@ -292,7 +292,7 @@ cmd3"
   stub docker \
     "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml pull myservice : echo pulled myservice" \
     "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml up -d --scale myservice=0 myservice : echo ran myservice dependencies" \
-    "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice"
+    "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 -T --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 0" \
@@ -323,7 +323,7 @@ cmd3"
   stub docker \
     "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml pull myservice : echo pulled myservice" \
     "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml up -d --scale myservice=0 myservice : echo ran myservice dependencies" \
-    "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 -e \* -e \* --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice with vars \${12} and \${14}"
+    "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 -e \* -e \* -T --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice with vars \${12} and \${14}"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 0" \
@@ -353,7 +353,7 @@ cmd3"
   stub docker \
     "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml pull myservice : echo pulled myservice" \
     "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml up -d --scale myservice=0 myservice : echo ran myservice dependencies" \
-    "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice"
+    "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 -T --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 0" \
@@ -380,7 +380,7 @@ cmd3"
   stub docker \
     "compose -f tests/composefiles/docker-compose.v2.0.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml pull myservice : echo pulled myservice" \
     "compose -f tests/composefiles/docker-compose.v2.0.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml up -d --scale myservice=0 myservice : echo ran myservice dependencies" \
-    "compose -f tests/composefiles/docker-compose.v2.0.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice"
+    "compose -f tests/composefiles/docker-compose.v2.0.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 -T --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice-tests/composefiles/docker-compose.v2.0.yml : exit 0" \
@@ -408,7 +408,7 @@ export BUILDKITE_JOB_ID=1111
   stub docker \
     "compose -f tests/composefiles/docker-compose.v2.0.yml -f tests/composefiles/docker-compose.v2.1.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml pull myservice : echo pulled myservice" \
     "compose -f tests/composefiles/docker-compose.v2.0.yml -f tests/composefiles/docker-compose.v2.1.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml up -d --scale myservice=0 myservice : echo pulled myservice" \
-    "compose -f tests/composefiles/docker-compose.v2.0.yml -f tests/composefiles/docker-compose.v2.1.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice"
+    "compose -f tests/composefiles/docker-compose.v2.0.yml -f tests/composefiles/docker-compose.v2.1.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 -T --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice-tests/composefiles/docker-compose.v2.0.yml-tests/composefiles/docker-compose.v2.1.yml : exit 0" \
@@ -435,7 +435,7 @@ export BUILDKITE_JOB_ID=1111
   stub docker \
     "compose -f tests/composefiles/docker-compose.v2.0.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml pull myservice : echo pulled myservice" \
     "compose -f tests/composefiles/docker-compose.v2.0.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml up -d --scale myservice=0 myservice : echo ran myservice dependencies" \
-    "compose -f tests/composefiles/docker-compose.v2.0.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice"
+    "compose -f tests/composefiles/docker-compose.v2.0.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 -T --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice-tests/composefiles/docker-compose.v2.0.yml : exit 0" \
@@ -487,7 +487,7 @@ export BUILDKITE_JOB_ID=1111
     "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml pull myservice : exit 2" \
     "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml pull myservice : echo pulled myservice" \
     "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml up -d --scale myservice=0 myservice : echo started dependencies for myservice" \
-    "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice"
+    "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 -T --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 0" \
@@ -502,7 +502,7 @@ export BUILDKITE_JOB_ID=1111
   unstub buildkite-agent
 }
 
-@test "Run without a TTY" {
+@test "Run with a TTY" {
   export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RUN=myservice
   export BUILDKITE_PIPELINE_SLUG=test
@@ -510,12 +510,12 @@ export BUILDKITE_JOB_ID=1111
   export BUILDKITE_COMMAND=pwd
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CHECK_LINKED_CONTAINERS=false
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLEANUP=false
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_TTY=false
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_TTY=true
 
   stub docker \
     "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml pull myservice : echo pulled myservice" \
     "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml up -d --scale myservice=0 myservice : echo started dependencies for myservice" \
-    "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 -T --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice without tty"
+    "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice without tty"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 0" \
@@ -541,7 +541,7 @@ export BUILDKITE_JOB_ID=1111
 
   stub docker \
     "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml pull myservice : echo pulled myservice" \
-    "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 --no-deps --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice without dependencies"
+    "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 -T --no-deps --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice without dependencies"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 0" \
@@ -567,7 +567,7 @@ export BUILDKITE_JOB_ID=1111
 
   stub docker \
     "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml pull myservice : echo pulled myservice" \
-    "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice with dependencies"
+    "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 -T --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice with dependencies"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 0" \
@@ -595,7 +595,7 @@ export BUILDKITE_JOB_ID=1111
   stub docker \
     "compose --no-ansi -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml pull myservice : echo pulled myservice" \
     "compose --no-ansi -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml up -d --scale myservice=0 myservice : echo started dependencies for myservice" \
-    "compose --no-ansi -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice without ansi output"
+    "compose --no-ansi -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 -T --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice without ansi output"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 0" \
@@ -622,7 +622,7 @@ export BUILDKITE_JOB_ID=1111
   stub docker \
     "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml pull myservice : echo pulled myservice" \
     "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml up -d --scale myservice=0 myservice : echo started dependencies for myservice" \
-    "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 --use-aliases --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice with use aliases output"
+    "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 -T --use-aliases --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice with use aliases output"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 0" \
@@ -650,7 +650,7 @@ export BUILDKITE_JOB_ID=1111
   stub docker \
     "compose --compatibility -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml pull myservice : echo pulled myservice" \
     "compose --compatibility -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml up -d --scale myservice=0 myservice : echo started dependencies for myservice" \
-    "compose --compatibility -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice with use aliases output"
+    "compose --compatibility -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 -T --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice with use aliases output"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 0" \
@@ -678,7 +678,7 @@ export BUILDKITE_JOB_ID=1111
   stub docker \
     "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml pull myservice : echo pulled myservice" \
     "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml up -d --scale myservice=0 myservice : echo started dependencies for myservice" \
-    "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 -v $PWD/dist:/app/dist -v $PWD/pkg:/app/pkg --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice with volumes"
+    "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 -v $PWD/dist:/app/dist -v $PWD/pkg:/app/pkg -T --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice with volumes"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 0" \
@@ -705,7 +705,7 @@ export BUILDKITE_JOB_ID=1111
   stub docker \
     "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml pull myservice : echo pulled myservice" \
     "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml up -d --scale myservice=0 myservice : echo started dependencies for myservice" \
-    "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 -v buildkite:/buildkite --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice with volumes"
+    "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 -v buildkite:/buildkite -T --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice with volumes"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 0" \
@@ -735,7 +735,7 @@ export BUILDKITE_JOB_ID=1111
   stub docker \
     "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml pull myservice : echo pulled myservice" \
     "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml up -d --scale myservice=0 myservice : echo started dependencies for myservice" \
-    "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 -v buildkite:/buildkite -v $PWD/dist:/app/dist --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice with volumes"
+    "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 -v buildkite:/buildkite -v $PWD/dist:/app/dist -T --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice with volumes"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 0" \
@@ -762,7 +762,7 @@ export BUILDKITE_JOB_ID=1111
   stub docker \
     "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml pull myservice : echo pulled myservice" \
     "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml up -d --scale myservice=0 myservice : echo started dependencies for myservice" \
-    "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 -v buildkite:/buildkite -v $PWD/dist:/app/dist --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice with volumes"
+    "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 -v buildkite:/buildkite -v $PWD/dist:/app/dist -T --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice with volumes"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 0" \
@@ -790,7 +790,7 @@ export BUILDKITE_JOB_ID=1111
 
   stub docker \
     "compose -f llamas1.yml -f llamas2.yml -f llamas3.yml -p buildkite1111 up -d --scale myservice=0 myservice : echo started dependencies for myservice" \
-    "compose -f llamas1.yml -f llamas2.yml -f llamas3.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 --rm myservice /bin/sh -e -c 'echo hello world' : echo ran myservice"
+    "compose -f llamas1.yml -f llamas2.yml -f llamas3.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 -T --rm myservice /bin/sh -e -c 'echo hello world' : echo ran myservice"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice-llamas1.yml-llamas2.yml-llamas3.yml : exit 1"
@@ -815,7 +815,7 @@ export BUILDKITE_JOB_ID=1111
 
   stub docker \
     "compose -f docker-compose.yml -p buildkite1111 up -d --scale myservice=0 myservice : echo started dependencies for myservice" \
-    "compose -f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 --rm myservice /bin/sh -e -c 'pwd' : exit 2"
+    "compose -f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 -T --rm myservice /bin/sh -e -c 'pwd' : exit 2"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 1"
@@ -843,7 +843,7 @@ export BUILDKITE_JOB_ID=1111
   stub docker \
     "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml pull --parallel myservice1 myservice2 : echo pulled myservice1 and myservice2" \
     "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml up -d --scale myservice1=0 myservice1 : echo started dependencies for myservice1" \
-    "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice1_build_1 --rm myservice1 /bin/sh -e -c 'pwd' : echo ran myservice1"
+    "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice1_build_1 -T --rm myservice1 /bin/sh -e -c 'pwd' : echo ran myservice1"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice1 : exit 0" \
@@ -872,7 +872,7 @@ export BUILDKITE_JOB_ID=1111
 
   stub docker \
     "compose -f docker-compose.yml -p buildkite1111 up -d --scale myservice=0 myservice : echo started dependencies for myservice" \
-    "compose -f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 --user=1000 --rm myservice /bin/sh -e -c $'sh -c \'whoami\'' : echo ran myservice"
+    "compose -f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 -T --user=1000 --rm myservice /bin/sh -e -c $'sh -c \'whoami\'' : echo ran myservice"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 1"
@@ -898,7 +898,7 @@ export BUILDKITE_JOB_ID=1111
 
   stub docker \
     "compose -f docker-compose.yml -p buildkite1111 up -d --scale myservice=0 myservice : echo started dependencies for myservice" \
-    "compose -f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 --user=1000:1001 --rm myservice /bin/sh -e -c $'sh -c \'whoami\'' : echo ran myservice"
+    "compose -f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 -T --user=1000:1001 --rm myservice /bin/sh -e -c $'sh -c \'whoami\'' : echo ran myservice"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 1"
@@ -948,7 +948,7 @@ export BUILDKITE_JOB_ID=1111
   stub docker \
     "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml pull myservice : echo pulled myservice" \
     "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml up -d --scale myservice=0 myservice : echo started dependencies for myservice" \
-    "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 myservice /bin/sh -e -c $'pwd' : echo ran myservice without tty"
+    "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 -T myservice /bin/sh -e -c $'pwd' : echo ran myservice without tty"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : echo myimage" \
@@ -974,7 +974,7 @@ export BUILDKITE_JOB_ID=1111
 
   stub docker \
     "compose -f docker-compose.yml -p buildkite1111 up -d --scale myservice=0 myservice : echo ran myservice dependencies" \
-    "compose -f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 --rm --entrypoint 'my custom entrypoint' myservice : echo ran myservice"
+    "compose -f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 -T --rm --entrypoint 'my custom entrypoint' myservice : echo ran myservice"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 1"
@@ -1000,7 +1000,7 @@ export BUILDKITE_JOB_ID=1111
 
   stub docker \
     "compose -f docker-compose.yml -p buildkite1111 up -d --scale myservice=0 myservice : echo ran myservice dependencies" \
-    "compose -f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 --rm -e BUILDKITE_JOB_ID -e BUILDKITE_BUILD_ID -e BUILDKITE_AGENT_ACCESS_TOKEN -v $BATS_MOCK_TMPDIR/bin/buildkite-agent:/usr/bin/buildkite-agent myservice : echo ran myservice"
+    "compose -f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 -T --rm -e BUILDKITE_JOB_ID -e BUILDKITE_BUILD_ID -e BUILDKITE_AGENT_ACCESS_TOKEN -v $BATS_MOCK_TMPDIR/bin/buildkite-agent:/usr/bin/buildkite-agent myservice : echo ran myservice"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 1"
@@ -1027,7 +1027,7 @@ export BUILDKITE_JOB_ID=1111
 
   stub docker \
     "compose -f docker-compose.yml -p buildkite1111 up -d --scale myservice=0 myservice : echo ran myservice dependencies" \
-    "compose -f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 --rm myservice /bin/sh -e -c 'echo hello world' : echo ran myservice"
+    "compose -f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 -T --rm myservice /bin/sh -e -c 'echo hello world' : echo ran myservice"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 1"
@@ -1053,7 +1053,7 @@ export BUILDKITE_JOB_ID=1111
 
   stub docker \
     "compose -f docker-compose.yml -p buildkite1111 up -d --scale myservice=0 myservice : echo ran myservice dependencies" \
-    "compose -f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 -v /tmp/sample-mirror:/tmp/sample-mirror:ro --rm myservice /bin/sh -e -c 'echo hello world' : echo ran myservice"
+    "compose -f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 -v /tmp/sample-mirror:/tmp/sample-mirror:ro -T --rm myservice /bin/sh -e -c 'echo hello world' : echo ran myservice"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 1"
@@ -1080,7 +1080,7 @@ export BUILDKITE_JOB_ID=1111
 
   stub docker \
     "compose -f docker-compose.yml -p buildkite1111 up -d --scale myservice=0 myservice : echo ran myservice dependencies" \
-    "compose -f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 --rm -e SSH_AUTH_SOCK=/ssh-agent -v /tmp/ssh_auth_sock:/ssh-agent -v /root/.ssh/known_hosts:/root/.ssh/known_hosts myservice /bin/sh -e -c 'echo hello world' : echo ran myservice"
+    "compose -f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 -T --rm -e SSH_AUTH_SOCK=/ssh-agent -v /tmp/ssh_auth_sock:/ssh-agent -v /root/.ssh/known_hosts:/root/.ssh/known_hosts myservice /bin/sh -e -c 'echo hello world' : echo ran myservice"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 1"
@@ -1112,7 +1112,7 @@ export BUILDKITE_JOB_ID=1111
 
   stub docker \
     "compose -f docker-compose.yml -p buildkite1111 up -d --scale myservice=0 myservice : echo ran myservice dependencies" \
-    "compose -f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 --rm -e SSH_AUTH_SOCK=/ssh-agent -v /tmp/ssh_auth_sock:/ssh-agent -v /root/.ssh/known_hosts:/tmp/test/.ssh/known_hosts myservice /bin/sh -e -c 'echo hello world' : echo ran myservice"
+    "compose -f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 -T --rm -e SSH_AUTH_SOCK=/ssh-agent -v /tmp/ssh_auth_sock:/ssh-agent -v /root/.ssh/known_hosts:/tmp/test/.ssh/known_hosts myservice /bin/sh -e -c 'echo hello world' : echo ran myservice"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 1"
@@ -1145,7 +1145,7 @@ export BUILDKITE_JOB_ID=1111
   stub docker \
     "compose -f docker-compose.yml -p buildkite1111 -f \* pull myservice : echo pulled myservice" \
     "compose -f docker-compose.yml -p buildkite1111 -f \* up -d --scale myservice=0 myservice : echo started dependencies for myservice" \
-    "compose -f docker-compose.yml -p buildkite1111 -f \* run --name buildkite1111_myservice_build_1 --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice without mount-checkout"
+    "compose -f docker-compose.yml -p buildkite1111 -f \* run --name buildkite1111_myservice_build_1 -T --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice without mount-checkout"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 0" \
@@ -1174,7 +1174,7 @@ export BUILDKITE_JOB_ID=1111
   stub docker \
     "compose -f docker-compose.yml -p buildkite1111 -f \* pull myservice : echo pulled myservice" \
     "compose -f docker-compose.yml -p buildkite1111 -f \* up -d --scale myservice=0 myservice : echo started dependencies for myservice" \
-    "compose -f docker-compose.yml -p buildkite1111 -f \* run --name buildkite1111_myservice_build_1 --workdir=/workdir -v /plugin:/workdir --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice with mount-checkout"
+    "compose -f docker-compose.yml -p buildkite1111 -f \* run --name buildkite1111_myservice_build_1 -T --workdir=/workdir -v /plugin:/workdir --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice with mount-checkout"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 0" \
@@ -1204,7 +1204,7 @@ export BUILDKITE_JOB_ID=1111
   stub docker \
     "compose -f docker-compose.yml -p buildkite1111 -f \* pull myservice : echo pulled myservice" \
     "compose -f docker-compose.yml -p buildkite1111 -f \* up -d --scale myservice=0 myservice : echo started dependencies for myservice" \
-    "compose -f docker-compose.yml -p buildkite1111 -f \* run --name buildkite1111_myservice_build_1 \* -v \* --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice with mount-checkout on \${13}"
+    "compose -f docker-compose.yml -p buildkite1111 -f \* run --name buildkite1111_myservice_build_1 -T \* -v \* --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice with mount-checkout on \${14}"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 0" \
@@ -1233,7 +1233,7 @@ export BUILDKITE_JOB_ID=1111
   stub docker \
     "compose -f docker-compose.yml -p buildkite1111 -f \* pull myservice : echo pulled myservice" \
     "compose -f docker-compose.yml -p buildkite1111 -f \* up -d --scale myservice=0 myservice : echo started dependencies for myservice" \
-    "compose -f docker-compose.yml -p buildkite1111 -f \* run --name buildkite1111_myservice_build_1 -v \* --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice with mount-checkout on \${12}"
+    "compose -f docker-compose.yml -p buildkite1111 -f \* run --name buildkite1111_myservice_build_1 -T -v \* --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice with mount-checkout on \${13}"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 0" \
@@ -1263,7 +1263,7 @@ export BUILDKITE_JOB_ID=1111
   stub docker \
     "compose -f docker-compose.yml -p buildkite1111 -f \* pull myservice : echo pulled myservice" \
     "compose -f docker-compose.yml -p buildkite1111 -f \* up -d --scale myservice=0 myservice : echo started dependencies for myservice" \
-    "compose -f docker-compose.yml -p buildkite1111 -f \* run --name buildkite1111_myservice_build_1 \* -v \* --rm myservice /bin/sh -e -c 'pwd' : echo echo ran myservice with mount-checkout on \${13}"
+    "compose -f docker-compose.yml -p buildkite1111 -f \* run --name buildkite1111_myservice_build_1 -T \* -v \* --rm myservice /bin/sh -e -c 'pwd' : echo echo ran myservice with mount-checkout on \${14}"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 0" \
@@ -1346,7 +1346,7 @@ export BUILDKITE_JOB_ID=1111
 
   stub docker \
     "compose -f docker-compose.yml -p buildkite1111 up --wait -d --scale myservice=0 myservice : echo ran myservice dependencies" \
-    "compose -f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 --rm myservice /bin/sh -e -c 'echo hello world' : echo ran myservice"
+    "compose -f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 -T --rm myservice /bin/sh -e -c 'echo hello world' : echo ran myservice"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 1"
@@ -1373,7 +1373,7 @@ export BUILDKITE_JOB_ID=1111
   stub docker \
     "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml pull myservice : echo pulled myservice" \
     "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml up -d --scale myservice=0 myservice : echo started dependencies for myservice" \
-    "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 --rm --service-ports myservice /bin/sh -e -c $'pwd' : echo ran myservice without tty"
+    "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 -T --rm --service-ports myservice /bin/sh -e -c $'pwd' : echo ran myservice without tty"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : echo myimage" \
@@ -1399,7 +1399,7 @@ export BUILDKITE_JOB_ID=1111
 
   stub docker \
     "compose -f docker-compose.yml -p buildkite1111 up --quiet-pull -d --scale myservice=0 myservice : echo ran myservice dependencies" \
-    "compose -f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 --rm myservice /bin/sh -e -c 'echo hello world' : echo ran myservice"
+    "compose -f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 -T --rm myservice /bin/sh -e -c 'echo hello world' : echo ran myservice"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 1"
@@ -1427,7 +1427,7 @@ export BUILDKITE_JOB_ID=1111
 
   stub docker \
     "compose -f docker-compose.yml -p buildkite1111 up -d --scale myservice=0 myservice : echo ran myservice dependencies" \
-    "compose -f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 -e VAR_A -e VAR_B -e VAR_C --rm myservice /bin/sh -e -c 'echo hello world' : echo ran myservice"
+    "compose -f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 -e VAR_A -e VAR_B -e VAR_C -T --rm myservice /bin/sh -e -c 'echo hello world' : echo ran myservice"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 1"

--- a/tests/v1/build.bats
+++ b/tests/v1/build.bats
@@ -3,8 +3,12 @@
 load "${BATS_PLUGIN_PATH}/load.bash"
 load '../../lib/shared.bash'
 
- export DOCKER_COMPOSE_STUB_DEBUG=/dev/stdout
+# export DOCKER_COMPOSE_STUB_DEBUG=/dev/stdout
 # export BATS_MOCK_TMPDIR=$PWD
+
+setup_file() {
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLI_VERSION=1
+}
 
 teardown() {
   # some test failures may leave this file around

--- a/tests/v1/build.bats
+++ b/tests/v1/build.bats
@@ -1,19 +1,18 @@
 #!/usr/bin/env bats
 
 load "${BATS_PLUGIN_PATH}/load.bash"
-load '../../lib/shared'
+load '../../lib/shared.bash'
 
- export DOCKER_STUB_DEBUG=/dev/stdout
- export BUILDKITE_AGENT_STUB_DEBUG=/dev/stdout
+ export DOCKER_COMPOSE_STUB_DEBUG=/dev/stdout
 # export BATS_MOCK_TMPDIR=$PWD
 
-setup_file() {
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLI_VERSION=2
+teardown() {
+  # some test failures may leave this file around
+  rm -f docker-compose.buildkite-1-override.yml
 }
 
-teardown() {
-  # plugin leaves override files around
-  rm -f docker-compose.buildkite*-override.yml
+setup_file() {
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLI_VERSION=1
 }
 
 @test "Build without a repository" {
@@ -22,15 +21,15 @@ teardown() {
   export BUILDKITE_PIPELINE_SLUG=test
   export BUILDKITE_BUILD_NUMBER=1
 
-  stub docker \
-    "compose -f docker-compose.yml -p buildkite1111 build --pull myservice : echo built myservice"
+  stub docker-compose \
+    "-f docker-compose.yml -p buildkite1111 build --pull myservice : echo built myservice"
 
   run "$PWD"/hooks/command
 
   assert_success
   assert_output --partial "built myservice"
 
-  unstub docker
+  unstub docker-compose
 }
 
 @test "Build with no-cache" {
@@ -40,14 +39,14 @@ teardown() {
   export BUILDKITE_PIPELINE_SLUG=test
   export BUILDKITE_BUILD_NUMBER=1
 
-  stub docker \
-    "compose -f docker-compose.yml -p buildkite1111 build --pull --no-cache myservice : echo built myservice"
+  stub docker-compose \
+    "-f docker-compose.yml -p buildkite1111 build --pull --no-cache myservice : echo built myservice"
 
   run "$PWD"/hooks/command
 
   assert_success
   assert_output --partial "built myservice"
-  unstub docker
+  unstub docker-compose
 }
 
 @test "Build with parallel" {
@@ -57,14 +56,14 @@ teardown() {
   export BUILDKITE_PIPELINE_SLUG=test
   export BUILDKITE_BUILD_NUMBER=1
 
-  stub docker \
-    "compose -f docker-compose.yml -p buildkite1111 build --pull --parallel myservice : echo built myservice"
+  stub docker-compose \
+    "-f docker-compose.yml -p buildkite1111 build --pull --parallel myservice : echo built myservice"
 
   run "$PWD"/hooks/command
 
   assert_success
   assert_output --partial "built myservice"
-  unstub docker
+  unstub docker-compose
 }
 
 @test "Build with build args" {
@@ -75,18 +74,52 @@ teardown() {
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_ARGS_0=MYARG=0
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_ARGS_1=MYARG=1
 
-  stub docker \
-    "compose -f docker-compose.yml -p buildkite1111 build --pull --build-arg MYARG=0 --build-arg MYARG=1 myservice : echo built myservice"
+  stub docker-compose \
+    "-f docker-compose.yml -p buildkite1111 build --pull --build-arg MYARG=0 --build-arg MYARG=1 myservice : echo built myservice"
 
   run "$PWD"/hooks/command
 
   assert_success
   assert_output --partial "built myservice"
-  unstub docker
+  unstub docker-compose
 }
 
+@test "Build with docker-compose and v1 is set explicitly " {
+  export BUILDKITE_JOB_ID=1111
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD=myservice
+  export BUILDKITE_PIPELINE_SLUG=test
+  export BUILDKITE_BUILD_NUMBER=1
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLI_VERSION=1
+
+  stub docker-compose \
+    "-f docker-compose.yml -p buildkite1111 build --pull myservice : echo built myservice"
+
+  run "$PWD"/hooks/command
+
+  assert_success
+  assert_output --partial "built myservice"
+  unstub docker-compose
+}
+
+@test "Build with a repository" {
+  export BUILDKITE_JOB_ID=1111
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD=myservice
+  export BUILDKITE_PIPELINE_SLUG=test
+  export BUILDKITE_BUILD_NUMBER=1
+
+  stub docker-compose \
+    "-f docker-compose.yml -p buildkite1111 build --pull myservice : echo built myservice"
+
+  run "$PWD"/hooks/command
+
+  assert_success
+  assert_output --partial "built myservice"
+
+  unstub docker-compose
+}
+
+# TODO: move this to push testing
 @test "Build with a repository and multiple build aliases" {
-  skip "need to be moved to push"
   export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD=myservice
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD_ALIAS_0=myservice-1
@@ -94,43 +127,51 @@ teardown() {
   export BUILDKITE_PIPELINE_SLUG=test
   export BUILDKITE_BUILD_NUMBER=1
 
-  stub docker \
-    "compose -f docker-compose.yml -p buildkite1111 build --pull myservice : echo built myservice" \
-    "compose -f docker-compose.yml -p buildkite1111 push myservice : echo pushed myservice" \
-
-  stub buildkite-agent \
-    "meta-data set docker-compose-plugin-built-image-tag-myservice my.repository/llamas:test-myservice-build-1 : echo set image metadata for myservice" \
-    "meta-data set docker-compose-plugin-built-image-tag-myservice-1 my.repository/llamas:test-myservice-build-1 : echo set image metadata for myservice-1" \
-    "meta-data set docker-compose-plugin-built-image-tag-myservice-2 my.repository/llamas:test-myservice-build-1 : echo set image metadata for myservice-2"
+  stub docker-compose \
+    "-f docker-compose.yml -p buildkite1111 build --pull myservice : echo built myservice"
 
   run "$PWD"/hooks/command
 
   assert_success
   assert_output --partial "built myservice"
-  assert_output --partial "pushed myservice"
-  assert_output --partial "set image metadata for myservice"
-  assert_output --partial "set image metadata for myservice-1"
-  assert_output --partial "set image metadata for myservice-2"
-  unstub docker
-  unstub buildkite-agent
+
+  unstub docker-compose
 }
 
-@test "Build with a custom config file" {
+@test "Build with a repository and push retries" {
+  export BUILDKITE_JOB_ID=1111
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD=myservice
+  export BUILDKITE_PIPELINE_SLUG=test
+  export BUILDKITE_BUILD_NUMBER=1
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_PUSH_RETRIES=3
+
+  stub docker-compose \
+    "-f docker-compose.yml -p buildkite1111 build --pull myservice : echo built myservice"
+
+  run "$PWD"/hooks/command
+
+  assert_success
+  assert_output --partial "built myservice"
+
+  unstub docker-compose
+}
+
+@test "Build with a repository and custom config file" {
   export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD=myservice
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CONFIG=tests/composefiles/docker-compose.v2.0.yml
   export BUILDKITE_PIPELINE_SLUG=test
   export BUILDKITE_BUILD_NUMBER=1
 
-  stub docker \
-    "compose -f tests/composefiles/docker-compose.v2.0.yml -p buildkite1111 build --pull myservice : echo built myservice"
+  stub docker-compose \
+    "-f tests/composefiles/docker-compose.v2.0.yml -p buildkite1111 build --pull myservice : echo built myservice"
 
   run "$PWD"/hooks/command
 
   assert_success
   assert_output --partial "built myservice"
 
-  unstub docker
+  unstub docker-compose
 }
 
 @test "Build with a repository and multiple custom config files" {
@@ -141,15 +182,15 @@ teardown() {
   export BUILDKITE_PIPELINE_SLUG=test
   export BUILDKITE_BUILD_NUMBER=1
 
-  stub docker \
-    "compose -f tests/composefiles/docker-compose.v2.0.yml -f tests/composefiles/docker-compose.v2.1.yml -p buildkite1111 build --pull myservice : echo built myservice"
+  stub docker-compose \
+    "-f tests/composefiles/docker-compose.v2.0.yml -f tests/composefiles/docker-compose.v2.1.yml -p buildkite1111 build --pull myservice : echo built myservice"
 
   run "$PWD"/hooks/command
 
   assert_success
   assert_output --partial "built myservice"
 
-  unstub docker
+  unstub docker-compose
 }
 
 @test "Build with a repository and multiple services" {
@@ -159,29 +200,33 @@ teardown() {
   export BUILDKITE_PIPELINE_SLUG=test
   export BUILDKITE_BUILD_NUMBER=1
 
-  stub docker \
-    "compose -f docker-compose.yml -p buildkite1112 build --pull myservice1 myservice2 : echo built all services"
+  stub docker-compose \
+    "-f docker-compose.yml -p buildkite1112 build --pull myservice1 myservice2 : echo built all services"
 
   run "$PWD"/hooks/command
 
   assert_success
   assert_output --partial "built all services"
 
-  unstub docker
+  unstub docker-compose
 }
 
 @test "Build with a docker-compose v1.0 configuration file" {
   export BUILDKITE_JOB_ID=1112
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CONFIG="tests/composefiles/docker-compose.v1.0.yml"
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD_0=helloworld
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CACHE_FROM_0=helloworld:my.repository/myservice_cache:latest
   export BUILDKITE_PIPELINE_SLUG=test
   export BUILDKITE_BUILD_NUMBER=1
 
+  stub docker-compose \
+    "-f tests/composefiles/docker-compose.v1.0.yml -p buildkite1112 build --pull helloworld : echo built service"
+
   run "$PWD"/hooks/command
 
-  assert_failure
-  assert_output --partial "Compose file versions 2.0 and above"
+  assert_success
+  assert_output --partial "built service"
+
+  unstub docker-compose
 }
 
 @test "Build with a cache-from image" {
@@ -192,8 +237,8 @@ teardown() {
   export BUILDKITE_PIPELINE_SLUG=test
   export BUILDKITE_BUILD_NUMBER=1
 
-  stub docker \
-    "compose -f tests/composefiles/docker-compose.v3.2.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml build --pull helloworld : echo built helloworld"
+  stub docker-compose \
+    "-f tests/composefiles/docker-compose.v3.2.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml build --pull helloworld : echo built helloworld"
 
   run "$PWD"/hooks/command
 
@@ -201,48 +246,7 @@ teardown() {
   assert_output --partial "- my.repository/myservice_cache:latest"
   assert_output --partial "built helloworld"
 
-  unstub docker
-}
-
-@test "Build with an invalid cache-from tag (just passed through)" {
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CONFIG="tests/composefiles/docker-compose.v3.2.yml"
-  export BUILDKITE_JOB_ID=1111
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD_0=helloworld
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CACHE_FROM_0=helloworld:my.repository/myservice_cache:-latest
-  export BUILDKITE_PIPELINE_SLUG=test
-  export BUILDKITE_BUILD_NUMBER=1
-
-  stub docker \
-    "compose -f tests/composefiles/docker-compose.v3.2.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml build --pull helloworld : echo built helloworld"
-
-  run "$PWD"/hooks/command
-
-  assert_success
-  assert_output --partial "- my.repository/myservice_cache:-latest"
-  assert_output --partial "built helloworld"
-
-  unstub docker
-}
-
-@test "Build with a cache-from image with no tag" {
-  export BUILDKITE_BUILD_NUMBER=1
-  export BUILDKITE_JOB_ID=1111
-  export BUILDKITE_PIPELINE_SLUG=test
-
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD_0=helloworld
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CACHE_FROM_0=helloworld:my.repository/myservice_cache
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CONFIG="tests/composefiles/docker-compose.v3.2.yml"
-
-  stub docker \
-    "compose -f tests/composefiles/docker-compose.v3.2.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml build --pull helloworld : echo built helloworld"
-
-  run "$PWD"/hooks/command
-
-  assert_success
-  assert_output --partial "- my.repository/myservice_cache"
-  assert_output --partial "built helloworld"
-
-  unstub docker
+  unstub docker-compose
 }
 
 @test "Build with a cache-from image with no-cache also set" {
@@ -254,17 +258,56 @@ teardown() {
   export BUILDKITE_PIPELINE_SLUG=test
   export BUILDKITE_BUILD_NUMBER=1
 
-  stub docker \
-    "compose -f tests/composefiles/docker-compose.v3.2.yml -p buildkite1111 build --pull --no-cache helloworld : echo built helloworld"
+  stub docker-compose \
+    "-f tests/composefiles/docker-compose.v3.2.yml -p buildkite1111 build --pull --no-cache helloworld : echo built helloworld"
 
   run "$PWD"/hooks/command
 
   assert_success
-  refute_output --partial "pulled cache image"
   refute_output --partial "- my.repository/myservice_cache:latest"
   assert_output --partial "built helloworld"
+  unstub docker-compose
+}
 
-  unstub docker
+@test "Build with an invalid cache-from tag" {
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CONFIG="tests/composefiles/docker-compose.v3.2.yml"
+  export BUILDKITE_JOB_ID=1111
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD_0=helloworld
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CACHE_FROM_0=helloworld:my.repository/myservice_cache:-latest
+  export BUILDKITE_PIPELINE_SLUG=test
+  export BUILDKITE_BUILD_NUMBER=1
+
+  stub docker-compose \
+    "-f tests/composefiles/docker-compose.v3.2.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml build --pull helloworld : echo built helloworld"
+
+  run "$PWD"/hooks/command
+
+  assert_success
+  assert_output --partial "- my.repository/myservice_cache:-latest"
+  assert_output --partial "built helloworld"
+
+  unstub docker-compose
+}
+
+@test "Build with a cache-from image with no tag" {
+  export BUILDKITE_BUILD_NUMBER=1
+  export BUILDKITE_JOB_ID=1111
+  export BUILDKITE_PIPELINE_SLUG=test
+
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD_0=helloworld
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CACHE_FROM_0=helloworld:my.repository/myservice_cache
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CONFIG="tests/composefiles/docker-compose.v3.2.yml"
+
+  stub docker-compose \
+    "-f tests/composefiles/docker-compose.v3.2.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml build --pull helloworld : echo built helloworld"
+
+  run "$PWD"/hooks/command
+
+  assert_success
+  assert_output --partial "- my.repository/myservice_cache"
+  assert_output --partial "built helloworld"
+
+  unstub docker-compose
 }
 
 @test "Build with several cache-from images for one service" {
@@ -276,8 +319,8 @@ teardown() {
   export BUILDKITE_PIPELINE_SLUG=test
   export BUILDKITE_BUILD_NUMBER=1
 
-  stub docker \
-    "compose -f tests/composefiles/docker-compose.v3.2.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml build --pull helloworld : echo built helloworld"
+  stub docker-compose \
+    "-f tests/composefiles/docker-compose.v3.2.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml build --pull helloworld : echo built helloworld"
 
   run "$PWD"/hooks/command
 
@@ -286,7 +329,7 @@ teardown() {
   assert_output --partial "- my.repository/myservice_cache:latest"
   assert_output --partial "built helloworld"
 
-  unstub docker
+  unstub docker-compose
 }
 
 @test "Build with a cache-from image with hyphen" {
@@ -297,8 +340,8 @@ teardown() {
   export BUILDKITE_PIPELINE_SLUG=test
   export BUILDKITE_BUILD_NUMBER=1
 
-  stub docker \
-    "compose -f tests/composefiles/docker-compose.v3.2.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml build --pull hello-world : echo built hello-world"
+  stub docker-compose \
+    "-f tests/composefiles/docker-compose.v3.2.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml build --pull hello-world : echo built hello-world"
 
   run "$PWD"/hooks/command
 
@@ -306,7 +349,7 @@ teardown() {
   assert_output --partial "- my.repository/my-service_cache:latest"
   assert_output --partial "built hello-world"
 
-  unstub docker
+  unstub docker-compose
 }
 
 @test "Build with a service name and cache-from with period" {
@@ -317,8 +360,8 @@ teardown() {
   export BUILDKITE_PIPELINE_SLUG=test
   export BUILDKITE_BUILD_NUMBER=1
 
-  stub docker \
-    "compose -f tests/composefiles/docker-compose.v3.2.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml build --pull \* : echo built \${10}"
+  stub docker-compose \
+    "-f tests/composefiles/docker-compose.v3.2.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml build --pull \* : echo built \$9"
 
   run "$PWD"/hooks/command
 
@@ -326,7 +369,7 @@ teardown() {
   assert_output --partial "- my.repository/my-service_cache:latest"
   assert_output --partial "built hello.world"
 
-  unstub docker
+  unstub docker-compose
 }
 
 @test "Build with target" {
@@ -337,8 +380,8 @@ teardown() {
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD=myservice
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_TARGET=intermediate
 
-  stub docker \
-    "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml build --pull \* : echo built \${10}"
+  stub docker-compose \
+    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml build --pull \* : echo built \${9}"
 
   run "$PWD"/hooks/command
 
@@ -346,39 +389,36 @@ teardown() {
   assert_output --partial "built myservice"
   assert_output --partial "    target: intermediate"
 
-  unstub docker
+  unstub docker-compose
 }
 
-@test "Build with ssh option as boolean" {
+@test "Build with ssh option (but no buildkit)" {
   export BUILDKITE_BUILD_NUMBER=1
   export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PIPELINE_SLUG=test
 
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD=myservice
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_SSH=true
-
-  stub docker \
-    "compose -f docker-compose.yml -p buildkite1111 build --pull --ssh default \* : echo built \${10} with ssh"
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILDKIT=false
 
   run "$PWD"/hooks/command
 
-  assert_success
-  assert_output --partial "built myservice"
-  assert_output --partial "with ssh"
-
-  unstub docker
+  assert_failure
+  assert_output --partial "You can not use the ssh option if you are not using buildkit"
+  refute_output --partial "built myservice"
 }
 
-@test "Build with ssh option as string" {
+@test "Build with ssh option as true and buildkit" {
   export BUILDKITE_BUILD_NUMBER=1
   export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PIPELINE_SLUG=test
 
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD=myservice
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_SSH=context
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILDKIT=true
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_SSH=true
 
-  stub docker \
-    "compose -f docker-compose.yml -p buildkite1111 build --pull --ssh context \* : echo built \${10} with ssh"
+  stub docker-compose \
+    "-f docker-compose.yml -p buildkite1111 build --pull --ssh default \* : echo built \${9} with ssh"
 
   run "$PWD"/hooks/command
 
@@ -386,7 +426,28 @@ teardown() {
   assert_output --partial "built myservice"
   assert_output --partial "with ssh"
 
-  unstub docker
+  unstub docker-compose
+}
+
+@test "Build with ssh option as string and buildkit" {
+  export BUILDKITE_BUILD_NUMBER=1
+  export BUILDKITE_JOB_ID=1111
+  export BUILDKITE_PIPELINE_SLUG=test
+
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD=myservice
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILDKIT=true
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_SSH=context
+
+  stub docker-compose \
+    "-f docker-compose.yml -p buildkite1111 build --pull --ssh context \* : echo built \${9} with ssh"
+
+  run "$PWD"/hooks/command
+
+  assert_success
+  assert_output --partial "built myservice"
+  assert_output --partial "with ssh"
+
+  unstub docker-compose
 }
 
 @test "Build with secrets" {
@@ -398,8 +459,8 @@ teardown() {
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_SECRETS_0='id=test,file=~/.test'
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_SECRETS_1='id=SECRET_VAR'
 
-  stub docker \
-    "compose -f docker-compose.yml -p buildkite1111 build --pull --secret \* --secret \* \* : echo built \${12} with secrets \${9} and \${11}"
+  stub docker-compose \
+    "-f docker-compose.yml -p buildkite1111 build --pull --secret \* --secret \* \* : echo built \${11} with secrets \${8} and \${10}"
 
   run "$PWD"/hooks/command
 
@@ -407,7 +468,7 @@ teardown() {
   assert_output --partial "built myservice"
   assert_output --partial "with secrets id=test,file=~/.test and id=SECRET_VAR"
 
-  unstub docker
+  unstub docker-compose
 }
 
 @test "Build without pull" {
@@ -417,13 +478,12 @@ teardown() {
   export BUILDKITE_PIPELINE_SLUG=test
   export BUILDKITE_BUILD_NUMBER=1
 
-  stub docker \
-    "compose -f docker-compose.yml -p buildkite1111 build myservice : echo built myservice"
+  stub docker-compose \
+    "-f docker-compose.yml -p buildkite1111 build myservice : echo built myservice"
 
   run "$PWD"/hooks/command
 
   assert_success
   assert_output --partial "built myservice"
-
-  unstub docker
+  unstub docker-compose
 }

--- a/tests/v1/push.bats
+++ b/tests/v1/push.bats
@@ -1,7 +1,7 @@
 #!/usr/bin/env bats
 
 load "${BATS_PLUGIN_PATH}/load.bash"
-load '../../lib/shared'
+load '../../lib/shared.bash'
 
 # export DOCKER_COMPOSE_STUB_DEBUG=/dev/tty
 # export DOCKER_STUB_DEBUG=/dev/tty
@@ -9,7 +9,7 @@ load '../../lib/shared'
 # export BATS_MOCK_TMPDIR=$PWD
 
 setup_file() {
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLI_VERSION=2
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLI_VERSION=1
 }
 
 @test "Push a single service with an image in its config" {
@@ -19,19 +19,24 @@ setup_file() {
   export BUILDKITE_BUILD_NUMBER=1
 
   stub buildkite-agent \
-    "meta-data set docker-compose-plugin-built-image-tag-app \* : echo \$4"
+    "meta-data exists docker-compose-plugin-built-image-tag-app : exit 1" \
+    "meta-data set docker-compose-plugin-built-image-tag-app \* : echo \$4 > ${BATS_TEST_TMPDIR}/build-push-metadata"
+
+  stub docker-compose \
+    "-f docker-compose.yml -p buildkite1111 config --images app : echo app-image" \
+    "-f docker-compose.yml -p buildkite1111 push app : echo pushed app"
 
   stub docker \
-    "compose -f docker-compose.yml -p buildkite1111 config : cat ${PWD}/tests/composefiles/docker-compose.config.v3.2.yml" \
-    "image inspect somewhere.dkr.ecr.some-region.amazonaws.com/blah : exit 0" \
-    "compose -f docker-compose.yml -p buildkite1111 push app : echo pushed app"
+    "image inspect app-image : exit 0"
 
   run "$PWD"/hooks/command
 
   assert_success
   assert_output --partial "pushed app"
-  unstub docker
+
+  unstub docker-compose
   unstub buildkite-agent
+  unstub docker
 }
 
 @test "Push a prebuilt image with a repository and a tag" {
@@ -41,16 +46,17 @@ setup_file() {
   export BUILDKITE_BUILD_NUMBER=1
 
   stub docker \
-    "compose -f docker-compose.yml -p buildkite1111 config : echo ''" \
-    "image inspect \* : exit 1" \
     "pull myimage : echo pulled prebuilt image" \
     "tag myimage my.repository/myservice:llamas : echo tagged image" \
     "push my.repository/myservice:llamas : echo pushed myservice"
 
+  stub docker-compose \
+    "-f docker-compose.yml -p buildkite1111 config --images myservice : echo ''"
+
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 0" \
     "meta-data get docker-compose-plugin-built-image-tag-myservice : echo myimage" \
-    "meta-data set docker-compose-plugin-built-image-tag-myservice \* : echo \$4"
+    "meta-data set docker-compose-plugin-built-image-tag-myservice \* : echo \$4 > ${BATS_TEST_TMPDIR}/build-push-metadata"
 
   run "$PWD"/hooks/command
 
@@ -58,37 +64,8 @@ setup_file() {
   assert_output --partial "pulled prebuilt image"
   assert_output --partial "tagged image"
   assert_output --partial "pushed myservice"
-  unstub docker
-  unstub buildkite-agent
-}
 
-@test "Push a prebuilt image with a repository and a tag in compatibility mode" {
-  export BUILDKITE_BUILD_NUMBER=1
-  export BUILDKITE_JOB_ID=1111
-  export BUILDKITE_PIPELINE_SLUG=test
-
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_PUSH=myservice:my.repository/myservice:llamas
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_COMPATIBILITY=true
-
-  stub docker \
-    "compose --compatibility -f docker-compose.yml -p buildkite1111 config : echo ''" \
-    "image inspect \* : exit 1" \
-    "pull myimage : echo pulled prebuilt image" \
-    "tag myimage my.repository/myservice:llamas : echo tagged image" \
-    "push my.repository/myservice:llamas : echo pushed myservice"
-
-
-  stub buildkite-agent \
-    "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 0" \
-    "meta-data get docker-compose-plugin-built-image-tag-myservice : echo myimage" \
-    "meta-data set docker-compose-plugin-built-image-tag-myservice \* : echo \$4"
-
-  run "$PWD"/hooks/command
-
-  assert_success
-  assert_output --partial "pulled prebuilt image"
-  assert_output --partial "tagged image"
-  assert_output --partial "pushed myservice"
+  unstub docker-compose
   unstub docker
   unstub buildkite-agent
 }
@@ -99,15 +76,8 @@ setup_file() {
   export BUILDKITE_PIPELINE_SLUG=test
   export BUILDKITE_BUILD_NUMBER=1
 
-  stub docker \
-    "compose -f docker-compose.yml -p buildkite1111 config : echo ''" \
-    "image inspect \* : exit 1" \
-    "pull prebuilt : echo ''" \
-    "tag prebuilt \* : echo 'invalid tag'; exit 1"
-
-  stub buildkite-agent \
-    "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 0" \
-    "meta-data get docker-compose-plugin-built-image-tag-myservice : echo prebuilt" \
+  stub docker-compose \
+    "-f docker-compose.yml -p buildkite1111 config --images myservice : echo ''"
 
   run "$PWD"/hooks/command
 
@@ -117,8 +87,7 @@ setup_file() {
   refute_output --partial "tagged image"
   assert_output --partial "invalid tag"
 
-  unstub docker
-  unstub buildkite-agent
+  unstub docker-compose
 }
 
 @test "Push a prebuilt image to multiple tags" {
@@ -130,30 +99,29 @@ setup_file() {
   export BUILDKITE_BUILD_NUMBER=1
 
   stub docker \
-    "compose -f docker-compose.yml -p buildkite1111 config : echo ''" \
-    "image inspect \* : exit 1" \
     "pull prebuilt : echo pulled prebuilt image" \
     "tag prebuilt my.repository/myservice:llamas : echo tagged image1" \
     "push my.repository/myservice:llamas : echo pushed myservice1" \
-    "compose -f docker-compose.yml -p buildkite1111 config : echo ''" \
-    "image inspect \* : exit 1" \
-    "tag prebuilt2 my.repository/myservice:latest : echo tagged image2" \
+    "tag prebuilt my.repository/myservice:latest : echo tagged image2" \
     "push my.repository/myservice:latest : echo pushed myservice2" \
-    "compose -f docker-compose.yml -p buildkite1111 config : echo ''" \
-    "image inspect \* : exit 1" \
-    "tag prebuilt3 my.repository/myservice:alpacas : echo tagged image3" \
+    "tag prebuilt my.repository/myservice:alpacas : echo tagged image3" \
     "push my.repository/myservice:alpacas : echo pushed myservice3"
+
+  stub docker-compose \
+    "-f docker-compose.yml -p buildkite1111 config --images myservice : echo ''" \
+    "-f docker-compose.yml -p buildkite1111 config --images myservice : echo ''" \
+    "-f docker-compose.yml -p buildkite1111 config --images myservice : echo ''"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 0" \
     "meta-data get docker-compose-plugin-built-image-tag-myservice : echo prebuilt" \
     "meta-data set docker-compose-plugin-built-image-tag-myservice \* : echo \$4" \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 0" \
-    "meta-data get docker-compose-plugin-built-image-tag-myservice : echo prebuilt2" \
+    "meta-data get docker-compose-plugin-built-image-tag-myservice : echo prebuilt" \
     "meta-data set docker-compose-plugin-built-image-tag-myservice \* : echo \$4" \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 0" \
-    "meta-data get docker-compose-plugin-built-image-tag-myservice : echo prebuilt3" \
-    "meta-data set docker-compose-plugin-built-image-tag-myservice \* : echo \$4"
+    "meta-data get docker-compose-plugin-built-image-tag-myservice : echo prebuilt" \
+    "meta-data set docker-compose-plugin-built-image-tag-myservice \* : echo \$4" \
 
   run "$PWD"/hooks/command
 
@@ -165,11 +133,13 @@ setup_file() {
   assert_output --partial "pushed myservice2"
   assert_output --partial "tagged image3"
   assert_output --partial "pushed myservice3"
+
+  unstub docker-compose
   unstub docker
   unstub buildkite-agent
 }
 
-@test "Push a single service with service image" {
+@test "Push a single service without pre-built nor service image" {
   export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_PUSH=helper:my.repository/helper:llamas
   export BUILDKITE_PIPELINE_SLUG=test
@@ -178,69 +148,76 @@ setup_file() {
   stub buildkite-agent \
     "meta-data set docker-compose-plugin-built-image-tag-helper \* : echo \$4"
 
-  stub docker \
-    "compose -f docker-compose.yml -p buildkite1111 config : cat ${PWD}/tests/composefiles/docker-compose.config.v3.2.yml" \
-    "image inspect buildkite1111-helper : exit 0" \
-    "tag buildkite1111-helper my.repository/helper:llamas : echo tagged helper" \
-    "push my.repository/helper:llamas : echo pushed helper"
-
-  run "$PWD"/hooks/command
-
-  assert_success
-  assert_output --partial "tagged helper"
-  assert_output --partial "pushed helper"
-  unstub docker
-  unstub buildkite-agent
-}
-
-@test "Push a single service without prebuilt nor service image" {
-  export BUILDKITE_JOB_ID=1111
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_PUSH=helper:my.repository/helper:llamas
-  export BUILDKITE_PIPELINE_SLUG=test
-  export BUILDKITE_BUILD_NUMBER=1
-
-  stub buildkite-agent \
-    "meta-data exists docker-compose-plugin-built-image-tag-helper : exit 1"
+  stub docker-compose \
+    "-f docker-compose.yml -p buildkite1111 config --images helper : echo ''"
 
   stub docker \
-    "compose -f docker-compose.yml -p buildkite1111 config : cat ${PWD}/tests/composefiles/docker-compose.config.v3.2.yml" \
-    "image inspect buildkite1111-helper : exit 1" 
+    "image inspect \* : exit 1"
 
   run "$PWD"/hooks/command
 
   assert_failure
+
   assert_output --partial 'No prebuilt-image nor service image found for service to push'
 
+  unstub docker-compose
   unstub docker
   unstub buildkite-agent
 }
 
-@test "Push two services with pre-built images" {
+@test "Push two services without pre-built nor service image (second one is never tried)" {
   export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_PUSH_0=myservice1:my.repository/myservice1
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_PUSH_1=myservice2:my.repository/myservice2:llamas
   export BUILDKITE_PIPELINE_SLUG=test
   export BUILDKITE_BUILD_NUMBER=1
 
+  stub docker-compose \
+    "-f docker-compose.yml -p buildkite1111 config --images myservice1 : echo ''"
+
   stub docker \
-    "compose -f docker-compose.yml -p buildkite1111 config : echo ''" \
-    "image inspect buildkite1111-myservice1 : exit 1" \
-    "pull prebuilt1 : exit 0" \
-    "tag prebuilt1 my.repository/myservice1 : echo tagging image1" \
+    "image inspect \* : exit 1"
+
+  stub buildkite-agent \
+    "meta-data exists docker-compose-plugin-built-image-tag-myservice1 : exit 1"
+
+  run "$PWD"/hooks/command
+
+  assert_failure
+
+  assert_output --partial 'No prebuilt-image nor service image found for service to push'
+
+  unstub docker-compose
+  unstub buildkite-agent
+  unstub docker
+}
+
+@test "Push two pre-built services with target repositories and tags" {
+  export BUILDKITE_JOB_ID=1111
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_PUSH_0=myservice1:my.repository/myservice1
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_PUSH_1=myservice2:my.repository/myservice2:llamas
+  export BUILDKITE_PIPELINE_SLUG=test
+  export BUILDKITE_BUILD_NUMBER=1
+
+  stub docker-compose \
+    "-f docker-compose.yml -p buildkite1111 config --images myservice1 : echo ''" \
+    "-f docker-compose.yml -p buildkite1111 config --images myservice2 : echo ''" \
+
+  stub docker \
+    "pull myservice1 : exit 0" \
+    "tag myservice1 my.repository/myservice1 : echo tagging image1" \
     "push my.repository/myservice1 : echo pushing myservice1 image" \
-    "compose -f docker-compose.yml -p buildkite1111 config : echo ''" \
-    "image inspect buildkite1111-myservice2 : exit 1" \
-    "pull prebuilt2 : exit 0" \
-    "tag prebuilt2 my.repository/myservice2:llamas : echo tagging image2" \
+    "pull myservice2 : exit 0" \
+    "tag myservice2 my.repository/myservice2:llamas : echo tagging image2" \
     "push my.repository/myservice2:llamas : echo pushing myservice2 image"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice1 : exit 0" \
-    "meta-data get docker-compose-plugin-built-image-tag-myservice1 : echo prebuilt1" \
+    "meta-data get docker-compose-plugin-built-image-tag-myservice1 : echo myservice1" \
     "meta-data set docker-compose-plugin-built-image-tag-myservice1 \* : echo \$4" \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice2 : exit 0" \
-    "meta-data get docker-compose-plugin-built-image-tag-myservice2 : echo prebuilt2" \
-    "meta-data set docker-compose-plugin-built-image-tag-myservice2 \* : echo \$4"
+    "meta-data get docker-compose-plugin-built-image-tag-myservice2 : echo myservice2" \
+    "meta-data set docker-compose-plugin-built-image-tag-myservice2 \* : echo \$4" \
 
   run "$PWD"/hooks/command
 
@@ -249,6 +226,8 @@ setup_file() {
   assert_output --partial "pushing myservice1 image"
   assert_output --partial "tagging image2"
   assert_output --partial "pushing myservice2 image"
-  unstub docker
+
+  unstub docker-compose
   unstub buildkite-agent
+  unstub docker
 }

--- a/tests/v1/push.bats
+++ b/tests/v1/push.bats
@@ -1,7 +1,7 @@
 #!/usr/bin/env bats
 
 load "${BATS_PLUGIN_PATH}/load.bash"
-load '../../lib/shared.bash'
+load '../../lib/shared'
 
 # export DOCKER_COMPOSE_STUB_DEBUG=/dev/tty
 # export DOCKER_STUB_DEBUG=/dev/tty
@@ -19,15 +19,14 @@ setup_file() {
   export BUILDKITE_BUILD_NUMBER=1
 
   stub buildkite-agent \
-    "meta-data exists docker-compose-plugin-built-image-tag-app : exit 1" \
-    "meta-data set docker-compose-plugin-built-image-tag-app \* : echo \$4 > ${BATS_TEST_TMPDIR}/build-push-metadata"
+    "meta-data set docker-compose-plugin-built-image-tag-app \* : echo setting metadata to \$4"
 
   stub docker-compose \
-    "-f docker-compose.yml -p buildkite1111 config : echo app-image" \
+    "-f docker-compose.yml -p buildkite1111 config : cat ${PWD}/tests/composefiles/docker-compose.config.v3.2.yml" \
     "-f docker-compose.yml -p buildkite1111 push app : echo pushed app"
 
   stub docker \
-    "image inspect app-image : exit 0"
+    "image inspect \* : exit 0"
 
   run "$PWD"/hooks/command
 
@@ -46,12 +45,13 @@ setup_file() {
   export BUILDKITE_BUILD_NUMBER=1
 
   stub docker \
+    "image inspect \* : exit 1" \
     "pull myimage : echo pulled prebuilt image" \
     "tag myimage my.repository/myservice:llamas : echo tagged image" \
     "push my.repository/myservice:llamas : echo pushed myservice"
 
   stub docker-compose \
-    "-f docker-compose.yml -p buildkite1111 config --images myservice : echo ''"
+    "-f docker-compose.yml -p buildkite1111 config : echo ''"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 0" \
@@ -76,18 +76,29 @@ setup_file() {
   export BUILDKITE_PIPELINE_SLUG=test
   export BUILDKITE_BUILD_NUMBER=1
 
+
+  stub docker \
+    "image inspect \* : exit 1" \
+    "pull prebuilt : echo 'pulled prebuilt image'" \
+    "tag prebuilt \* : echo 'invalid tag'; exit 1"
+
   stub docker-compose \
-    "-f docker-compose.yml -p buildkite1111 config --images myservice : echo ''"
+    "-f docker-compose.yml -p buildkite1111 config : echo ''"
+
+  stub buildkite-agent \
+    "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 0" \
+    "meta-data get docker-compose-plugin-built-image-tag-myservice : echo prebuilt" \
 
   run "$PWD"/hooks/command
 
   assert_failure
-
-  refute_output --partial "pulled prebuilt image"
+  assert_output --partial "Pulling pre-built service"
   refute_output --partial "tagged image"
   assert_output --partial "invalid tag"
 
+  unstub docker
   unstub docker-compose
+  unstub buildkite-agent
 }
 
 @test "Push a prebuilt image to multiple tags" {
@@ -99,18 +110,21 @@ setup_file() {
   export BUILDKITE_BUILD_NUMBER=1
 
   stub docker \
+    "image inspect \* : exit 1" \
     "pull prebuilt : echo pulled prebuilt image" \
     "tag prebuilt my.repository/myservice:llamas : echo tagged image1" \
     "push my.repository/myservice:llamas : echo pushed myservice1" \
+    "image inspect \* : exit 1" \
     "tag prebuilt my.repository/myservice:latest : echo tagged image2" \
     "push my.repository/myservice:latest : echo pushed myservice2" \
+    "image inspect \* : exit 1" \
     "tag prebuilt my.repository/myservice:alpacas : echo tagged image3" \
     "push my.repository/myservice:alpacas : echo pushed myservice3"
 
   stub docker-compose \
-    "-f docker-compose.yml -p buildkite1111 config --images myservice : echo ''" \
-    "-f docker-compose.yml -p buildkite1111 config --images myservice : echo ''" \
-    "-f docker-compose.yml -p buildkite1111 config --images myservice : echo ''"
+    "-f docker-compose.yml -p buildkite1111 config : echo ''" \
+    "-f docker-compose.yml -p buildkite1111 config : echo ''" \
+    "-f docker-compose.yml -p buildkite1111 config : echo ''"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 0" \
@@ -146,10 +160,10 @@ setup_file() {
   export BUILDKITE_BUILD_NUMBER=1
 
   stub buildkite-agent \
-    "meta-data set docker-compose-plugin-built-image-tag-helper \* : echo \$4"
+    "meta-data exists docker-compose-plugin-built-image-tag-helper : exit 1"
 
   stub docker-compose \
-    "-f docker-compose.yml -p buildkite1111 config --images helper : echo ''"
+    "-f docker-compose.yml -p buildkite1111 config : echo ''"
 
   stub docker \
     "image inspect \* : exit 1"
@@ -173,7 +187,7 @@ setup_file() {
   export BUILDKITE_BUILD_NUMBER=1
 
   stub docker-compose \
-    "-f docker-compose.yml -p buildkite1111 config --images myservice1 : echo ''"
+    "-f docker-compose.yml -p buildkite1111 config : echo ''"
 
   stub docker \
     "image inspect \* : exit 1"
@@ -200,13 +214,15 @@ setup_file() {
   export BUILDKITE_BUILD_NUMBER=1
 
   stub docker-compose \
-    "-f docker-compose.yml -p buildkite1111 config --images myservice1 : echo ''" \
-    "-f docker-compose.yml -p buildkite1111 config --images myservice2 : echo ''" \
+    "-f docker-compose.yml -p buildkite1111 config : echo ''" \
+    "-f docker-compose.yml -p buildkite1111 config : echo ''" \
 
   stub docker \
+    "image inspect \* : exit 1" \
     "pull myservice1 : exit 0" \
     "tag myservice1 my.repository/myservice1 : echo tagging image1" \
     "push my.repository/myservice1 : echo pushing myservice1 image" \
+    "image inspect \* : exit 1" \
     "pull myservice2 : exit 0" \
     "tag myservice2 my.repository/myservice2:llamas : echo tagging image2" \
     "push my.repository/myservice2:llamas : echo pushing myservice2 image"

--- a/tests/v1/push.bats
+++ b/tests/v1/push.bats
@@ -23,7 +23,7 @@ setup_file() {
     "meta-data set docker-compose-plugin-built-image-tag-app \* : echo \$4 > ${BATS_TEST_TMPDIR}/build-push-metadata"
 
   stub docker-compose \
-    "-f docker-compose.yml -p buildkite1111 config --images app : echo app-image" \
+    "-f docker-compose.yml -p buildkite1111 config : echo app-image" \
     "-f docker-compose.yml -p buildkite1111 push app : echo pushed app"
 
   stub docker \

--- a/tests/v1/run.bats
+++ b/tests/v1/run.bats
@@ -1,16 +1,16 @@
 #!/usr/bin/env bats
 
 load "${BATS_PLUGIN_PATH}/load.bash"
-load '../../lib/shared'
-load '../../lib/run'
+load '../../lib/shared.bash'
+load '../../lib/run.bash'
 
 # export DOCKER_COMPOSE_STUB_DEBUG=/dev/tty
 # export BUILDKITE_AGENT_STUB_DEBUG=/dev/tty
 # export BATS_MOCK_TMPDIR=$PWD
 
 setup_file() {
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLI_VERSION=2
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RUN_LABELS="false"
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLI_VERSION=1
 }
 
 teardown() {
@@ -27,9 +27,9 @@ teardown() {
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CHECK_LINKED_CONTAINERS=false
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLEANUP=false
 
-  stub docker \
-    "compose -f docker-compose.yml -p buildkite1111 up -d --scale myservice=0 myservice : echo ran myservice dependencies" \
-    "compose -f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 -T --rm myservice /bin/sh -e -c 'echo hello world' : echo ran myservice"
+  stub docker-compose \
+    "-f docker-compose.yml -p buildkite1111 up -d --scale myservice=0 myservice : echo ran myservice dependencies" \
+    "-f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 -T --rm myservice /bin/sh -e -c 'echo hello world' : echo ran myservice"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 1"
@@ -38,8 +38,7 @@ teardown() {
 
   assert_success
   assert_output --partial "ran myservice"
-
-  unstub docker
+  unstub docker-compose
   unstub buildkite-agent
 }
 
@@ -52,9 +51,9 @@ teardown() {
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CHECK_LINKED_CONTAINERS=false
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLEANUP=false
 
-  stub docker \
-    "compose -f docker-compose.yml -p buildkite1111 up -d --scale myservice=0 myservice : echo ran myservice dependencies" \
-    "compose -f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 -T --rm myservice : echo ran myservice"
+  stub docker-compose \
+    "-f docker-compose.yml -p buildkite1111 up -d --scale myservice=0 myservice : echo ran myservice dependencies" \
+    "-f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 -T --rm myservice : echo ran myservice"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 1"
@@ -62,9 +61,9 @@ teardown() {
   run "$PWD"/hooks/command
 
   assert_success
+  refute_output --partial "The Docker Compose Plugin does not correctly support step-level array commands"
   assert_output --partial "ran myservice"
-
-  unstub docker
+  unstub docker-compose
   unstub buildkite-agent
 }
 
@@ -78,9 +77,9 @@ teardown() {
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CHECK_LINKED_CONTAINERS=false
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLEANUP=false
 
-  stub docker \
-    "compose -f docker-compose.yml -p buildkite1111 up -d --scale myservice=0 myservice : echo ran myservice dependencies" \
-    "compose -f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 -T --workdir=/test_workdir --rm myservice : echo ran myservice"
+  stub docker-compose \
+    "-f docker-compose.yml -p buildkite1111 up -d --scale myservice=0 myservice : echo ran myservice dependencies" \
+    "-f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 -T --workdir=/test_workdir --rm myservice : echo ran myservice"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 1"
@@ -89,8 +88,7 @@ teardown() {
 
   assert_success
   assert_output --partial "ran myservice"
-
-  unstub docker
+  unstub docker-compose
   unstub buildkite-agent
 }
 
@@ -103,9 +101,9 @@ teardown() {
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CHECK_LINKED_CONTAINERS=false
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLEANUP=false
 
-  stub docker \
-    "compose -f docker-compose.yml -p buildkite1111 up -d --scale myservice=0 myservice : echo ran myservice dependencies" \
-    "compose -f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 -T --rm myservice /bin/sh -e -c $'sh -c \'echo hello world\'' : echo ran myservice"
+  stub docker-compose \
+    "-f docker-compose.yml -p buildkite1111 up -d --scale myservice=0 myservice : echo ran myservice dependencies" \
+    "-f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 -T --rm myservice /bin/sh -e -c $'sh -c \'echo hello world\'' : echo ran myservice"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 1"
@@ -114,8 +112,7 @@ teardown() {
 
   assert_success
   assert_output --partial "ran myservice"
-
-  unstub docker
+  unstub docker-compose
   unstub buildkite-agent
 }
 
@@ -130,9 +127,9 @@ cmd3"
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CHECK_LINKED_CONTAINERS=false
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLEANUP=false
 
-  stub docker \
-    "compose -f docker-compose.yml -p buildkite1111 up -d --scale myservice=0 myservice : echo ran myservice dependencies" \
-    "compose -f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 -T --rm myservice /bin/sh -e -c $'cmd1\ncmd2\ncmd3' : echo ran myservice"
+  stub docker-compose \
+    "-f docker-compose.yml -p buildkite1111 up -d --scale myservice=0 myservice : echo ran myservice dependencies" \
+    "-f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 -T --rm myservice /bin/sh -e -c $'cmd1\ncmd2\ncmd3' : echo ran myservice"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 1"
@@ -140,9 +137,9 @@ cmd3"
   run "$PWD"/hooks/command
 
   assert_success
+  assert_output --partial "The Docker Compose Plugin does not correctly support step-level array commands"
   assert_output --partial "ran myservice"
-
-  unstub docker
+  unstub docker-compose
   unstub buildkite-agent
 }
 
@@ -157,9 +154,9 @@ cmd3"
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CHECK_LINKED_CONTAINERS=false
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLEANUP=false
 
-  stub docker \
-    "compose -f docker-compose.yml -p buildkite1111 up -d --scale myservice=0 myservice : echo ran myservice dependencies" \
-    "compose -f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 -T --rm myservice echo 'hello world' : echo ran myservice"
+  stub docker-compose \
+    "-f docker-compose.yml -p buildkite1111 up -d --scale myservice=0 myservice : echo ran myservice dependencies" \
+    "-f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 -T --rm myservice echo 'hello world' : echo ran myservice"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 1"
@@ -167,9 +164,9 @@ cmd3"
   run "$PWD"/hooks/command
 
   assert_success
+  refute_output --partial "The Docker Compose Plugin does not correctly support step-level array commands"
   assert_output --partial "ran myservice"
-
-  unstub docker
+  unstub docker-compose
   unstub buildkite-agent
 }
 
@@ -187,9 +184,9 @@ cmd3"
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_ENVIRONMENT_1=MYENV
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_ENVIRONMENT_2=ANOTHER="this is a long string with spaces; and semi-colons"
 
-  stub docker \
-    "compose -f docker-compose.yml -p buildkite1111 up -d --scale myservice=0 myservice : echo ran myservice dependencies" \
-    "compose -f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 -e MYENV=0 -e MYENV -e MYENV=2 -e MYENV -e ANOTHER=this\ is\ a\ long\ string\ with\ spaces\;\ and\ semi-colons -T --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice"
+  stub docker-compose \
+    "-f docker-compose.yml -p buildkite1111 up -d --scale myservice=0 myservice : echo ran myservice dependencies" \
+    "-f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 -e MYENV=0 -e MYENV -e MYENV=2 -e MYENV -e ANOTHER=this\ is\ a\ long\ string\ with\ spaces\;\ and\ semi-colons -T --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 1"
@@ -198,8 +195,7 @@ cmd3"
 
   assert_success
   assert_output --partial "ran myservice"
-
-  unstub docker
+  unstub docker-compose
   unstub buildkite-agent
 }
 
@@ -213,9 +209,9 @@ cmd3"
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CHECK_LINKED_CONTAINERS=false
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLEANUP=false
 
-  stub docker \
-    "compose -f docker-compose.yml -p buildkite1111 up -d --scale myservice=0 myservice : echo ran myservice dependencies" \
-    "compose -f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 -T --rm myservice /bin/sh -e -c 'echo hello world' : echo ran myservice"
+  stub docker-compose \
+    "-f docker-compose.yml -p buildkite1111 up -d --scale myservice=0 myservice : echo ran myservice dependencies" \
+    "-f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 -T --rm myservice /bin/sh -e -c 'echo hello world' : echo ran myservice"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 1"
@@ -224,8 +220,7 @@ cmd3"
 
   assert_success
   assert_output --partial "ran myservice"
-
-  unstub docker
+  unstub docker-compose
   unstub buildkite-agent
 }
 
@@ -240,9 +235,9 @@ cmd3"
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CHECK_LINKED_CONTAINERS=false
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLEANUP=false
 
-  stub docker \
-    "compose -f docker-compose.yml -p buildkite1111 up -d --scale myservice=0 myservice : echo ran myservice dependencies" \
-    "compose -f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 -T --rm myservice /bin/sh -e -c 'echo hello world' : echo ran myservice"
+  stub docker-compose \
+    "-f docker-compose.yml -p buildkite1111 up -d --scale myservice=0 myservice : echo ran myservice dependencies" \
+    "-f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 -T --rm myservice /bin/sh -e -c 'echo hello world' : echo ran myservice"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 1"
@@ -251,34 +246,7 @@ cmd3"
 
   assert_success
   assert_output --partial "ran myservice"
-
-  unstub docker
-  unstub buildkite-agent
-}
-
-@test "Run without a prebuilt image without pulling" {
-  export BUILDKITE_JOB_ID=1111
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RUN=myservice
-  export BUILDKITE_PIPELINE_SLUG=test
-  export BUILDKITE_BUILD_NUMBER=1
-  export BUILDKITE_COMMAND="echo hello world"
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CHECK_LINKED_CONTAINERS=false
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLEANUP=false
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_SKIP_PULL=true
-
-  stub docker \
-    "compose -f docker-compose.yml -p buildkite1111 up -d --scale myservice=0 myservice : echo ran myservice dependencies" \
-    "compose -f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 -T --rm myservice /bin/sh -e -c 'echo hello world' : echo ran myservice"
-
-  stub buildkite-agent \
-    "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 1"
-
-  run "$PWD"/hooks/command
-
-  assert_success
-  assert_output --partial "ran myservice"
-
-  unstub docker
+  unstub docker-compose
   unstub buildkite-agent
 }
 
@@ -290,10 +258,10 @@ cmd3"
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RUN=myservice
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_PROPAGATE_ENVIRONMENT=true
 
-  stub docker \
-    "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml pull myservice : echo pulled myservice" \
-    "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml up -d --scale myservice=0 myservice : echo ran myservice dependencies" \
-    "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 -T --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice"
+  stub docker-compose \
+    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml pull myservice : echo pulled myservice" \
+    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml up -d --scale myservice=0 myservice : echo ran myservice dependencies" \
+    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 -T --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 0" \
@@ -305,7 +273,7 @@ cmd3"
   assert_output --partial "Running /bin/sh -e -c 'pwd' in service myservice"
   assert_output --partial "Not propagating environment variables to container"
 
-  unstub docker
+  unstub docker-compose
   unstub buildkite-agent
 }
 
@@ -321,10 +289,10 @@ cmd3"
   echo "VAR0=1" > "${BUILDKITE_ENV_FILE}"
   echo "VAR2=lalala" >> "${BUILDKITE_ENV_FILE}"
 
-  stub docker \
-    "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml pull myservice : echo pulled myservice" \
-    "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml up -d --scale myservice=0 myservice : echo ran myservice dependencies" \
-    "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 -e \* -e \* -T --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice with vars \${12} and \${14}"
+  stub docker-compose \
+    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml pull myservice : echo pulled myservice" \
+    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml up -d --scale myservice=0 myservice : echo ran myservice dependencies" \
+    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 -e \* -e \* -T --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice with vars \${11} and \${13}"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 0" \
@@ -336,7 +304,7 @@ cmd3"
   assert_output --partial "Running /bin/sh -e -c 'pwd' in service myservice"
   assert_output --partial "ran myservice with vars VAR0 and VAR2"
 
-  unstub docker
+  unstub docker-compose
   unstub buildkite-agent
 
   rm "${BUILDKITE_ENV_FILE}"
@@ -351,10 +319,10 @@ cmd3"
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CHECK_LINKED_CONTAINERS=false
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLEANUP=false
 
-  stub docker \
-    "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml pull myservice : echo pulled myservice" \
-    "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml up -d --scale myservice=0 myservice : echo ran myservice dependencies" \
-    "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 -T --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice"
+  stub docker-compose \
+    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml pull myservice : echo pulled myservice" \
+    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml up -d --scale myservice=0 myservice : echo ran myservice dependencies" \
+    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 -T --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 0" \
@@ -364,7 +332,7 @@ cmd3"
 
   assert_success
   assert_output --partial "ran myservice"
-  unstub docker
+  unstub docker-compose
   unstub buildkite-agent
 }
 
@@ -378,10 +346,10 @@ cmd3"
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CHECK_LINKED_CONTAINERS=false
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLEANUP=false
 
-  stub docker \
-    "compose -f tests/composefiles/docker-compose.v2.0.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml pull myservice : echo pulled myservice" \
-    "compose -f tests/composefiles/docker-compose.v2.0.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml up -d --scale myservice=0 myservice : echo ran myservice dependencies" \
-    "compose -f tests/composefiles/docker-compose.v2.0.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 -T --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice"
+  stub docker-compose \
+    "-f tests/composefiles/docker-compose.v2.0.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml pull myservice : echo pulled myservice" \
+    "-f tests/composefiles/docker-compose.v2.0.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml up -d --scale myservice=0 myservice : echo ran myservice dependencies" \
+    "-f tests/composefiles/docker-compose.v2.0.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 -T --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice-tests/composefiles/docker-compose.v2.0.yml : exit 0" \
@@ -391,7 +359,7 @@ cmd3"
 
   assert_success
   assert_output --partial "ran myservice"
-  unstub docker
+  unstub docker-compose
   unstub buildkite-agent
 }
 
@@ -406,10 +374,10 @@ export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CHECK_LINKED_CONTAINERS=false
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLEANUP=false
 
-  stub docker \
-    "compose -f tests/composefiles/docker-compose.v2.0.yml -f tests/composefiles/docker-compose.v2.1.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml pull myservice : echo pulled myservice" \
-    "compose -f tests/composefiles/docker-compose.v2.0.yml -f tests/composefiles/docker-compose.v2.1.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml up -d --scale myservice=0 myservice : echo pulled myservice" \
-    "compose -f tests/composefiles/docker-compose.v2.0.yml -f tests/composefiles/docker-compose.v2.1.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 -T --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice"
+  stub docker-compose \
+    "-f tests/composefiles/docker-compose.v2.0.yml -f tests/composefiles/docker-compose.v2.1.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml pull myservice : echo pulled myservice" \
+    "-f tests/composefiles/docker-compose.v2.0.yml -f tests/composefiles/docker-compose.v2.1.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml up -d --scale myservice=0 myservice : echo pulled myservice" \
+    "-f tests/composefiles/docker-compose.v2.0.yml -f tests/composefiles/docker-compose.v2.1.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 -T --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice-tests/composefiles/docker-compose.v2.0.yml-tests/composefiles/docker-compose.v2.1.yml : exit 0" \
@@ -419,7 +387,7 @@ export BUILDKITE_JOB_ID=1111
 
   assert_success
   assert_output --partial "ran myservice"
-  unstub docker
+  unstub docker-compose
   unstub buildkite-agent
 }
 
@@ -433,10 +401,10 @@ export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CHECK_LINKED_CONTAINERS=false
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLEANUP=false
 
-  stub docker \
-    "compose -f tests/composefiles/docker-compose.v2.0.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml pull myservice : echo pulled myservice" \
-    "compose -f tests/composefiles/docker-compose.v2.0.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml up -d --scale myservice=0 myservice : echo ran myservice dependencies" \
-    "compose -f tests/composefiles/docker-compose.v2.0.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 -T --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice"
+  stub docker-compose \
+    "-f tests/composefiles/docker-compose.v2.0.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml pull myservice : echo pulled myservice" \
+    "-f tests/composefiles/docker-compose.v2.0.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml up -d --scale myservice=0 myservice : echo ran myservice dependencies" \
+    "-f tests/composefiles/docker-compose.v2.0.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 -T --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice-tests/composefiles/docker-compose.v2.0.yml : exit 0" \
@@ -446,7 +414,7 @@ export BUILDKITE_JOB_ID=1111
 
   assert_success
   assert_output --partial "ran myservice"
-  unstub docker
+  unstub docker-compose
   unstub buildkite-agent
 }
 
@@ -459,8 +427,8 @@ export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CHECK_LINKED_CONTAINERS=false
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLEANUP=false
 
-  stub docker \
-    "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml pull myservice : exit 2"
+  stub docker-compose \
+    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml pull myservice : exit 2"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 0" \
@@ -470,7 +438,7 @@ export BUILDKITE_JOB_ID=1111
 
   assert_failure
   assert_output --partial "Exited with 2"
-  unstub docker
+  unstub docker-compose
   unstub buildkite-agent
 }
 
@@ -484,11 +452,11 @@ export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLEANUP=false
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_PULL_RETRIES=3
 
-  stub docker \
-    "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml pull myservice : exit 2" \
-    "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml pull myservice : echo pulled myservice" \
-    "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml up -d --scale myservice=0 myservice : echo started dependencies for myservice" \
-    "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 -T --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice"
+  stub docker-compose \
+    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml pull myservice : exit 2" \
+    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml pull myservice : echo pulled myservice" \
+    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml up -d --scale myservice=0 myservice : echo started dependencies for myservice" \
+    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 -T --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 0" \
@@ -499,7 +467,7 @@ export BUILDKITE_JOB_ID=1111
   assert_success
   assert_output --partial "pulled myservice"
   assert_output --partial "ran myservice"
-  unstub docker
+  unstub docker-compose
   unstub buildkite-agent
 }
 
@@ -513,10 +481,10 @@ export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLEANUP=false
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_TTY=true
 
-  stub docker \
-    "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml pull myservice : echo pulled myservice" \
-    "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml up -d --scale myservice=0 myservice : echo started dependencies for myservice" \
-    "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice without tty"
+  stub docker-compose \
+    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml pull myservice : echo pulled myservice" \
+    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml up -d --scale myservice=0 myservice : echo started dependencies for myservice" \
+    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice without tty"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 0" \
@@ -526,7 +494,7 @@ export BUILDKITE_JOB_ID=1111
 
   assert_success
   assert_output --partial "ran myservice without tty"
-  unstub docker
+  unstub docker-compose
   unstub buildkite-agent
 }
 
@@ -540,9 +508,9 @@ export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLEANUP=false
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_DEPENDENCIES=false
 
-  stub docker \
-    "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml pull myservice : echo pulled myservice" \
-    "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 -T --no-deps --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice without dependencies"
+  stub docker-compose \
+    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml pull myservice : echo pulled myservice" \
+    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 -T --no-deps --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice without dependencies"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 0" \
@@ -552,7 +520,7 @@ export BUILDKITE_JOB_ID=1111
 
   assert_success
   assert_output --partial "ran myservice without dependencies"
-  unstub docker
+  unstub docker-compose
   unstub buildkite-agent
 }
 
@@ -566,9 +534,9 @@ export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLEANUP=false
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_PRE_RUN_DEPENDENCIES=false
 
-  stub docker \
-    "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml pull myservice : echo pulled myservice" \
-    "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 -T --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice with dependencies"
+  stub docker-compose \
+    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml pull myservice : echo pulled myservice" \
+    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 -T --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice with dependencies"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 0" \
@@ -578,8 +546,7 @@ export BUILDKITE_JOB_ID=1111
 
   assert_success
   assert_output --partial "ran myservice with dependencies"
-
-  unstub docker
+  unstub docker-compose
   unstub buildkite-agent
 }
 
@@ -593,10 +560,10 @@ export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLEANUP=false
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_ANSI=false
 
-  stub docker \
-    "compose --no-ansi -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml pull myservice : echo pulled myservice" \
-    "compose --no-ansi -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml up -d --scale myservice=0 myservice : echo started dependencies for myservice" \
-    "compose --no-ansi -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 -T --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice without ansi output"
+  stub docker-compose \
+    "--no-ansi -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml pull myservice : echo pulled myservice" \
+    "--no-ansi -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml up -d --scale myservice=0 myservice : echo started dependencies for myservice" \
+    "--no-ansi -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 -T --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice without ansi output"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 0" \
@@ -606,7 +573,34 @@ export BUILDKITE_JOB_ID=1111
 
   assert_success
   assert_output --partial "ran myservice without ansi output"
-  unstub docker
+  unstub docker-compose
+  unstub buildkite-agent
+}
+
+
+@test "Run without pull" {
+  export BUILDKITE_JOB_ID=1111
+  export BUILDKITE_PIPELINE_SLUG=test
+  export BUILDKITE_BUILD_NUMBER=1
+  export BUILDKITE_COMMAND=pwd
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RUN=myservice
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_SKIP_PULL=true
+
+  stub docker-compose \
+    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml up -d --scale myservice=0 myservice : echo started dependencies for myservice" \
+    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 -T --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice without pull"
+
+  stub buildkite-agent \
+    "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 0" \
+    "meta-data get docker-compose-plugin-built-image-tag-myservice : echo myimage"
+
+  run "$PWD"/hooks/command
+
+  assert_success
+  assert_output --partial "Running /bin/sh -e -c 'pwd' in service myservice"
+  assert_output --partial "ran myservice without pull"
+  
+  unstub docker-compose
   unstub buildkite-agent
 }
 
@@ -620,10 +614,10 @@ export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLEANUP=false
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_USE_ALIASES=true
 
-  stub docker \
-    "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml pull myservice : echo pulled myservice" \
-    "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml up -d --scale myservice=0 myservice : echo started dependencies for myservice" \
-    "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 -T --use-aliases --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice with use aliases output"
+  stub docker-compose \
+    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml pull myservice : echo pulled myservice" \
+    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml up -d --scale myservice=0 myservice : echo started dependencies for myservice" \
+    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 -T --use-aliases --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice with use aliases output"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 0" \
@@ -633,10 +627,9 @@ export BUILDKITE_JOB_ID=1111
 
   assert_success
   assert_output --partial "ran myservice with use aliases output"
-  unstub docker
+  unstub docker-compose
   unstub buildkite-agent
 }
-
 
 @test "Run with compatibility mode" {
   export BUILDKITE_BUILD_NUMBER=1
@@ -648,10 +641,10 @@ export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLEANUP=false
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_COMPATIBILITY=true
 
-  stub docker \
-    "compose --compatibility -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml pull myservice : echo pulled myservice" \
-    "compose --compatibility -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml up -d --scale myservice=0 myservice : echo started dependencies for myservice" \
-    "compose --compatibility -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 -T --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice with use aliases output"
+  stub docker-compose \
+    "--compatibility -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml pull myservice : echo pulled myservice" \
+    "--compatibility -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml up -d --scale myservice=0 myservice : echo started dependencies for myservice" \
+    "--compatibility -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 -T --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice with use aliases output"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 0" \
@@ -661,7 +654,7 @@ export BUILDKITE_JOB_ID=1111
 
   assert_success
   assert_output --partial "ran myservice with use aliases output"
-  unstub docker
+  unstub docker-compose
   unstub buildkite-agent
 }
 
@@ -676,10 +669,10 @@ export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_VOLUMES_0="./dist:/app/dist"
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_VOLUMES_1="./pkg:/app/pkg"
 
-  stub docker \
-    "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml pull myservice : echo pulled myservice" \
-    "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml up -d --scale myservice=0 myservice : echo started dependencies for myservice" \
-    "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 -v $PWD/dist:/app/dist -v $PWD/pkg:/app/pkg -T --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice with volumes"
+  stub docker-compose \
+    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml pull myservice : echo pulled myservice" \
+    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml up -d --scale myservice=0 myservice : echo started dependencies for myservice" \
+    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 -v $PWD/dist:/app/dist -v $PWD/pkg:/app/pkg -T --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice with volumes"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 0" \
@@ -689,7 +682,7 @@ export BUILDKITE_JOB_ID=1111
 
   assert_success
   assert_output --partial "ran myservice with volumes"
-  unstub docker
+  unstub docker-compose
   unstub buildkite-agent
 }
 
@@ -703,10 +696,10 @@ export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLEANUP=false
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_VOLUMES="buildkite:/buildkite"
 
-  stub docker \
-    "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml pull myservice : echo pulled myservice" \
-    "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml up -d --scale myservice=0 myservice : echo started dependencies for myservice" \
-    "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 -v buildkite:/buildkite -T --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice with volumes"
+  stub docker-compose \
+    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml pull myservice : echo pulled myservice" \
+    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml up -d --scale myservice=0 myservice : echo started dependencies for myservice" \
+    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 -v buildkite:/buildkite -T --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice with volumes"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 0" \
@@ -716,7 +709,7 @@ export BUILDKITE_JOB_ID=1111
 
   assert_success
   assert_output --partial "ran myservice with volumes"
-  unstub docker
+  unstub docker-compose
   unstub buildkite-agent
 }
 
@@ -733,10 +726,10 @@ export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLEANUP=false
   export BUILDKITE_DOCKER_DEFAULT_VOLUMES="buildkite:/buildkite; ./dist:/app/dist;; ;   ;"
 
-  stub docker \
-    "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml pull myservice : echo pulled myservice" \
-    "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml up -d --scale myservice=0 myservice : echo started dependencies for myservice" \
-    "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 -v buildkite:/buildkite -v $PWD/dist:/app/dist -T --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice with volumes"
+  stub docker-compose \
+    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml pull myservice : echo pulled myservice" \
+    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml up -d --scale myservice=0 myservice : echo started dependencies for myservice" \
+    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 -v buildkite:/buildkite -v $PWD/dist:/app/dist -T --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice with volumes"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 0" \
@@ -746,7 +739,111 @@ export BUILDKITE_JOB_ID=1111
 
   assert_success
   assert_output --partial "ran myservice with volumes"
-  unstub docker
+  unstub docker-compose
+  unstub buildkite-agent
+}
+
+@test "Run with volumes with variables" {
+  export BUILDKITE_JOB_ID=1111
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RUN=myservice
+  export BUILDKITE_PIPELINE_SLUG=test
+  export BUILDKITE_BUILD_NUMBER=1
+  export BUILDKITE_COMMAND=pwd
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CHECK_LINKED_CONTAINERS=false
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLEANUP=false
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_VOLUMES_0="\$SUPER_VARIABLE:/mnt"
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_VOLUMES_1="/:\$OTHER_VARIABLE"
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_VOLUMES_2="\$RELATIVE_VARIABLE:/srv"
+
+  export SUPER_VARIABLE='/test/path'
+  export OTHER_VARIABLE='/path/tested'
+  export RELATIVE_VARIABLE='./path'
+
+  stub docker-compose \
+    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml pull myservice : echo pulled myservice" \
+    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml up -d --scale myservice=0 myservice : echo started dependencies for myservice" \
+    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 -v \\\$SUPER_VARIABLE:/mnt -v /:\\\$OTHER_VARIABLE -v \\\$RELATIVE_VARIABLE:/srv -T --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice with volumes"
+
+  stub buildkite-agent \
+    "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 0" \
+    "meta-data get docker-compose-plugin-built-image-tag-myservice : echo myimage"
+
+  run "$PWD"/hooks/command
+
+  assert_success
+  assert_output --partial "ran myservice with volumes"
+  unstub docker-compose
+  unstub buildkite-agent
+}
+
+
+@test "Run with volumes with variables but option turned off" {
+  export BUILDKITE_JOB_ID=1111
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RUN=myservice
+  export BUILDKITE_PIPELINE_SLUG=test
+  export BUILDKITE_BUILD_NUMBER=1
+  export BUILDKITE_COMMAND=pwd
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CHECK_LINKED_CONTAINERS=false
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLEANUP=false
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_EXPAND_VOLUME_VARS=false
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_VOLUMES_0="\$SUPER_VARIABLE:/mnt"
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_VOLUMES_1="/:\$OTHER_VARIABLE"
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_VOLUMES_2="\$RELATIVE_VARIABLE:/srv"
+
+
+  export SUPER_VARIABLE='/test/path'
+  export OTHER_VARIABLE='/path/tested'
+  export RELATIVE_VARIABLE='./path'
+
+  stub docker-compose \
+    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml pull myservice : echo pulled myservice" \
+    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml up -d --scale myservice=0 myservice : echo started dependencies for myservice" \
+    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 -v \\\$SUPER_VARIABLE:/mnt -v /:\\\$OTHER_VARIABLE -v \\\$RELATIVE_VARIABLE:/srv -T --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice with volumes"
+
+  stub buildkite-agent \
+    "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 0" \
+    "meta-data get docker-compose-plugin-built-image-tag-myservice : echo myimage"
+
+  run "$PWD"/hooks/command
+
+  assert_success
+  assert_output --partial "ran myservice with volumes"
+  unstub docker-compose
+  unstub buildkite-agent
+}
+
+@test "Run with volumes with variables and option turned on" {
+  export BUILDKITE_JOB_ID=1111
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RUN=myservice
+  export BUILDKITE_PIPELINE_SLUG=test
+  export BUILDKITE_BUILD_NUMBER=1
+  export BUILDKITE_COMMAND=pwd
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CHECK_LINKED_CONTAINERS=false
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLEANUP=true
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_EXPAND_VOLUME_VARS=true
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_VOLUMES_0="\$SUPER_VARIABLE:/mnt"
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_VOLUMES_1="/:\$OTHER_VARIABLE"
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_VOLUMES_2="\$RELATIVE_VARIABLE:/srv"
+
+
+  export SUPER_VARIABLE='/test/path'
+  export OTHER_VARIABLE='/path/tested'
+  export RELATIVE_VARIABLE='./path'
+
+  stub docker-compose \
+    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml pull myservice : echo pulled myservice" \
+    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml up -d --scale myservice=0 myservice : echo started dependencies for myservice" \
+    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 -v /test/path:/mnt -v /:/path/tested -v $PWD/path:/srv -T --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice with volumes"
+
+  stub buildkite-agent \
+    "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 0" \
+    "meta-data get docker-compose-plugin-built-image-tag-myservice : echo myimage"
+
+  run "$PWD"/hooks/command
+
+  assert_success
+  assert_output --partial "ran myservice with volumes"
+  unstub docker-compose
   unstub buildkite-agent
 }
 
@@ -760,10 +857,10 @@ export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLEANUP=false
   export BUILDKITE_DOCKER_DEFAULT_VOLUMES="buildkite:/buildkite;./dist:/app/dist"
 
-  stub docker \
-    "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml pull myservice : echo pulled myservice" \
-    "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml up -d --scale myservice=0 myservice : echo started dependencies for myservice" \
-    "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 -v buildkite:/buildkite -v $PWD/dist:/app/dist -T --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice with volumes"
+  stub docker-compose \
+    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml pull myservice : echo pulled myservice" \
+    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml up -d --scale myservice=0 myservice : echo started dependencies for myservice" \
+    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 -v buildkite:/buildkite -v $PWD/dist:/app/dist -T --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice with volumes"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 0" \
@@ -773,7 +870,7 @@ export BUILDKITE_JOB_ID=1111
 
   assert_success
   assert_output --partial "ran myservice with volumes"
-  unstub docker
+  unstub docker-compose
   unstub buildkite-agent
 }
 
@@ -789,9 +886,9 @@ export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CONFIG_1="llamas2.yml"
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CONFIG_2="llamas3.yml"
 
-  stub docker \
-    "compose -f llamas1.yml -f llamas2.yml -f llamas3.yml -p buildkite1111 up -d --scale myservice=0 myservice : echo started dependencies for myservice" \
-    "compose -f llamas1.yml -f llamas2.yml -f llamas3.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 -T --rm myservice /bin/sh -e -c 'echo hello world' : echo ran myservice"
+  stub docker-compose \
+    "-f llamas1.yml -f llamas2.yml -f llamas3.yml -p buildkite1111 up -d --scale myservice=0 myservice : echo started dependencies for myservice" \
+    "-f llamas1.yml -f llamas2.yml -f llamas3.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 -T --rm myservice /bin/sh -e -c 'echo hello world' : echo ran myservice"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice-llamas1.yml-llamas2.yml-llamas3.yml : exit 1"
@@ -800,8 +897,7 @@ export BUILDKITE_JOB_ID=1111
 
   assert_success
   assert_output --partial "ran myservice"
-
-  unstub docker
+  unstub docker-compose
   unstub buildkite-agent
 }
 
@@ -814,9 +910,9 @@ export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CHECK_LINKED_CONTAINERS=false
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLEANUP=false
 
-  stub docker \
-    "compose -f docker-compose.yml -p buildkite1111 up -d --scale myservice=0 myservice : echo started dependencies for myservice" \
-    "compose -f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 -T --rm myservice /bin/sh -e -c 'pwd' : exit 2"
+  stub docker-compose \
+    "-f docker-compose.yml -p buildkite1111 up -d --scale myservice=0 myservice : echo started dependencies for myservice" \
+    "-f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 -T --rm myservice /bin/sh -e -c 'pwd' : exit 2"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 1"
@@ -826,7 +922,7 @@ export BUILDKITE_JOB_ID=1111
   assert_failure
   assert_output --partial "^^^ +++"
   assert_output --partial "Failed to run command, exited with 2"
-  unstub docker
+  unstub docker-compose
   unstub buildkite-agent
 }
 
@@ -841,10 +937,10 @@ export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CHECK_LINKED_CONTAINERS=false
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLEANUP=false
 
-  stub docker \
-    "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml pull --parallel myservice1 myservice2 : echo pulled myservice1 and myservice2" \
-    "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml up -d --scale myservice1=0 myservice1 : echo started dependencies for myservice1" \
-    "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice1_build_1 -T --rm myservice1 /bin/sh -e -c 'pwd' : echo ran myservice1"
+  stub docker-compose \
+    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml pull --parallel myservice1 myservice2 : echo pulled myservice1 and myservice2" \
+    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml up -d --scale myservice1=0 myservice1 : echo started dependencies for myservice1" \
+    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice1_build_1 -T --rm myservice1 /bin/sh -e -c 'pwd' : echo ran myservice1"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice1 : exit 0" \
@@ -857,7 +953,7 @@ export BUILDKITE_JOB_ID=1111
   assert_success
   assert_output --partial "pulled myservice1 and myservice2"
   assert_output --partial "ran myservice1"
-  unstub docker
+  unstub docker-compose
   unstub buildkite-agent
 }
 
@@ -871,9 +967,9 @@ export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLEANUP=false
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_USER="1000"
 
-  stub docker \
-    "compose -f docker-compose.yml -p buildkite1111 up -d --scale myservice=0 myservice : echo started dependencies for myservice" \
-    "compose -f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 -T --user=1000 --rm myservice /bin/sh -e -c $'sh -c \'whoami\'' : echo ran myservice"
+  stub docker-compose \
+    "-f docker-compose.yml -p buildkite1111 up -d --scale myservice=0 myservice : echo started dependencies for myservice" \
+    "-f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 -T --user=1000 --rm myservice /bin/sh -e -c $'sh -c \'whoami\'' : echo ran myservice"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 1"
@@ -882,8 +978,7 @@ export BUILDKITE_JOB_ID=1111
 
   assert_success
   assert_output --partial "ran myservice"
-
-  unstub docker
+  unstub docker-compose
   unstub buildkite-agent
 }
 
@@ -897,9 +992,9 @@ export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLEANUP=false
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_USER="1000:1001"
 
-  stub docker \
-    "compose -f docker-compose.yml -p buildkite1111 up -d --scale myservice=0 myservice : echo started dependencies for myservice" \
-    "compose -f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 -T --user=1000:1001 --rm myservice /bin/sh -e -c $'sh -c \'whoami\'' : echo ran myservice"
+  stub docker-compose \
+    "-f docker-compose.yml -p buildkite1111 up -d --scale myservice=0 myservice : echo started dependencies for myservice" \
+    "-f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 -T --user=1000:1001 --rm myservice /bin/sh -e -c $'sh -c \'whoami\'' : echo ran myservice"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 1"
@@ -908,8 +1003,7 @@ export BUILDKITE_JOB_ID=1111
 
   assert_success
   assert_output --partial "ran myservice"
-
-  unstub docker
+  unstub docker-compose
   unstub buildkite-agent
 }
 
@@ -936,7 +1030,7 @@ export BUILDKITE_JOB_ID=1111
 }
 
 
-@test "Run without --rm" {
+@test "Run without -T --rm" {
   export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RUN=myservice
   export BUILDKITE_PIPELINE_SLUG=test
@@ -945,11 +1039,12 @@ export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CHECK_LINKED_CONTAINERS=false
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLEANUP=false
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RM=false
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_TTY=true
 
-  stub docker \
-    "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml pull myservice : echo pulled myservice" \
-    "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml up -d --scale myservice=0 myservice : echo started dependencies for myservice" \
-    "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 -T myservice /bin/sh -e -c $'pwd' : echo ran myservice without tty"
+  stub docker-compose \
+    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml pull myservice : echo pulled myservice" \
+    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml up -d --scale myservice=0 myservice : echo started dependencies for myservice" \
+    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 myservice /bin/sh -e -c $'pwd' : echo ran myservice without tty"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : echo myimage" \
@@ -959,7 +1054,7 @@ export BUILDKITE_JOB_ID=1111
 
   assert_success
   assert_output --partial "ran myservice without tty"
-  unstub docker
+  unstub docker-compose
   unstub buildkite-agent
 }
 
@@ -973,9 +1068,9 @@ export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLEANUP=false
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_ENTRYPOINT="my custom entrypoint"
 
-  stub docker \
-    "compose -f docker-compose.yml -p buildkite1111 up -d --scale myservice=0 myservice : echo ran myservice dependencies" \
-    "compose -f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 -T --rm --entrypoint 'my custom entrypoint' myservice : echo ran myservice"
+  stub docker-compose \
+    "-f docker-compose.yml -p buildkite1111 up -d --scale myservice=0 myservice : echo ran myservice dependencies" \
+    "-f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 -T --rm --entrypoint 'my custom entrypoint' myservice : echo ran myservice"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 1"
@@ -984,8 +1079,7 @@ export BUILDKITE_JOB_ID=1111
 
   assert_success
   assert_output --partial "ran myservice"
-
-  unstub docker
+  unstub docker-compose
   unstub buildkite-agent
 }
 
@@ -999,9 +1093,9 @@ export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLEANUP=false
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_MOUNT_BUILDKITE_AGENT=true
 
-  stub docker \
-    "compose -f docker-compose.yml -p buildkite1111 up -d --scale myservice=0 myservice : echo ran myservice dependencies" \
-    "compose -f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 -T --rm -e BUILDKITE_JOB_ID -e BUILDKITE_BUILD_ID -e BUILDKITE_AGENT_ACCESS_TOKEN -v $BATS_MOCK_TMPDIR/bin/buildkite-agent:/usr/bin/buildkite-agent myservice : echo ran myservice"
+  stub docker-compose \
+    "-f docker-compose.yml -p buildkite1111 up -d --scale myservice=0 myservice : echo ran myservice dependencies" \
+    "-f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 -T --rm -e BUILDKITE_JOB_ID -e BUILDKITE_BUILD_ID -e BUILDKITE_AGENT_ACCESS_TOKEN -v $BATS_MOCK_TMPDIR/bin/buildkite-agent:/usr/bin/buildkite-agent myservice : echo ran myservice"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 1"
@@ -1010,8 +1104,7 @@ export BUILDKITE_JOB_ID=1111
 
   assert_success
   assert_output --partial "ran myservice"
-
-  unstub docker
+  unstub docker-compose
   unstub buildkite-agent
 }
 
@@ -1026,9 +1119,9 @@ export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_NO_CACHE=true
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD_PARALLEL=true
 
-  stub docker \
-    "compose -f docker-compose.yml -p buildkite1111 up -d --scale myservice=0 myservice : echo ran myservice dependencies" \
-    "compose -f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 -T --rm myservice /bin/sh -e -c 'echo hello world' : echo ran myservice"
+  stub docker-compose \
+    "-f docker-compose.yml -p buildkite1111 up -d --scale myservice=0 myservice : echo ran myservice dependencies" \
+    "-f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 -T --rm myservice /bin/sh -e -c 'echo hello world' : echo ran myservice"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 1"
@@ -1037,8 +1130,7 @@ export BUILDKITE_JOB_ID=1111
 
   assert_success
   assert_output --partial "ran myservice"
-
-  unstub docker
+  unstub docker-compose
   unstub buildkite-agent
 }
 
@@ -1052,9 +1144,9 @@ export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLEANUP=false
   export BUILDKITE_REPO_MIRROR=/tmp/sample-mirror
 
-  stub docker \
-    "compose -f docker-compose.yml -p buildkite1111 up -d --scale myservice=0 myservice : echo ran myservice dependencies" \
-    "compose -f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 -v /tmp/sample-mirror:/tmp/sample-mirror:ro -T --rm myservice /bin/sh -e -c 'echo hello world' : echo ran myservice"
+  stub docker-compose \
+    "-f docker-compose.yml -p buildkite1111 up -d --scale myservice=0 myservice : echo ran myservice dependencies" \
+    "-f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 -v /tmp/sample-mirror:/tmp/sample-mirror:ro -T --rm myservice /bin/sh -e -c 'echo hello world' : echo ran myservice"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 1"
@@ -1063,8 +1155,7 @@ export BUILDKITE_JOB_ID=1111
 
   assert_success
   assert_output --partial "ran myservice"
-
-  unstub docker
+  unstub docker-compose
   unstub buildkite-agent
 }
 
@@ -1079,9 +1170,9 @@ export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLEANUP=false
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_MOUNT_SSH_AGENT=true
 
-  stub docker \
-    "compose -f docker-compose.yml -p buildkite1111 up -d --scale myservice=0 myservice : echo ran myservice dependencies" \
-    "compose -f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 -T --rm -e SSH_AUTH_SOCK=/ssh-agent -v /tmp/ssh_auth_sock:/ssh-agent -v /root/.ssh/known_hosts:/root/.ssh/known_hosts myservice /bin/sh -e -c 'echo hello world' : echo ran myservice"
+  stub docker-compose \
+    "-f docker-compose.yml -p buildkite1111 up -d --scale myservice=0 myservice : echo ran myservice dependencies" \
+    "-f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 -T --rm -e SSH_AUTH_SOCK=/ssh-agent -v /tmp/ssh_auth_sock:/ssh-agent -v /root/.ssh/known_hosts:/root/.ssh/known_hosts myservice /bin/sh -e -c 'echo hello world' : echo ran myservice"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 1"
@@ -1091,12 +1182,12 @@ export BUILDKITE_JOB_ID=1111
 
   run "$PWD"/hooks/command
 
+  assert_success
+
   kill %1
 
-  assert_success
   assert_output --partial "ran myservice"
-
-  unstub docker
+  unstub docker-compose
   unstub buildkite-agent
 }
 
@@ -1111,9 +1202,9 @@ export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLEANUP=false
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_MOUNT_SSH_AGENT=/tmp/test
 
-  stub docker \
-    "compose -f docker-compose.yml -p buildkite1111 up -d --scale myservice=0 myservice : echo ran myservice dependencies" \
-    "compose -f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 -T --rm -e SSH_AUTH_SOCK=/ssh-agent -v /tmp/ssh_auth_sock:/ssh-agent -v /root/.ssh/known_hosts:/tmp/test/.ssh/known_hosts myservice /bin/sh -e -c 'echo hello world' : echo ran myservice"
+  stub docker-compose \
+    "-f docker-compose.yml -p buildkite1111 up -d --scale myservice=0 myservice : echo ran myservice dependencies" \
+    "-f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 -T --rm -e SSH_AUTH_SOCK=/ssh-agent -v /tmp/ssh_auth_sock:/ssh-agent -v /root/.ssh/known_hosts:/tmp/test/.ssh/known_hosts myservice /bin/sh -e -c 'echo hello world' : echo ran myservice"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 1"
@@ -1123,30 +1214,29 @@ export BUILDKITE_JOB_ID=1111
 
   run "$PWD"/hooks/command
 
+  assert_success
+
   kill %1
 
-  assert_success
   assert_output --partial "ran myservice"
-
-  unstub docker
+  unstub docker-compose
   unstub buildkite-agent
 }
 
 @test "Run without mount-checkout doesn't set volume" {
-  export BUILDKITE_BUILD_NUMBER=1
   export BUILDKITE_JOB_ID=1111
-  export BUILDKITE_PIPELINE_SLUG=test
-  export BUILDKITE_COMMAND=pwd
-
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RUN=myservice
+  export BUILDKITE_PIPELINE_SLUG=test
+  export BUILDKITE_BUILD_NUMBER=1
+  export BUILDKITE_COMMAND=pwd
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CHECK_LINKED_CONTAINERS=false
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLEANUP=false
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_MOUNT_CHECKOUT=false
 
-  stub docker \
-    "compose -f docker-compose.yml -p buildkite1111 -f \* pull myservice : echo pulled myservice" \
-    "compose -f docker-compose.yml -p buildkite1111 -f \* up -d --scale myservice=0 myservice : echo started dependencies for myservice" \
-    "compose -f docker-compose.yml -p buildkite1111 -f \* run --name buildkite1111_myservice_build_1 -T --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice without mount-checkout"
+  stub docker-compose \
+    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml pull myservice : echo pulled myservice" \
+    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml up -d --scale myservice=0 myservice : echo started dependencies for myservice" \
+    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 -T --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice without mount-checkout"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 0" \
@@ -1156,26 +1246,24 @@ export BUILDKITE_JOB_ID=1111
 
   assert_success
   assert_output --partial "ran myservice without mount-checkout"
-
-  unstub docker
+  unstub docker-compose
   unstub buildkite-agent
 }
 
 @test "Run with mount-checkout set to true" {
-  export BUILDKITE_BUILD_NUMBER=1
   export BUILDKITE_JOB_ID=1111
-  export BUILDKITE_PIPELINE_SLUG=test
-  export BUILDKITE_COMMAND=pwd
-
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RUN=myservice
+  export BUILDKITE_PIPELINE_SLUG=test
+  export BUILDKITE_BUILD_NUMBER=1
+  export BUILDKITE_COMMAND=pwd
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CHECK_LINKED_CONTAINERS=false
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLEANUP=false
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_MOUNT_CHECKOUT=true
 
-  stub docker \
-    "compose -f docker-compose.yml -p buildkite1111 -f \* pull myservice : echo pulled myservice" \
-    "compose -f docker-compose.yml -p buildkite1111 -f \* up -d --scale myservice=0 myservice : echo started dependencies for myservice" \
-    "compose -f docker-compose.yml -p buildkite1111 -f \* run --name buildkite1111_myservice_build_1 -T --workdir=/workdir -v /plugin:/workdir --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice with mount-checkout"
+  stub docker-compose \
+    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml pull myservice : echo pulled myservice" \
+    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml up -d --scale myservice=0 myservice : echo started dependencies for myservice" \
+    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 -T --workdir=/workdir -v $PWD:/workdir --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice with mount-checkout"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 0" \
@@ -1185,27 +1273,25 @@ export BUILDKITE_JOB_ID=1111
 
   assert_success
   assert_output --partial "ran myservice with mount-checkout"
-
-  unstub docker
+  unstub docker-compose
   unstub buildkite-agent
 }
 
 @test "Run with mount-checkout set to true with custom workdir" {
-  export BUILDKITE_BUILD_NUMBER=1
   export BUILDKITE_JOB_ID=1111
-  export BUILDKITE_PIPELINE_SLUG=test
-  export BUILDKITE_COMMAND=pwd
-
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RUN=myservice
+  export BUILDKITE_PIPELINE_SLUG=test
+  export BUILDKITE_BUILD_NUMBER=1
+  export BUILDKITE_COMMAND=pwd
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CHECK_LINKED_CONTAINERS=false
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLEANUP=false
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_MOUNT_CHECKOUT=true
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_WORKDIR="/custom_workdir"
 
-  stub docker \
-    "compose -f docker-compose.yml -p buildkite1111 -f \* pull myservice : echo pulled myservice" \
-    "compose -f docker-compose.yml -p buildkite1111 -f \* up -d --scale myservice=0 myservice : echo started dependencies for myservice" \
-    "compose -f docker-compose.yml -p buildkite1111 -f \* run --name buildkite1111_myservice_build_1 -T \* -v \* --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice with mount-checkout on \${14}"
+  stub docker-compose \
+    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml pull myservice : echo pulled myservice" \
+    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml up -d --scale myservice=0 myservice : echo started dependencies for myservice" \
+    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 -T --workdir=$BUILDKITE_PLUGIN_DOCKER_COMPOSE_WORKDIR -v $PWD:$BUILDKITE_PLUGIN_DOCKER_COMPOSE_WORKDIR --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice with mount-checkout"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 0" \
@@ -1214,9 +1300,8 @@ export BUILDKITE_JOB_ID=1111
   run "$PWD"/hooks/command
 
   assert_success
-  assert_output --partial "ran myservice with mount-checkout on /plugin:/custom_workdir"
-
-  unstub docker
+  assert_output --partial "ran myservice with mount-checkout"
+  unstub docker-compose
   unstub buildkite-agent
 }
 
@@ -1231,10 +1316,10 @@ export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLEANUP=false
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_MOUNT_CHECKOUT="/special"
 
-  stub docker \
-    "compose -f docker-compose.yml -p buildkite1111 -f \* pull myservice : echo pulled myservice" \
-    "compose -f docker-compose.yml -p buildkite1111 -f \* up -d --scale myservice=0 myservice : echo started dependencies for myservice" \
-    "compose -f docker-compose.yml -p buildkite1111 -f \* run --name buildkite1111_myservice_build_1 -T -v \* --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice with mount-checkout on \${13}"
+  stub docker-compose \
+    "-f docker-compose.yml -p buildkite1111 -f \* pull myservice : echo pulled myservice" \
+    "-f docker-compose.yml -p buildkite1111 -f \* up -d --scale myservice=0 myservice : echo started dependencies for myservice" \
+    "-f docker-compose.yml -p buildkite1111 -f \* run --name buildkite1111_myservice_build_1 -T -v \* --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice with mount-checkout on \${12}"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 0" \
@@ -1245,7 +1330,7 @@ export BUILDKITE_JOB_ID=1111
   assert_success
   assert_output --partial "ran myservice with mount-checkout on /plugin:/special"
 
-  unstub docker
+  unstub docker-compose
   unstub buildkite-agent
 }
 
@@ -1261,10 +1346,10 @@ export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_MOUNT_CHECKOUT="/special"
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_WORKDIR="/custom_workdir"
 
-  stub docker \
-    "compose -f docker-compose.yml -p buildkite1111 -f \* pull myservice : echo pulled myservice" \
-    "compose -f docker-compose.yml -p buildkite1111 -f \* up -d --scale myservice=0 myservice : echo started dependencies for myservice" \
-    "compose -f docker-compose.yml -p buildkite1111 -f \* run --name buildkite1111_myservice_build_1 -T \* -v \* --rm myservice /bin/sh -e -c 'pwd' : echo echo ran myservice with mount-checkout on \${14}"
+  stub docker-compose \
+    "-f docker-compose.yml -p buildkite1111 -f \* pull myservice : echo pulled myservice" \
+    "-f docker-compose.yml -p buildkite1111 -f \* up -d --scale myservice=0 myservice : echo started dependencies for myservice" \
+    "-f docker-compose.yml -p buildkite1111 -f \* run --name buildkite1111_myservice_build_1 -T \* -v \* --rm myservice /bin/sh -e -c 'pwd' : echo echo ran myservice with mount-checkout on \${13}"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 0" \
@@ -1276,7 +1361,7 @@ export BUILDKITE_JOB_ID=1111
   assert_output --partial "ran myservice with mount-checkout on /plugin:/special"
   assert_output --partial "--workdir=/custom_workdir"
 
-  unstub docker
+  unstub docker-compose
   unstub buildkite-agent
 }
 
@@ -1291,8 +1376,8 @@ export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLEANUP=false
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_MOUNT_CHECKOUT="not_absolute"
 
-  stub docker \
-    "compose -f docker-compose.yml -p buildkite1111 -f \* pull myservice : echo pulled myservice"
+  stub docker-compose \
+    "-f docker-compose.yml -p buildkite1111 -f \* pull myservice : echo pulled myservice"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 0" \
@@ -1303,7 +1388,7 @@ export BUILDKITE_JOB_ID=1111
   assert_failure
   assert_output --partial "mount-checkout should be either true or an absolute path to use as a mountpoint"
 
-  unstub docker
+  unstub docker-compose
   unstub buildkite-agent
 }
 
@@ -1319,8 +1404,8 @@ export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_MOUNT_CHECKOUT="not-absolute"
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_WORKDIR="/custom_workdir"
 
-  stub docker \
-    "compose -f docker-compose.yml -p buildkite1111 -f \* pull myservice : echo pulled myservice"
+  stub docker-compose \
+    "-f docker-compose.yml -p buildkite1111 -f \* pull myservice : echo pulled myservice"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 0" \
@@ -1331,7 +1416,7 @@ export BUILDKITE_JOB_ID=1111
   assert_failure
   assert_output --partial "mount-checkout should be either true or an absolute path to use as a mountpoint"
 
-  unstub docker
+  unstub docker-compose
   unstub buildkite-agent
 }
 
@@ -1345,9 +1430,9 @@ export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CHECK_LINKED_CONTAINERS=false
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_WAIT=true
 
-  stub docker \
-    "compose -f docker-compose.yml -p buildkite1111 up --wait -d --scale myservice=0 myservice : echo ran myservice dependencies" \
-    "compose -f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 -T --rm myservice /bin/sh -e -c 'echo hello world' : echo ran myservice"
+  stub docker-compose \
+    "-f docker-compose.yml -p buildkite1111 up --wait -d --scale myservice=0 myservice : echo ran myservice dependencies" \
+    "-f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 -T --rm myservice /bin/sh -e -c 'echo hello world' : echo ran myservice"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 1"
@@ -1355,9 +1440,10 @@ export BUILDKITE_JOB_ID=1111
   run "$PWD"/hooks/command
 
   assert_success
+  assert_output --partial "Starting dependencies"
   assert_output --partial "ran myservice"
 
-  unstub docker
+  unstub docker-compose
   unstub buildkite-agent
 }
 
@@ -1371,10 +1457,10 @@ export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLEANUP=false
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_SERVICE_PORTS=true
 
-  stub docker \
-    "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml pull myservice : echo pulled myservice" \
-    "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml up -d --scale myservice=0 myservice : echo started dependencies for myservice" \
-    "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 -T --rm --service-ports myservice /bin/sh -e -c $'pwd' : echo ran myservice without tty"
+  stub docker-compose \
+    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml pull myservice : echo pulled myservice" \
+    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml up -d --scale myservice=0 myservice : echo started dependencies for myservice" \
+    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 -T --rm --service-ports myservice /bin/sh -e -c $'pwd' : echo ran myservice without tty"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : echo myimage" \
@@ -1384,7 +1470,49 @@ export BUILDKITE_JOB_ID=1111
 
   assert_success
   assert_output --partial "ran myservice without tty"
-  unstub docker
+  unstub docker-compose
+  unstub buildkite-agent
+}
+
+@test "Run with Docker labels" {
+  # Pipeline vars
+  export BUILDKITE_AGENT_ID="1234"
+  export BUILDKITE_AGENT_NAME="agent"
+  export BUILDKITE_BUILD_NUMBER=1
+  export BUILDKITE_COMMAND=pwd
+  export BUILDKITE_JOB_ID=1111
+  export BUILDKITE_LABEL="Testjob"
+  export BUILDKITE_PIPELINE_NAME="label-test"
+  export BUILDKITE_PIPELINE_SLUG=test
+  export BUILDKITE_STEP_KEY="test-job"
+
+  # Plugin config
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RUN=myservice
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RUN_LABELS="true"
+
+  stub docker-compose \
+    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml pull myservice : echo pulled myservice" \
+    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml up -d --scale myservice=0 myservice : echo started dependencies for myservice" \
+    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 \
+      --label com.buildkite.pipeline_name=${BUILDKITE_PIPELINE_NAME} \
+      --label com.buildkite.pipeline_slug=${BUILDKITE_PIPELINE_SLUG} \
+      --label com.buildkite.build_number=${BUILDKITE_BUILD_NUMBER} \
+      --label com.buildkite.job_id=${BUILDKITE_JOB_ID} \
+      --label com.buildkite.job_label=${BUILDKITE_LABEL} \
+      --label com.buildkite.step_key=${BUILDKITE_STEP_KEY} \
+      --label com.buildkite.agent_name=${BUILDKITE_AGENT_NAME} \
+      --label com.buildkite.agent_id=${BUILDKITE_AGENT_ID} \
+      -T --rm myservice /bin/sh -e -c $'pwd' : echo ran myservice"
+
+  stub buildkite-agent \
+    "meta-data exists docker-compose-plugin-built-image-tag-myservice : echo myimage" \
+    "meta-data get docker-compose-plugin-built-image-tag-myservice : echo myimage"
+
+  run "$PWD"/hooks/command
+
+  assert_success
+  assert_output --partial "ran myservice"
+  unstub docker-compose
   unstub buildkite-agent
 }
 
@@ -1398,9 +1526,9 @@ export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CHECK_LINKED_CONTAINERS=false
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_QUIET_PULL=true
 
-  stub docker \
-    "compose -f docker-compose.yml -p buildkite1111 up --quiet-pull -d --scale myservice=0 myservice : echo ran myservice dependencies" \
-    "compose -f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 -T --rm myservice /bin/sh -e -c 'echo hello world' : echo ran myservice"
+  stub docker-compose \
+    "-f docker-compose.yml -p buildkite1111 up --quiet-pull -d --scale myservice=0 myservice : echo ran myservice dependencies" \
+    "-f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 -T --rm myservice /bin/sh -e -c 'echo hello world' : echo ran myservice"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 1"
@@ -1411,7 +1539,7 @@ export BUILDKITE_JOB_ID=1111
   refute_output --partial "Pulling"
   assert_output --partial "ran myservice"
 
-  unstub docker
+  unstub docker-compose
   unstub buildkite-agent
 }
 
@@ -1426,9 +1554,9 @@ export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CHECK_LINKED_CONTAINERS=false
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLEANUP=false
 
-  stub docker \
-    "compose -f docker-compose.yml -p buildkite1111 up -d --scale myservice=0 myservice : echo ran myservice dependencies" \
-    "compose -f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 -e VAR_A -e VAR_B -e VAR_C -T --rm myservice /bin/sh -e -c 'echo hello world' : echo ran myservice"
+  stub docker-compose \
+    "-f docker-compose.yml -p buildkite1111 up -d --scale myservice=0 myservice : echo ran myservice dependencies" \
+    "-f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 -e VAR_A -e VAR_B -e VAR_C -T --rm myservice /bin/sh -e -c 'echo hello world' : echo ran myservice"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 1"
@@ -1437,7 +1565,7 @@ export BUILDKITE_JOB_ID=1111
 
   assert_success
   assert_output --partial "ran myservice"
-  unstub docker
+  unstub docker-compose
   unstub buildkite-agent
 }
 
@@ -1458,5 +1586,54 @@ export BUILDKITE_JOB_ID=1111
 
   assert_failure
   assert_output --partial "env-propagation-list desired, but LIST_OF_VARS is not defined!"
+  unstub buildkite-agent
+}
+
+@test "Run with expanded run log group by default" {
+  export BUILDKITE_JOB_ID=1111
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RUN=myservice
+  export BUILDKITE_PIPELINE_SLUG=test
+  export BUILDKITE_BUILD_NUMBER=1
+  export BUILDKITE_COMMAND="echo hello world"
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CHECK_LINKED_CONTAINERS=false
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLEANUP=false
+
+  stub docker-compose \
+    "-f docker-compose.yml -p buildkite1111 up -d --scale myservice=0 myservice : echo ran myservice dependencies" \
+    "-f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 -T --rm myservice /bin/sh -e -c 'echo hello world' : echo ran myservice"
+
+  stub buildkite-agent \
+    "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 1"
+
+  run "$PWD"/hooks/command
+
+  assert_success
+  assert_output --partial "+++ :docker: Running /bin/sh -e -c 'echo hello world' in service myservice"
+  unstub docker-compose
+  unstub buildkite-agent
+}
+
+@test "Run with collapsed run log group" {
+  export BUILDKITE_JOB_ID=1111
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RUN=myservice
+  export BUILDKITE_PIPELINE_SLUG=test
+  export BUILDKITE_BUILD_NUMBER=1
+  export BUILDKITE_COMMAND="echo hello world"
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CHECK_LINKED_CONTAINERS=false
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLEANUP=false
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_COLLAPSE_LOGS=true
+
+  stub docker-compose \
+    "-f docker-compose.yml -p buildkite1111 up -d --scale myservice=0 myservice : echo ran myservice dependencies" \
+    "-f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 -T --rm myservice /bin/sh -e -c 'echo hello world' : echo ran myservice"
+
+  stub buildkite-agent \
+    "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 1"
+
+  run "$PWD"/hooks/command
+
+  assert_success
+  assert_output --partial "--- :docker: Running /bin/sh -e -c 'echo hello world' in service myservice"
+  unstub docker-compose
   unstub buildkite-agent
 }


### PR DESCRIPTION
:scream:

Updates the whole plugin to use CLI v2 as the default instead of v1 that has been deprecated.

Closes #390 