### PR TITLE
Fix ansi option deprecation

### DIFF
--- a/lib/shared.bash
+++ b/lib/shared.bash
@@ -241,7 +241,7 @@ function run_docker_compose() {
   fi
 
   if [[ "$(plugin_read_config ANSI "true")" == "false" ]] ; then
-    command+=(--no-ansi)
+    command+=(--ansi never)
   fi
 
   # Enable compatibility mode for v3 files

--- a/tests/run.bats
+++ b/tests/run.bats
@@ -523,9 +523,9 @@ cmd3"
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_ANSI=false
 
   stub docker \
-    "compose --no-ansi -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml pull myservice : echo pulled myservice" \
-    "compose --no-ansi -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml up -d --scale myservice=0 myservice : echo started dependencies for myservice" \
-    "compose --no-ansi -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 -T --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice without ansi output"
+    "compose --ansi never -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml pull myservice : echo pulled myservice" \
+    "compose --ansi never -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml up -d --scale myservice=0 myservice : echo started dependencies for myservice" \
+    "compose --ansi never -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 -T --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice without ansi output"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 0" \

--- a/tests/v1/run.bats
+++ b/tests/v1/run.bats
@@ -479,9 +479,9 @@ cmd3"
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_ANSI=false
 
   stub docker-compose \
-    "--no-ansi -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml pull myservice : echo pulled myservice" \
-    "--no-ansi -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml up -d --scale myservice=0 myservice : echo started dependencies for myservice" \
-    "--no-ansi -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 -T --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice without ansi output"
+    "--ansi never -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml pull myservice : echo pulled myservice" \
+    "--ansi never -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml up -d --scale myservice=0 myservice : echo started dependencies for myservice" \
+    "--ansi never -f docker-compose.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml run --name buildkite1111_myservice_build_1 -T --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice without ansi output"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 0" \


### PR DESCRIPTION
This PR fixes deprecation message: `option '--no-ansi' is DEPRECATED ! Please use '--ansi' instead.`