### PR TITLE
Add service label build options

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,10 +64,6 @@ Important: this only works when building a single service, an error will be gene
 
 A list of KEY=VALUE that are passed through as build arguments when image is being built.
 
-#### `labels` (build and run only, string or array)
-
-A list of KEY=VALUE that are passed through as service labels when image is being built or ran. These will be merged with any service labels defined in the compose file.
-
 #### `env` or `environment` (run only, string or array)
 
 A list of either KEY or KEY=VALUE that are passed through as environment variables to the container.
@@ -271,6 +267,14 @@ The default is `true`.
 If set to true, adds useful Docker labels to the primary container. See [Container Labels](#container-labels) for more info.
 
 The default is `true`.
+
+#### `labels` (run only, string or array)
+
+A list of KEY=VALUE that are passed through as service labels when image is being ran. These will be merged with any service labels defined in the compose file.
+
+#### `build-labels` (build only, string or array)
+
+A list of KEY=VALUE that are passed through as service labels when image is being built. These will be merged with any service labels defined in the compose file.
 
 #### `compatibility` (boolean)
 

--- a/README.md
+++ b/README.md
@@ -268,10 +268,6 @@ If set to true, adds useful Docker labels to the primary container. See [Contain
 
 The default is `true`.
 
-#### `labels` (run only, string or array)
-
-A list of KEY=VALUE that are passed through as service labels when image is being ran. These will be merged with any service labels defined in the compose file.
-
 #### `build-labels` (build only, string or array)
 
 A list of KEY=VALUE that are passed through as service labels when image is being built. These will be merged with any service labels defined in the compose file.

--- a/README.md
+++ b/README.md
@@ -64,6 +64,10 @@ Important: this only works when building a single service, an error will be gene
 
 A list of KEY=VALUE that are passed through as build arguments when image is being built.
 
+#### `labels` (build only, string or array)
+
+A list of KEY=VALUE that are passed through as service labels when image is being built. These will be merged with any service labels defined in the compose file.
+
 #### `env` or `environment` (run only, string or array)
 
 A list of either KEY or KEY=VALUE that are passed through as environment variables to the container.
@@ -146,7 +150,7 @@ If set to `true` it will mount onto `/workdir`, unless `workdir` is set, in whic
 
 Default: `false`
 
-### `buildkit-inline-cache` (optional, build-only, boolean)
+#### `buildkit-inline-cache` (optional, build-only, boolean)
 
 Whether to pass the `BUILDKIT_INLINE_CACHE=1` build arg when building an image. Can be safely used in combination with `args`.
 

--- a/README.md
+++ b/README.md
@@ -64,9 +64,9 @@ Important: this only works when building a single service, an error will be gene
 
 A list of KEY=VALUE that are passed through as build arguments when image is being built.
 
-#### `labels` (build only, string or array)
+#### `labels` (build and run only, string or array)
 
-A list of KEY=VALUE that are passed through as service labels when image is being built. These will be merged with any service labels defined in the compose file.
+A list of KEY=VALUE that are passed through as service labels when image is being built or ran. These will be merged with any service labels defined in the compose file.
 
 #### `env` or `environment` (run only, string or array)
 

--- a/commands/build.sh
+++ b/commands/build.sh
@@ -50,7 +50,7 @@ for service_name in $(plugin_read_list BUILD) ; do
   labels=()
   while read -r label ; do
     [[ -n "${label:-}" ]] && labels+=("${label}")
-  done <<< "$(plugin_read_list LABELS)"
+  done <<< "$(plugin_read_list BUILD_LABELS)"
 
   if [[ -n "${target}" ]] || [[ "${#labels[@]}" -gt 0 ]] || [[ "${#cache_from[@]}" -gt 0 ]]; then
     build_images+=("$service_name" "${image_name}" "${target}")

--- a/commands/build.sh
+++ b/commands/build.sh
@@ -43,18 +43,26 @@ for service_name in $(plugin_read_list BUILD) ; do
   image_name="" # no longer used here
 
   cache_from=()
-  cache_length=0
-  
   for cache_line in $(get_caches_for_service "$service_name"); do
     cache_from+=("$cache_line")
-    cache_length=$((cache_length + 1))
   done
 
-  if [[ -n "${target}" ]] || [[ "${cache_length:-0}" -gt 0 ]]; then
-    build_images+=("$service_name" "${image_name}" "${target}" "${cache_length}")
+  labels=()
+  while read -r label ; do
+    [[ -n "${label:-}" ]] && labels+=("${label}")
+  done <<< "$(plugin_read_list LABELS)"
 
-    if [[ "${cache_length:-0}" -gt 0 ]]; then
+  if [[ -n "${target}" ]] || [[ "${#labels[@]}" -gt 0 ]] || [[ "${#cache_from[@]}" -gt 0 ]]; then
+    build_images+=("$service_name" "${image_name}" "${target}")
+    
+    build_images+=("${#cache_from[@]}")
+    if [[ "${#cache_from[@]}" -gt 0 ]]; then
       build_images+=("${cache_from[@]}")
+    fi
+    
+    build_images+=("${#labels[@]}")
+    if [[ "${#labels[@]}" -gt 0 ]]; then
+      build_images+=("${labels[@]}")
     fi
   fi
 done

--- a/commands/run.sh
+++ b/commands/run.sh
@@ -92,6 +92,10 @@ if [[ "$(plugin_read_config RUN_LABELS "true")" =~ ^(true|on|1)$ ]]; then
   )
 fi
 
+while read -r label ; do
+  [[ -n "${label:-}" ]] && run_params+=("--label" "${label}")
+done <<< "$(plugin_read_list LABELS)"
+
 # append env vars provided in ENV or ENVIRONMENT, these are newline delimited
 while IFS=$'\n' read -r env ; do
   [[ -n "${env:-}" ]] && run_params+=("-e" "${env}")

--- a/commands/run.sh
+++ b/commands/run.sh
@@ -92,10 +92,6 @@ if [[ "$(plugin_read_config RUN_LABELS "true")" =~ ^(true|on|1)$ ]]; then
   )
 fi
 
