### PR TITLE
Add option to build with `--with-dependencies`

### DIFF
--- a/README.md
+++ b/README.md
@@ -328,6 +328,12 @@ It will add the `--ssh` option to the build command with the passed value (if `t
 
 All elements in this array will be passed literally to the `build` command as parameters of the [`--secrets` option](https://docs.docker.com/engine/reference/commandline/buildx_build/#secret). Note that you must have BuildKit enabled for this option to have any effect and special `RUN` stanzas in your Dockerfile to actually make use of them.
 
+#### `with-dependencies` (build only, boolean)
+
+If set to true, docker compose build will be run with the `--with-dependencies` option which will also build dependencies transitively.
+
+The default is `false`.
+
 ## Developing
 
 To run the tests:

--- a/README.md
+++ b/README.md
@@ -330,7 +330,7 @@ All elements in this array will be passed literally to the `build` command as pa
 
 #### `with-dependencies` (build only, boolean)
 
-If set to true, docker compose build will be run with the `--with-dependencies` option which will also build dependencies transitively.
+If set to true, docker compose will build with the `--with-dependencies` option which will also build dependencies transitively.
 
 The default is `false`.
 

--- a/commands/build.sh
+++ b/commands/build.sh
@@ -101,6 +101,10 @@ if [[ "$(plugin_read_config BUILDKIT_INLINE_CACHE "false")" == "true" ]] ; then
   build_params+=("--build-arg" "BUILDKIT_INLINE_CACHE=1")
 fi
 
+if [[ "$(plugin_read_config WITH_DEPENDENCIES "false")" == "true" ]] ; then
+  build_params+=(--with-dependencies)
+fi
+
 # Parse the list of secrets to pass on to build command
 while read -r line ; do
   [[ -n "$line" ]] && build_params+=("--secret" "$line")

--- a/plugin.yml
+++ b/plugin.yml
@@ -129,6 +129,8 @@ configuration:
       minimum: 1
     wait:
       type: boolean
+    with-dependencies:
+      type: boolean
     workdir:
       type: string
   anyOf:
@@ -183,4 +185,5 @@ configuration:
     user: [ run ]
     volumes: [ run ]
     wait: [ run ]
+    with-dependencies: [ build ]
     workdir: [ run ]

--- a/tests/build.bats
+++ b/tests/build.bats
@@ -343,3 +343,18 @@ setup_file() {
   assert_output --partial "built myservice"
   unstub docker
 }
+
+@test "Build with with-dependencies" {
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD=myservice
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_WITH_DEPENDENCIES=true
+
+  stub docker \
+    "compose -f docker-compose.yml -p buildkite1111 build --pull --with-dependencies myservice : echo built myservice"
+
+  run "$PWD"/hooks/command
+
+  assert_success
+  assert_output --partial "built myservice"
+
+  unstub docker
+}


### PR DESCRIPTION
In [compose >= v2.2.4.0](https://github.com/docker/compose/releases/tag/v2.24.0) there is a new option `--with-dependencies` which can be used to "Also build dependencies (transitively)" added in this PR: https://github.com/docker/compose/pull/11290.

Add support for passing this option to `docker compose build`.

Lots of copy/pasting so I'm not sure if I did this right. And let me know if more context would be helpful.