### PR TITLE
Add run-image option

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,10 @@ None of the following are mandatory.
 
 Pull down multiple pre-built images. By default only the service that is being run will be pulled down, but this allows multiple images to be specified to handle prebuilt dependent images. Note that pulling will be skipped if the `skip-pull` option is activated.
 
+#### `run-image` (run only, string)
+
+Set the service image to pull during a run. This can be useful if the image was created outside of the plugin.
+
 #### `collapse-logs` (boolean)
 
 Whether to collapse or expand the log group that is created for the output of the main commands (`run`, `build` and `push`). When this setting is `true`, the output is collected into a `---` group, when `false` the output is collected into a `+++` group. Setting this to `true` can be useful to de-emphasize plugin output if your command creates its own `+++` group.

--- a/commands/run.sh
+++ b/commands/run.sh
@@ -40,8 +40,16 @@ prebuilt_service_overrides=()
 prebuilt_services=()
 
 # We look for a prebuilt images for all the pull services and the run_service.
+prebuilt_image_override="$(plugin_read_config RUN_IMAGE)"
 for service_name in "${prebuilt_candidates[@]}" ; do
-  if prebuilt_image=$(get_prebuilt_image "$service_name") ; then
+  prebuilt_image=$(get_prebuilt_image "$service_name") || :
+
+  # override run_service prebuilt_image if set
+  if [[ -n "$prebuilt_image_override" ]] && [[ "$service_name" == "$run_service" ]] ; then
+    prebuilt_image="$prebuilt_image_override"
+  fi
+
+  if [[ -n "$prebuilt_image" ]] ; then
     echo "~~~ :docker: Found a pre-built image for $service_name"
     prebuilt_service_overrides+=("$service_name" "$prebuilt_image" "" 0 0)
     prebuilt_services+=("$service_name")

--- a/plugin.yml
+++ b/plugin.yml
@@ -93,6 +93,8 @@ configuration:
       type: boolean
     rm:
       type: boolean
+    run-image:
+      type: string
     run-labels:
       type: boolean
     secrets:
@@ -167,6 +169,7 @@ configuration:
     push-retries: [ push ]
     quiet-pull: [ run ]
     rm: [ run ]
+    run-image: [ run ]
     run-labels: [ run ]
     service-ports: [ run ]
     skip-pull: [ build, run ]

--- a/tests/run.bats
+++ b/tests/run.bats
@@ -1280,3 +1280,28 @@ cmd3"
   assert_output --partial "env-propagation-list desired, but LIST_OF_VARS is not defined!"
   unstub buildkite-agent
 }
+
+@test "Run wit a run image override" {
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RUN=myservice
+  export BUILDKITE_COMMAND="echo hello world"
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RUN_IMAGE=docker.buildkite.com/myservice:123
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CHECK_LINKED_CONTAINERS=false
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLEANUP=false
+
+  stub docker \
+    "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml pull myservice : echo pulled myservice" \
+    "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml up -d --scale myservice=0 myservice : echo ran myservice dependencies" \
+    "compose -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 -T --rm myservice /bin/sh -e -c 'echo hello world' : echo ran myservice"
+
+  stub buildkite-agent \
+    "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 1"
+
+  run "$PWD"/hooks/command
+
+  assert_success
+  assert_output --partial "image: docker.buildkite.com/myservice:123"
+  assert_output --partial "ran myservice"
+
+  unstub docker
+  unstub buildkite-agent
+}


### PR DESCRIPTION
One final addition!

We have ran into this case a few times where one of the following happens:
* A image was created outside of the docker-compose-plugin but we still want to execute run commands on it
  * This is usually from a manual docker build
* Multiple images were created (with different names) for a single service. In this case the plugin will always pull the latest one created
  * This is usually from separate architecture builds which we combine later but want to test individually

For these cases we can inject an:
```
buildkite-agent meta-data set docker-compose-plugin-built-image-tag*
```
before running but I think an official option would be helpful.

This PR adds a new `run-image` option where you can pass an image and it will try to run with it.

An example:
```
  - label: ":docker: Build (multiplatform)"
    command: >-
      docker buildx build
      --target build
      --platform "linux/amd64,linux/arm64"
      --build-arg BUILDKIT_INLINE_CACHE=1
      --cache-from "${DOCKER_BUILD_BASE}/example/build:unstable-multi"
      -t "${DOCKER_BUILD_BASE}/example/build:${CI_BUILD_ID}"
      example/ 

  - label: ":golang: Test"
    command: go test -v ./...
    plugins:
      - ${DOCKER_COMPOSE_PLUGIN}:
          run: build
          run-image: ${DOCKER_BUILD_BASE}/example/build:${CI_BUILD_ID}
```
