### PR TITLE
Add metadata key prefix to support builds with independent clusters/registries

### DIFF
--- a/commands/push.sh
+++ b/commands/push.sh
@@ -26,7 +26,7 @@ if plugin_read_list_into_result BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD; then
   build_services=("${result[@]}")
 fi
 
-metadata_key_prefix="$(plugin_read_config METADATA_KEY_PREFIX '')"
+prebuilt_image_namespace="$(plugin_read_config PREBUILT_IMAGE_NAMESPACE 'docker-compose-plugin-')"
 
 # Then we figure out what to push, and where
 for line in $(plugin_read_list PUSH) ; do
@@ -39,7 +39,7 @@ for line in $(plugin_read_list PUSH) ; do
   elif in_array "${service_name}" "${build_services[@]}"; then
     echo "~~~ :docker: Service was built in this step, using that image"
     service_image="$(default_compose_image_for_service "${service_name}")"
-  elif prebuilt_image="$(get_prebuilt_image "$metadata_key_prefix" "$service_name")"; then
+  elif prebuilt_image="$(get_prebuilt_image "$prebuilt_image_namespace" "$service_name")"; then
     echo "~~~ :docker: Using pre-built image ${prebuilt_image}"
 
     # Only pull it down once
@@ -65,7 +65,7 @@ for line in $(plugin_read_list PUSH) ; do
   if [[ ${#tokens[@]} -eq 1 ]] ; then
     echo "${group_type} :docker: Pushing images for ${service_name}" >&2;
     retry "$push_retries" run_docker_compose push "${service_name}"
-    set_prebuilt_image "${metadata_key_prefix}" "${service_name}" "${service_image}"
+    set_prebuilt_image "${prebuilt_image_namespace}" "${service_name}" "${service_image}"
     target_image="${service_image}" # necessary for build-alias
   # push: "service-name:repo:tag"
   else
@@ -73,7 +73,7 @@ for line in $(plugin_read_list PUSH) ; do
     echo "${group_type} :docker: Pushing image $target_image" >&2;
     plugin_prompt_and_run docker tag "$service_image" "$target_image"
     retry "$push_retries" plugin_prompt_and_run docker push "$target_image"
-    set_prebuilt_image "${metadata_key_prefix}" "${service_name}" "${target_image}"
+    set_prebuilt_image "${prebuilt_image_namespace}" "${service_name}" "${target_image}"
   fi
 done
 
@@ -84,5 +84,5 @@ for service_alias in $(plugin_read_list BUILD_ALIAS) ; do
     exit 1
   fi
 
-  set_prebuilt_image "${metadata_key_prefix}" "$service_alias" "${target_image}"
+  set_prebuilt_image "${prebuilt_image_namespace}" "$service_alias" "${target_image}"
 done

--- a/commands/run.sh
+++ b/commands/run.sh
@@ -35,7 +35,7 @@ while read -r name ; do
   fi
 done <<< "$(plugin_read_list PULL)"
 
-metadata_key_prefix="$(plugin_read_config METADATA_KEY_PREFIX '')"
+prebuilt_image_namespace="$(plugin_read_config PREBUILT_IMAGE_NAMESPACE 'docker-compose-plugin-')"
 
 # A list of tuples of [service image cache_from] for build_image_override_file
 prebuilt_service_overrides=()
@@ -47,7 +47,7 @@ for service_name in "${prebuilt_candidates[@]}" ; do
   if [[ -n "$prebuilt_image_override" ]] && [[ "$service_name" == "$run_service" ]] ; then
     echo "~~~ :docker: Overriding run image for $service_name"
     prebuilt_image="$prebuilt_image_override"
-  elif prebuilt_image=$(get_prebuilt_image "$metadata_key_prefix" "$service_name") ; then
+  elif prebuilt_image=$(get_prebuilt_image "$prebuilt_image_namespace" "$service_name") ; then
      echo "~~~ :docker: Found a pre-built image for $service_name"
   fi
 

--- a/commands/run.sh
+++ b/commands/run.sh
@@ -35,6 +35,8 @@ while read -r name ; do
   fi
 done <<< "$(plugin_read_list PULL)"
 
+metadata_key_prefix="$(plugin_read_config METADATA_KEY_PREFIX '')"
+
 # A list of tuples of [service image cache_from] for build_image_override_file
 prebuilt_service_overrides=()
 prebuilt_services=()
@@ -45,7 +47,7 @@ for service_name in "${prebuilt_candidates[@]}" ; do
   if [[ -n "$prebuilt_image_override" ]] && [[ "$service_name" == "$run_service" ]] ; then
     echo "~~~ :docker: Overriding run image for $service_name"
     prebuilt_image="$prebuilt_image_override"
-  elif prebuilt_image=$(get_prebuilt_image "$service_name") ; then
+  elif prebuilt_image=$(get_prebuilt_image "$metadata_key_prefix" "$service_name") ; then
      echo "~~~ :docker: Found a pre-built image for $service_name"
   fi
 

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -10,7 +10,7 @@ The following pipeline will run `test.sh` inside a `app` service container using
 steps:
   - command: test.sh
     plugins:
-      - docker-compose#v5.2.0:
+      - docker-compose#v5.3.0:
           run: app
 ```
 
@@ -19,7 +19,7 @@ steps:
 ```yml
 steps:
   - plugins:
-      - docker-compose#v5.2.0:
+      - docker-compose#v5.3.0:
           run: app
           command: ["custom", "command", "values"]
 ```
@@ -30,7 +30,7 @@ The plugin will honor the value of the `COMPOSE_FILE` environment variable if on
 steps:
   - command: test.sh
     plugins:
-      - docker-compose#v5.2.0:
+      - docker-compose#v5.3.0:
           run: app
           config: docker-compose.tests.yml
           env:
@@ -46,7 +46,7 @@ steps:
   - plugins:
       - docker-login#v2.0.1:
           username: xyz
-      - docker-compose#v5.2.0:
+      - docker-compose#v5.3.0:
           build: app
           push: app:index.docker.io/myorg/myrepo:tag
   - wait
@@ -54,7 +54,7 @@ steps:
     plugins:
       - docker-login#v2.0.1:
           username: xyz
-      - docker-compose#v5.2.0:
+      - docker-compose#v5.3.0:
           run: app
 ```
 
@@ -71,7 +71,7 @@ steps:
   - command: generate-dist.sh
     artifact_paths: "dist/*"
     plugins:
-      - docker-compose#v5.2.0:
+      - docker-compose#v5.3.0:
           run: app
           volumes:
             - "./dist:/folder/dist"
@@ -95,7 +95,7 @@ this plugin offers a `environment` block of its own:
 steps:
   - command: generate-dist.sh
     plugins:
-      - docker-compose#v5.2.0:
+      - docker-compose#v5.3.0:
           run: app
           env:
             - BUILDKITE_BUILD_NUMBER
@@ -113,7 +113,7 @@ Alternatively, you can have the plugin add all environment variables defined for
 steps:
   - command: use-vars.sh
     plugins:
-      - docker-compose#v5.2.0:
+      - docker-compose#v5.3.0:
           run: app
           propagate-environment: true
 ```
@@ -148,7 +148,7 @@ Alternatively, if you want to set build arguments when pre-building an image, th
 steps:
   - command: generate-dist.sh
     plugins:
-      - docker-compose#v5.2.0:
+      - docker-compose#v5.3.0:
           build: app
           args:
             - MY_CUSTOM_ARG=panda
@@ -165,7 +165,7 @@ If you have multiple steps that use the same service/image (such as steps that r
 steps:
   - label: ":docker: Build"
     plugins:
-      - docker-compose#v5.2.0:
+      - docker-compose#v5.3.0:
           build: app
           push: app
 
@@ -175,7 +175,7 @@ steps:
     command: test.sh
     parallelism: 25
     plugins:
-      - docker-compose#v5.2.0:
+      - docker-compose#v5.3.0:
           run: app
 ```
 
@@ -191,7 +191,7 @@ steps:
     agents:
       queue: docker-builder
     plugins:
-      - docker-compose#v5.2.0:
+      - docker-compose#v5.3.0:
           build:
             - app
             - tests
@@ -205,7 +205,7 @@ steps:
     command: test.sh
     parallelism: 25
     plugins:
-      - docker-compose#v5.2.0:
+      - docker-compose#v5.3.0:
           run: tests
 ```
 
@@ -217,7 +217,7 @@ If you want to push your Docker images ready for deployment, you can use the `pu
 steps:
   - label: ":docker: Push"
     plugins:
-      - docker-compose#v5.2.0:
+      - docker-compose#v5.3.0:
           push: app
 ```
 
@@ -227,7 +227,7 @@ To push multiple images, you can use a list:
 steps:
   - label: ":docker: Push"
     plugins:
-      - docker-compose#v5.2.0:
+      - docker-compose#v5.3.0:
           push:
             - first-service
             - second-service
@@ -239,7 +239,7 @@ If you want to push to a specific location (that's not defined as the `image` in
 steps:
   - label: ":docker: Push"
     plugins:
-      - docker-compose#v5.2.0:
+      - docker-compose#v5.3.0:
           push:
             - app:index.docker.io/myorg/myrepo/myapp
             - app:index.docker.io/myorg/myrepo/myapp:latest
@@ -253,7 +253,7 @@ A newly spawned agent won't contain any of the docker caches for the first run w
 steps:
   - label: ":docker Build an image"
     plugins:
-      - docker-compose#v5.2.0:
+      - docker-compose#v5.3.0:
           build: app
           push: app:index.docker.io/myorg/myrepo:my-branch
           cache-from:
@@ -264,7 +264,7 @@ steps:
 
   - label: ":docker: Push to final repository"
     plugins:
-      - docker-compose#v5.2.0:
+      - docker-compose#v5.3.0:
           push:
             - app:myregistry:port/myrepo/myapp:latest
 ```
@@ -277,7 +277,7 @@ The values you add in the `cache-from` will be mapped to the corresponding servi
 steps:
   - label: ":docker Build an image"
     plugins:
-      - docker-compose#v5.2.0:
+      - docker-compose#v5.3.0:
           build: app
           push: app:index.docker.io/myorg/myrepo:my-branch
           cache-from:
@@ -288,7 +288,7 @@ steps:
 
   - label: ":docker: Push to final repository"
     plugins:
-      - docker-compose#v5.2.0:
+      - docker-compose#v5.3.0:
           push:
             - app:myregistry:port/myrepo/myapp:latest
 ```

--- a/lib/metadata.bash
+++ b/lib/metadata.bash
@@ -7,14 +7,10 @@ function plugin_check_metadata_exists() {
 
 # Read agent metadata for the plugin
 function plugin_get_metadata() {
-  local metadata_key_prefix="$1"
+  local namespace="$1"
   local key="$2"
 
-  if [ -n "$metadata_key_prefix" ]; then
-    metadata_key_prefix="$metadata_key_prefix-"
-  fi
-
-  key="docker-compose-plugin-$metadata_key_prefix$key"
+  key="$namespace$key"
 
   if plugin_check_metadata_exists "$key"; then
     plugin_prompt buildkite-agent meta-data get "$key"
@@ -26,15 +22,11 @@ function plugin_get_metadata() {
 
 # Write agent metadata for the plugin
 function plugin_set_metadata() {
-  local metadata_key_prefix="$1"
+  local namespace="$1"
   local key="$2"
   local value="$3"
 
-  if [ -n "$metadata_key_prefix" ]; then
-    metadata_key_prefix="$metadata_key_prefix-"
-  fi
-
-  key="docker-compose-plugin-$metadata_key_prefix$key"
+  key="$namespace$key"
 
   plugin_prompt_and_must_run buildkite-agent meta-data set "$key" "$value"
 }
@@ -60,17 +52,17 @@ function prebuilt_image_meta_data_key() {
 
 # Sets a prebuilt image for a service name
 function set_prebuilt_image() {
-  local metadata_key_prefix="$1"
+  local namespace="$1"
   local service="$2"
   local image="$3"
 
-  plugin_set_metadata "$metadata_key_prefix" "$(prebuilt_image_meta_data_key "$service")" "$image"
+  plugin_set_metadata "$namespace" "$(prebuilt_image_meta_data_key "$service")" "$image"
 }
 
 # Gets a prebuilt image for a service name
 function get_prebuilt_image() {
-  local metadata_key_prefix="$1"
+  local namespace="$1"
   local service="$2"
 
-  plugin_get_metadata "$metadata_key_prefix" "$(prebuilt_image_meta_data_key "$service")"
+  plugin_get_metadata "$namespace" "$(prebuilt_image_meta_data_key "$service")"
 }

--- a/lib/metadata.bash
+++ b/lib/metadata.bash
@@ -7,7 +7,15 @@ function plugin_check_metadata_exists() {
 
 # Read agent metadata for the plugin
 function plugin_get_metadata() {
-  local key="docker-compose-plugin-$1"
+  local metadata_key_prefix="$1"
+  local key="$2"
+
+  if [ -n "$metadata_key_prefix" ]; then
+    metadata_key_prefix="$metadata_key_prefix-"
+  fi
+
+  key="docker-compose-plugin-$metadata_key_prefix$key"
+
   if plugin_check_metadata_exists "$key"; then
     plugin_prompt buildkite-agent meta-data get "$key"
     buildkite-agent meta-data get "$key"
@@ -18,8 +26,16 @@ function plugin_get_metadata() {
 
 # Write agent metadata for the plugin
 function plugin_set_metadata() {
-  local key="docker-compose-plugin-$1"
-  local value="$2"
+  local metadata_key_prefix="$1"
+  local key="$2"
+  local value="$3"
+
+  if [ -n "$metadata_key_prefix" ]; then
+    metadata_key_prefix="$metadata_key_prefix-"
+  fi
+
+  key="docker-compose-plugin-$metadata_key_prefix$key"
+
   plugin_prompt_and_must_run buildkite-agent meta-data set "$key" "$value"
 }
 
@@ -44,13 +60,17 @@ function prebuilt_image_meta_data_key() {
 
 # Sets a prebuilt image for a service name
 function set_prebuilt_image() {
-  local service="$1"
-  local image="$2"
-  plugin_set_metadata "$(prebuilt_image_meta_data_key "$service")" "$image"
+  local metadata_key_prefix="$1"
+  local service="$2"
+  local image="$3"
+
+  plugin_set_metadata "$metadata_key_prefix" "$(prebuilt_image_meta_data_key "$service")" "$image"
 }
 
 # Gets a prebuilt image for a service name
 function get_prebuilt_image() {
-  local service="$1"
-  plugin_get_metadata "$(prebuilt_image_meta_data_key "$service")"
+  local metadata_key_prefix="$1"
+  local service="$2"
+
+  plugin_get_metadata "$metadata_key_prefix" "$(prebuilt_image_meta_data_key "$service")"
 }

--- a/plugin.yml
+++ b/plugin.yml
@@ -131,6 +131,8 @@ configuration:
       type: boolean
     workdir:
       type: string
+    metadata-key-prefix:
+      type: string
   anyOf:
     - required:
       - run

--- a/plugin.yml
+++ b/plugin.yml
@@ -78,6 +78,8 @@ configuration:
       type: boolean
     pre-run-dependencies:
       type: boolean
+    prebuilt-image-namespace:
+      type: string
     propagate-environment:
       type: boolean
     propagate-uid-gid:
@@ -130,8 +132,6 @@ configuration:
     wait:
       type: boolean
     workdir:
-      type: string
-    metadata-key-prefix:
       type: string
   anyOf:
     - required:

--- a/tests/metadata.bats
+++ b/tests/metadata.bats
@@ -36,7 +36,7 @@ load '../lib/metadata'
   # Only expect the 'exists' command to be called, not the 'get'
   stub buildkite-agent "meta-data exists docker-compose-plugin-built-image-tag-test : exit 1"
 
-  run get_prebuilt_image "test"
+  run get_prebuilt_image "" "test"
   
   assert_failure
   unstub buildkite-agent
@@ -47,7 +47,7 @@ load '../lib/metadata'
     "meta-data exists docker-compose-plugin-built-image-tag-test : exit 0" \
     "meta-data get docker-compose-plugin-built-image-tag-test : exit 0" 
 
-  run get_prebuilt_image "test"
+  run get_prebuilt_image "" "test"
   
   assert_success
   assert_output --partial "buildkite-agent meta-data get docker-compose-plugin-built-image-tag-test"

--- a/tests/metadata.bats
+++ b/tests/metadata.bats
@@ -36,8 +36,8 @@ load '../lib/metadata'
   # Only expect the 'exists' command to be called, not the 'get'
   stub buildkite-agent "meta-data exists docker-compose-plugin-built-image-tag-test : exit 1"
 
-  run get_prebuilt_image "" "test"
-  
+  run get_prebuilt_image "docker-compose-plugin-" "test"
+
   assert_failure
   unstub buildkite-agent
 }
@@ -45,10 +45,10 @@ load '../lib/metadata'
 @test "Only get prebuilt image from metadata if 'exists' check returns true" {
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-test : exit 0" \
-    "meta-data get docker-compose-plugin-built-image-tag-test : exit 0" 
+    "meta-data get docker-compose-plugin-built-image-tag-test : exit 0"
 
-  run get_prebuilt_image "" "test"
-  
+  run get_prebuilt_image "docker-compose-plugin-" "test"
+
   assert_success
   assert_output --partial "buildkite-agent meta-data get docker-compose-plugin-built-image-tag-test"
   unstub buildkite-agent


### PR DESCRIPTION
In scenarios where agent clusters are isolated from each other, with each cluster responsible for building its own image and pushing it to its respective image registry, there is a potential race condition that can lead to errors during separate `run`/`push` steps. Specifically, one of the steps may attempt to pull an image from the wrong image registry due to shared metadata across all clusters.

To mitigate it and ensure that each cluster is building and running images from the correct image registry, I propose introducing a new `metadata_key_prefix` parameter. This parameter would allow users to specify a unique prefix for the metadata keys used by the plugin, effectively isolating the metadata for each agent cluster.

## example

docker-compose.yml
```
version: '3.10'
service:
  app:
    build: .
```

pipeline.yml
```
steps:
  - name: ":docker: Build staging image"
    key: "build_staging"
    plugins:
      ... docker login plugin into registry ${IMAGE_REPO_STAGING} ...
      - docker-compose#v5.2.0:
          build: app
          push: app:${IMAGE_REPO_STAGING}:${BUILD_TAG}
          metadata_key_prefix: "staging"
    agents:
      queue: staging-agents

  - name: ":docker: Build production image"
    key: "build_production"
    plugins:
      ... docker login plugin into registry ${IMAGE_REPO_PRODUCTION} ...
      - docker-compose#v5.2.0:
          build: app
          push: app:${IMAGE_REPO_PRODUCTION}:${BUILD_TAG}
          metadata_key_prefix: "production"
    agents:
      queue: staging-production

  - name: ":docker: run staging image"
    key: "run_staging"
    depends_on:
      - build_staging
    plugins:
      ... docker login plugin into registry ${IMAGE_REPO_STAGING} ...
      - docker-compose#v5.2.0:
          run: app
          metadata_key_prefix: "staging"
    agents:
      queue: staging-agents

  - name: ":docker: run production image"
    key: "run_production"
    depends_on:
      - build_production
    plugins:
      ... docker login plugin into registry ${IMAGE_REPO_PRODUCTION} ...
      - docker-compose#v5.2.0:
          run: app
          metadata_key_prefix: "production"
    agents:
      queue: staging-production
```