### PR TITLE
Add buildkite inline cache env

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,12 @@ If set to `true` it will mount onto `/workdir`, unless `workdir` is set, in whic
 
 Default: `false`
 
+### `buildkit-inline-cache` (optional, build-only, boolean)
+
+Whether to pass the `BUILDKIT_INLINE_CACHE=1` build arg when building an image. Can be safely used in combination with `args`.
+
+Default: `false`
+
 #### `pull-retries` (run only, integer)
 
 A number of times to retry failed docker pull. Defaults to 0.

--- a/commands/build.sh
+++ b/commands/build.sh
@@ -89,6 +89,10 @@ if [[ "$(plugin_read_config BUILD_PARALLEL "false")" == "true" ]] ; then
   build_params+=(--parallel)
 fi
 
+if [[ "$(plugin_read_config BUILDKIT_INLINE_CACHE "false")" == "true" ]] ; then
+  build_params+=("--build-arg" "BUILDKIT_INLINE_CACHE=1")
+fi
+
 # Parse the list of secrets to pass on to build command
 while read -r line ; do
   [[ -n "$line" ]] && build_params+=("--secret" "$line")

--- a/plugin.yml
+++ b/plugin.yml
@@ -27,6 +27,8 @@ configuration:
       type: boolean
     buildkit:
       type: boolean
+    buildkit-inline-cache:
+      type: boolean
     cache-from:
       type: [ string, array ]
       minimum: 1
@@ -138,6 +140,7 @@ configuration:
     build-alias: [ push ]
     build-parallel: [ build ]
     buildkit: [ build ]
+    buildkit-inline-cache: [ build ]
     cache-from: [ build ]
     command: [ run ]
     dependencies: [ run ]

--- a/tests/build.bats
+++ b/tests/build.bats
@@ -337,8 +337,8 @@ setup_file() {
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_ARGS_1=MYARG=1
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILDKIT_INLINE_CACHE=true
 
-  stub docker-compose \
-    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml build --pull --build-arg BUILDKIT_INLINE_CACHE=1 --build-arg MYARG=0 --build-arg MYARG=1 myservice : echo built myservice"
+  stub docker \
+    "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml build --pull --build-arg BUILDKIT_INLINE_CACHE=1 --build-arg MYARG=0 --build-arg MYARG=1 myservice : echo built myservice"
 
   run $PWD/hooks/command
 

--- a/tests/build.bats
+++ b/tests/build.bats
@@ -344,5 +344,5 @@ setup_file() {
 
   assert_success
   assert_output --partial "built myservice"
-  unstub docker-compose
+  unstub docker
 }

--- a/tests/build.bats
+++ b/tests/build.bats
@@ -329,16 +329,13 @@ setup_file() {
 }
 
 @test "Build with buildkit-inline-cache" {
-  export BUILDKITE_JOB_ID=1111
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD=myservice
-  export BUILDKITE_PIPELINE_SLUG=test
-  export BUILDKITE_BUILD_NUMBER=1
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_ARGS_0=MYARG=0
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_ARGS_1=MYARG=1
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILDKIT_INLINE_CACHE=true
 
   stub docker \
-    "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml build --pull --build-arg BUILDKIT_INLINE_CACHE=1 --build-arg MYARG=0 --build-arg MYARG=1 myservice : echo built myservice"
+    "compose -f docker-compose.yml -p buildkite1111 build --pull --build-arg BUILDKIT_INLINE_CACHE=1 --build-arg MYARG=0 --build-arg MYARG=1 myservice : echo built myservice"
 
   run $PWD/hooks/command
 

--- a/tests/build.bats
+++ b/tests/build.bats
@@ -327,3 +327,22 @@ setup_file() {
 
   unstub docker
 }
+
+@test "Build with buildkit-inline-cache" {
+  export BUILDKITE_JOB_ID=1111
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD=myservice
+  export BUILDKITE_PIPELINE_SLUG=test
+  export BUILDKITE_BUILD_NUMBER=1
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_ARGS_0=MYARG=0
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_ARGS_1=MYARG=1
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILDKIT_INLINE_CACHE=true
+
+  stub docker-compose \
+    "-f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml build --pull --build-arg BUILDKIT_INLINE_CACHE=1 --build-arg MYARG=0 --build-arg MYARG=1 myservice : echo built myservice"
+
+  run $PWD/hooks/command
+
+  assert_success
+  assert_output --partial "built myservice"
+  unstub docker-compose
+}


### PR DESCRIPTION
It's possible to set this via the args config property. However, when trying to define it as global default with
```
BUILDKITE_PLUGIN_DOCKER_COMPOSE_ARGS_0="BUILDKIT_INLINE_CACHE=1"
```
you can end up accidentally overwriting args provided in a pipeline.yml.

Providing a separate config property allows you to set it via an env var
while avoiding overwriting any provided args.

### Use Case
We build a lot of images and usually have our users setup their own pipelines. As owners we want to ensure that every image is built with inline cache.