-while read -r label ; do
-  [[ -n "${label:-}" ]] && run_params+=("--label" "${label}")
-done <<< "$(plugin_read_list LABELS)"
-
 # append env vars provided in ENV or ENVIRONMENT, these are newline delimited
 while IFS=$'\n' read -r env ; do
   [[ -n "${env:-}" ]] && run_params+=("-e" "${env}")

--- a/commands/run.sh
+++ b/commands/run.sh
@@ -43,7 +43,7 @@ prebuilt_services=()
 for service_name in "${prebuilt_candidates[@]}" ; do
   if prebuilt_image=$(get_prebuilt_image "$service_name") ; then
     echo "~~~ :docker: Found a pre-built image for $service_name"
-    prebuilt_service_overrides+=("$service_name" "$prebuilt_image" "" 0)
+    prebuilt_service_overrides+=("$service_name" "$prebuilt_image" "" 0 0)
     prebuilt_services+=("$service_name")
 
     # If it's prebuilt, we need to pull it down

--- a/lib/shared.bash
+++ b/lib/shared.bash
@@ -170,6 +170,7 @@ function build_image_override_file_with_version() {
     cache_from_amt="${1:-0}"
     [[ -n "${1:-}" ]] && shift; # remove the value if not empty
     if [[ "${cache_from_amt}" -gt 0 ]]; then
+      cache_from=()
       for _ in $(seq 1 "$cache_from_amt"); do
         cache_from+=( "$1" ); shift
       done
@@ -179,6 +180,7 @@ function build_image_override_file_with_version() {
     labels_amt="${1:-0}"
     [[ -n "${1:-}" ]] && shift; # remove the value if not empty
     if [[ "${labels_amt}" -gt 0 ]]; then
+      labels=()
       for _ in $(seq 1 "$labels_amt"); do
         labels+=( "$1" ); shift
       done

--- a/lib/shared.bash
+++ b/lib/shared.bash
@@ -170,7 +170,7 @@ function build_image_override_file_with_version() {
     cache_from_amt="${1:-0}"
     [[ -n "${1:-}" ]] && shift; # remove the value if not empty
     if [[ "${cache_from_amt}" -gt 0 ]]; then
-      for amt in $(seq 1 "$cache_from_amt"); do
+      for _ in $(seq 1 "$cache_from_amt"); do
         cache_from+=( "$1" ); shift
       done
     fi
@@ -179,7 +179,7 @@ function build_image_override_file_with_version() {
     labels_amt="${1:-0}"
     [[ -n "${1:-}" ]] && shift; # remove the value if not empty
     if [[ "${labels_amt}" -gt 0 ]]; then
-      for amt in $(seq 1 "$labels_amt"); do
+      for _ in $(seq 1 "$labels_amt"); do
         labels+=( "$1" ); shift
       done
     fi

--- a/lib/shared.bash
+++ b/lib/shared.bash
@@ -171,7 +171,7 @@ function build_image_override_file_with_version() {
     if (( $# > 0 )); then
       cache_from_amt=$1
       shift
-      while (( cache_from_amt-- > 0 )) ; do
+      while (( cache_from_amt-- > 0 )); do
         cache_from+=( "$1" ); shift
       done
     fi
@@ -181,7 +181,7 @@ function build_image_override_file_with_version() {
     if (( $# > 0 )); then
       labels_amt=$1
       shift
-      while (( labels_amt-- > 0 )) ; do
+      while (( labels_amt-- > 0 )); do
         labels+=( "$1" ); shift
       done
     fi

--- a/lib/shared.bash
+++ b/lib/shared.bash
@@ -167,26 +167,24 @@ function build_image_override_file_with_version() {
     shift 3
 
     # load cache_from array
-    cache_from=()
-    if (( $# > 0 )); then
-      cache_from_amt=$1
-      shift
-      while (( cache_from_amt-- > 0 )); do
+    cache_from_amt="${1:-0}"
+    [[ -n "${1:-}" ]] && shift; # remove the value if not empty
+    if [[ "${cache_from_amt}" -gt 0 ]]; then
+      for amt in $(seq 1 "$cache_from_amt"); do
         cache_from+=( "$1" ); shift
       done
     fi
 
     # load labels array
-    labels=()
-    if (( $# > 0 )); then
-      labels_amt=$1
-      shift
-      while (( labels_amt-- > 0 )); do
+    labels_amt="${1:-0}"
+    [[ -n "${1:-}" ]] && shift; # remove the value if not empty
+    if [[ "${labels_amt}" -gt 0 ]]; then
+      for amt in $(seq 1 "$labels_amt"); do
         labels+=( "$1" ); shift
       done
     fi
 
-    if [[ -z "$image_name" ]] && [[ -z "$target" ]] && [[ "${#cache_from[@]}" -eq 0 ]] && [[ "${#labels[@]}" -eq 0 ]]; then
+    if [[ -z "$image_name" ]] && [[ -z "$target" ]] && [[ "$cache_from_amt" -eq 0 ]] && [[ "$labels_amt" -eq 0 ]]; then
       # should not print out an empty service
       continue
     fi
@@ -197,7 +195,7 @@ function build_image_override_file_with_version() {
       printf "    image: %s\\n" "$image_name"
     fi
 
-    if [[ "${#cache_from[@]}" -gt 0 ]] || [[ -n "$target" ]] || [[ "${#labels[@]}" -gt 0 ]]; then
+    if [[ "$cache_from_amt" -gt 0 ]] || [[ -n "$target" ]] || [[ "$labels_amt" -gt 0 ]]; then
       printf "    build:\\n"
     fi
 
@@ -205,7 +203,7 @@ function build_image_override_file_with_version() {
       printf "      target: %s\\n" "$target"
     fi
 
-    if [[ "${#cache_from[@]}" -gt 0 ]] ; then
+    if [[ "$cache_from_amt" -gt 0 ]] ; then
       if ! docker_compose_supports_cache_from "$version" ; then
         echo "Unsupported Docker Compose config file version: $version"
         echo "The 'cache_from' option can only be used with Compose file versions 2.2 or 3.2 and above."
@@ -220,7 +218,7 @@ function build_image_override_file_with_version() {
       done
     fi
 
-    if [[ "${#labels[@]}" -gt 0 ]] ; then
+    if [[ "$labels_amt" -gt 0 ]] ; then
       printf "      labels:\\n"
       for label in "${labels[@]}"; do
         printf "        - %s\\n" "${label}"

--- a/plugin.yml
+++ b/plugin.yml
@@ -66,9 +66,6 @@ configuration:
       type: boolean
     graceful-shutdown:
       type: boolean
-    labels:
-      type: [ string, array ]
-      minimum: 1
     leave-volumes:
       type: boolean
     mount-buildkite-agent:
@@ -157,7 +154,6 @@ configuration:
     environment: [ run ]
     expand-volume-vars: [ volumes ]
     graceful-shutdown: [ run ]
-    labels: [ run ]
     leave-volumes: [ run ]
     mount-buildkite-agent: [ run ]
     mount-checkout: [ run ]

--- a/plugin.yml
+++ b/plugin.yml
@@ -153,7 +153,7 @@ configuration:
     environment: [ run ]
     expand-volume-vars: [ volumes ]
     graceful-shutdown: [ run ]
-    labels: [ build ]
+    labels: [ build, run ]
     leave-volumes: [ run ]
     mount-buildkite-agent: [ run ]
     mount-checkout: [ run ]

--- a/plugin.yml
+++ b/plugin.yml
@@ -63,6 +63,9 @@ configuration:
       type: boolean
     graceful-shutdown:
       type: boolean
+    labels:
+      type: [ string, array ]
+      minimum: 1
     leave-volumes:
       type: boolean
     mount-buildkite-agent:
@@ -150,6 +153,7 @@ configuration:
     environment: [ run ]
     expand-volume-vars: [ volumes ]
     graceful-shutdown: [ run ]
+    labels: [ build ]
     leave-volumes: [ run ]
     mount-buildkite-agent: [ run ]
     mount-checkout: [ run ]

--- a/plugin.yml
+++ b/plugin.yml
@@ -23,6 +23,9 @@ configuration:
     build-alias:
       type: [ string, array ]
       minimum: 1
+    build-labels:
+      type: [ string, array ]
+      minimum: 1
     build-parallel:
       type: boolean
     buildkit:
@@ -141,6 +144,7 @@ configuration:
     ansi: [ run ]
     args: [ build ]
     build-alias: [ push ]
+    build-labels: [ build ]
     build-parallel: [ build ]
     buildkit: [ build ]
     buildkit-inline-cache: [ build ]
@@ -153,7 +157,7 @@ configuration:
     environment: [ run ]
     expand-volume-vars: [ volumes ]
     graceful-shutdown: [ run ]
-    labels: [ build, run ]
+    labels: [ run ]
     leave-volumes: [ run ]
     mount-buildkite-agent: [ run ]
     mount-checkout: [ run ]

--- a/tests/image-override-file.bats
+++ b/tests/image-override-file.bats
@@ -36,6 +36,23 @@ EOF
   assert_output "$myservice_override_file2"
 }
 
+@test "Build a docker-compose file with target" {
+  myservice_override_file3=$(cat <<-EOF
+version: '3.2'
+services:
+  myservice:
+    image: newimage:1.0.0
+    build:
+      target: build
+EOF
+  )
+
+  run build_image_override_file_with_version "3.2" "myservice" "newimage:1.0.0" "build" 0
+
+  assert_success
+  assert_output "$myservice_override_file3"
+}
+
 @test "Build a docker-compose file with cache-from" {
   myservice_override_file3=$(cat <<-EOF
 version: '3.2'

--- a/tests/image-override-file.bats
+++ b/tests/image-override-file.bats
@@ -29,8 +29,8 @@ EOF
   )
 
   run build_image_override_file_with_version "2.1" \
-    "myservice1" "newimage1:1.0.0" "" 0 \
-    "myservice2" "newimage2:1.0.0" "" 0
+    "myservice1" "newimage1:1.0.0" "" 0 0 \
+    "myservice2" "newimage2:1.0.0" "" 0 0
 
   assert_success
   assert_output "$myservice_override_file2"
@@ -72,6 +72,66 @@ EOF
   assert_success
   assert_output "$myservice_override_file4"
 }
+
+@test "Build a docker-compose file with labels" {
+  myservice_override_file3=$(cat <<-EOF
+version: '3.2'
+services:
+  myservice:
+    image: newimage:1.0.0
+    build:
+      labels:
+        - com.buildkite.test=test
+EOF
+  )
+
+  run build_image_override_file_with_version "3.2" "myservice" "newimage:1.0.0" "" 0 1 "com.buildkite.test=test"
+
+  assert_success
+  assert_output "$myservice_override_file3"
+}
+
+@test "Build a docker-compose file with multiple labels" {
+  myservice_override_file3=$(cat <<-EOF
+version: '3.2'
+services:
+  myservice:
+    image: newimage:1.0.0
+    build:
+      labels:
+        - com.buildkite.test=test
+        - com.buildkite.test2=test2
+EOF
+  )
+
+  run build_image_override_file_with_version "3.2" "myservice" "newimage:1.0.0" "" 0 2 "com.buildkite.test=test" "com.buildkite.test2=test2"
+
+  assert_success
+  assert_output "$myservice_override_file3"
+}
+
+@test "Build a docker-compose file with multiple cache-from and multiple labels" {
+  myservice_override_file3=$(cat <<-EOF
+version: '3.2'
+services:
+  myservice:
+    image: newimage:1.0.0
+    build:
+      cache_from:
+        - my.repository/myservice:latest
+        - my.repository/myservice:target
+      labels:
+        - com.buildkite.test=test
+        - com.buildkite.test2=test2
+EOF
+  )
+
+  run build_image_override_file_with_version "3.2" "myservice" "newimage:1.0.0" "" 2 "my.repository/myservice:latest" "my.repository/myservice:target" 2 "com.buildkite.test=test" "com.buildkite.test2=test2"
+
+  assert_success
+  assert_output "$myservice_override_file3"
+}
+
 
 @test "Build a docker-compose file with cache-from and compose-file version 2" {
   run build_image_override_file_with_version "2" "myservice" "newimage:1.0.0" "" 1 "my.repository/myservice:latest"

--- a/tests/image-override-file.bats
+++ b/tests/image-override-file.bats
@@ -132,6 +132,28 @@ EOF
   assert_output "$myservice_override_file3"
 }
 
+@test "Build a docker-compose file with multiple cache-from and multiple labels and target" {
+  myservice_override_file3=$(cat <<-EOF
+version: '3.2'
+services:
+  myservice:
+    image: newimage:1.0.0
+    build:
+      target: build
+      cache_from:
+        - my.repository/myservice:latest
+        - my.repository/myservice:target
+      labels:
+        - com.buildkite.test=test
+        - com.buildkite.test2=test2
+EOF
+  )
+
+  run build_image_override_file_with_version "3.2" "myservice" "newimage:1.0.0" "build" 2 "my.repository/myservice:latest" "my.repository/myservice:target" 2 "com.buildkite.test=test" "com.buildkite.test2=test2"
+
+  assert_success
+  assert_output "$myservice_override_file3"
+}
 
 @test "Build a docker-compose file with cache-from and compose-file version 2" {
   run build_image_override_file_with_version "2" "myservice" "newimage:1.0.0" "" 1 "my.repository/myservice:latest"

--- a/tests/run.bats
+++ b/tests/run.bats
@@ -1280,28 +1280,3 @@ cmd3"
   assert_output --partial "env-propagation-list desired, but LIST_OF_VARS is not defined!"
   unstub buildkite-agent
 }
-
-@test "Run with a list of propagated labels" {
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_LABELS_0="com.buildkite.test=test"
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_LABELS_1="com.buildkite.test2=test2"
-  export BUILDKITE_COMMAND="echo hello world"
-
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RUN=myservice
-  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CHECK_LINKED_CONTAINERS=false
-
-  stub docker \
-    "compose -f docker-compose.yml -p buildkite1111 up -d --scale myservice=0 myservice : echo ran myservice dependencies" \
-    "compose -f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 --label com.buildkite.test=test --label com.buildkite.test2=test2 -T --rm myservice /bin/sh -e -c 'echo hello world' : echo ran myservice"
-
-  stub buildkite-agent \
-    "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 1"
-
-  run "$PWD"/hooks/command
-
-  assert_success
-  refute_output --partial "Pulling"
-  assert_output --partial "ran myservice"
-
-  unstub docker
-  unstub buildkite-agent
-}


### PR DESCRIPTION
It would be really handy to be able to add service labels in the pipeline. This change allows labels to be defined for build or run.

This will add any defined labels to the compose override and those will be merged accordingly. Small example:

docker-compose.yml
```
services:
  app:
    build:
      context: .
      labels:
        - dev.pardot.docker.image-metadata=test-metadata
```

pipeline.yml
```
      - ${DOCKER_COMPOSE_PLUGIN}:
          build: app
          labels: 
            - dev.pardot.docker.test=test
            - dev.pardot.docker.test2=test2
```

image labels after build:
```
      "Labels": {
        "com.docker.compose.project": "buildkite018dd7eac0554b8eb556b2b206b874d0",
        "com.docker.compose.service": "app",
        "com.docker.compose.version": "2.12.2",
        "dev.pardot.docker.image-metadata": "test-metadata",
        "dev.pardot.docker.test": "test",
        "dev.pardot.docker.test2": "test2"
      }
```

### Testing

I've done some basic Buldkite builds with different combinations of `labels` and `cache_from`.

### Use Case
Our users setup their own compose files. As owners we want to ensure that every image is built with specific labels.