### PR TITLE
SUP-2585: Add Support for changing Build Drivers

### DIFF
--- a/README.md
+++ b/README.md
@@ -344,7 +344,29 @@ If set to true, docker compose will build with the `--with-dependencies` option 
 
 The default is `false`.
 
-#### `build-driver` (string)
+#### `builder` (object)
+
+Defines the properties required for creating, using and removing Builder Instances. If not set, the default Builder Instance on the Agent Instance will be used.
+
+##### `bootstrap` (boolean)
+
+If set to true, will boot builder instance after creation. Optional when using `create`.
+
+The default is `true`.
+
+##### create (boolean)
+
+If set to true, will use `docker buildx create` to create a new Builder Instance using the propeties defined.
+
+The default is `false`.
+
+##### debug (boolean)
+
+If set to true, enables debug logging during creation of builder instance. Optional when using `create`.
+
+The default is `false`.
+
+##### `driver` (string)
 
 If set will create a Builder Instance using the selected Driver and use it. Available Drivers:
 
@@ -352,7 +374,45 @@ If set will create a Builder Instance using the selected Driver and use it. Avai
 - `kubernetes` creates BuildKit pods in a Kubernetes cluster.
 - `remote` connects directly to a manually managed BuildKit daemon.
 
-The default is `""` resulting in using the default `docker` driver. More details on different [Build Drivers](https://docs.docker.com/build/builders/drivers/).
+More details on different [Build Drivers](https://docs.docker.com/build/builders/drivers/).
+
+##### `driver-opt` (string)
+
+Optional, commas separated, Key-Value pairs of driver-specific options to configure the Builder Instance when using `create`. Available options for each Driver:
+
+- [docker-container](https://docs.docker.com/build/builders/drivers/docker-container/)
+- [kubernetes](https://docs.docker.com/build/builders/drivers/kubernetes/)
+- [remote](https://docs.docker.com/build/builders/drivers/remote/)
+
+Example: `memory=100m`
+
+##### name (string)
+
+Sets the name of the Builder instance to create or use. Required when using `create` or `use` builder paramaters.
+
+##### platform (string)
+
+Commas separated, fixed platforms for builder instance. Optional when using `create`.
+
+Example: `linux/amd64,linux/arm64`
+
+##### remote-address
+
+Address of remote builder instance. Required when using `driver: remote`.
+
+Example: `tcp://localhost:1234`
+
+##### remove (boolean)
+
+If set to true will stop and remove the Builder Instance specified by `name`.
+
+The default is `false`.
+
+##### use (boolean)
+
+If set to true will use Builder Instance specified by `name`.
+
+The default is `false`.
 
 ## Developing
 

--- a/README.md
+++ b/README.md
@@ -344,9 +344,9 @@ If set to true, docker compose will build with the `--with-dependencies` option 
 
 The default is `false`.
 
-#### `docker-driver` {string}
+#### `build-driver` {string}
 
-If set will create a Docker Builder Instance using the selected Driver and use it. Available Drivers:
+If set will create a Builder Instance using the selected Driver and use it. Available Drivers:
 
 - `docker-container` creates a dedicated BuildKit container using Docker.
 - `kubernetes` creates BuildKit pods in a Kubernetes cluster.

--- a/README.md
+++ b/README.md
@@ -386,6 +386,18 @@ Commas separated, Key-Value pairs of driver-specific options to configure the Bu
 
 Example: `memory=100m,cpuset-cpus=1`
 
+##### `keep-daemon` (boolean)
+
+If set to true, will keep the BuildKit daemon running after the buildx context (Builder) is removed. This is useful when you manage BuildKit daemons and buildx contexts independently. Only supported by the `docker-container` and `kubernetes` drivers. Optional when using `remove`.
+
+The default is `false`.
+
+##### `keep-state` (boolean)
+
+If set to true, will keep BuildKit state so it can be reused by a new Builder with the same name, persisting the driver's cache. Currently, only supported by the `docker-container` driver. Optional when using `remove`.
+
+The default is `false`.
+
 ##### `name`
 
 Sets the name of the Builder instance to create or use. Required when using `create` or `use` builder paramaters.

--- a/README.md
+++ b/README.md
@@ -344,6 +344,16 @@ If set to true, docker compose will build with the `--with-dependencies` option 
 
 The default is `false`.
 
+#### `docker-driver` {string}
+
+If set will create a Docker Builder Instance using the selected Driver and use it. Available Drivers:
+
+- `docker-container` creates a dedicated BuildKit container using Docker.
+- `kubernetes` creates BuildKit pods in a Kubernetes cluster.
+- `remote` connects directly to a manually managed BuildKit daemon.
+
+The default is `""` resulting in using the default `docker` driver. More details on different [Build Drivers](https://docs.docker.com/build/builders/drivers/).
+
 ## Developing
 
 To run the tests:

--- a/README.md
+++ b/README.md
@@ -354,19 +354,19 @@ If set to true, will boot builder instance after creation. Optional when using `
 
 The default is `true`.
 
-##### create (boolean)
+##### `create` (boolean)
 
 If set to true, will use `docker buildx create` to create a new Builder Instance using the propeties defined.
 
 The default is `false`.
 
-##### debug (boolean)
+##### `debug` (boolean)
 
 If set to true, enables debug logging during creation of builder instance. Optional when using `create`.
 
 The default is `false`.
 
-##### `driver` (string)
+##### `driver`
 
 If set will create a Builder Instance using the selected Driver and use it. Available Drivers:
 
@@ -376,7 +376,7 @@ If set will create a Builder Instance using the selected Driver and use it. Avai
 
 More details on different [Build Drivers](https://docs.docker.com/build/builders/drivers/).
 
-##### `driver-opt` (string)
+##### `driver-opt`
 
 Optional, commas separated, Key-Value pairs of driver-specific options to configure the Builder Instance when using `create`. Available options for each Driver:
 
@@ -386,29 +386,29 @@ Optional, commas separated, Key-Value pairs of driver-specific options to config
 
 Example: `memory=100m`
 
-##### name (string)
+##### `name`
 
 Sets the name of the Builder instance to create or use. Required when using `create` or `use` builder paramaters.
 
-##### platform (string)
+##### `platform`
 
 Commas separated, fixed platforms for builder instance. Optional when using `create`.
 
 Example: `linux/amd64,linux/arm64`
 
-##### remote-address
+##### `remote-address`
 
 Address of remote builder instance. Required when using `driver: remote`.
 
 Example: `tcp://localhost:1234`
 
-##### remove (boolean)
+##### `remove` (boolean)
 
 If set to true will stop and remove the Builder Instance specified by `name`.
 
 The default is `false`.
 
-##### use (boolean)
+##### `use` (boolean)
 
 If set to true will use Builder Instance specified by `name`.
 

--- a/README.md
+++ b/README.md
@@ -344,7 +344,7 @@ If set to true, docker compose will build with the `--with-dependencies` option 
 
 The default is `false`.
 
-#### `build-driver` {string}
+#### `build-driver` (string)
 
 If set will create a Builder Instance using the selected Driver and use it. Available Drivers:
 

--- a/README.md
+++ b/README.md
@@ -378,13 +378,13 @@ More details on different [Build Drivers](https://docs.docker.com/build/builders
 
 ##### `driver-opt`
 
-Optional, commas separated, Key-Value pairs of driver-specific options to configure the Builder Instance when using `create`. Available options for each Driver:
+Commas separated, Key-Value pairs of driver-specific options to configure the Builder Instance when using `create`. Available options for each Driver:
 
 - [docker-container](https://docs.docker.com/build/builders/drivers/docker-container/)
 - [kubernetes](https://docs.docker.com/build/builders/drivers/kubernetes/)
 - [remote](https://docs.docker.com/build/builders/drivers/remote/)
 
-Example: `memory=100m`
+Example: `memory=100m,cpuset-cpus=1`
 
 ##### `name`
 

--- a/README.md
+++ b/README.md
@@ -356,7 +356,7 @@ The default is `true`.
 
 ##### `create` (boolean)
 
-If set to true, will use `docker buildx create` to create a new Builder Instance using the propeties defined.
+If set to true, will use `docker buildx create` to create a new Builder Instance using the propeties defined. If a Builder Instance with the same `name` already exists, it will not be recreated.
 
 The default is `false`.
 

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -331,7 +331,7 @@ steps:
           cache-from:
             - "app:myregistry:port/myrepo/myapp:my-branch"
             - "app:myregistry:port/myrepo/myapp:latest"
-          driver:
+          builder:
             name: container
             driver: docker-container
             create: true
@@ -353,7 +353,7 @@ steps:
           cache-from:
             - "app:myregistry:port/myrepo/myapp:my-branch"
             - "app:myregistry:port/myrepo/myapp:latest"
-          driver:
+          builder:
             name: container
             use: true
 ```
@@ -372,7 +372,7 @@ steps:
           cache-from:
             - "app:myregistry:port/myrepo/myapp:my-branch"
             - "app:myregistry:port/myrepo/myapp:latest"
-          driver:
+          builder:
             name: container
             remove: true
 ```
@@ -396,7 +396,7 @@ steps:
             - type=registry,ref=${DOCKER_REGISTRY}/${IMAGE_REPO}:cache
           cache-to:
             - type=registry,mode=max,image-manifest=true,oci-mediatypes=true,ref=${DOCKER_REGISTRY}/${IMAGE_REPO}:cache
-          driver:
+          builder:
             name: container
             use: true
             create: true
@@ -410,7 +410,7 @@ steps:
           build: app
           cache-from:
             - type=registry,ref=${DOCKER_REGISTRY}/${IMAGE_REPO}:cache
-          driver:
+          builder:
             name: container
             use: true
             create: true

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -374,6 +374,9 @@ steps:
             - "app:myregistry:port/myrepo/myapp:latest"
           builder:
             name: container
+            driver: docker-container
+            create: true
+            use: true
             remove: true
 ```
 

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -396,9 +396,9 @@ steps:
           build: app
           push: app:${DOCKER_REGISTRY}/${IMAGE_REPO}:cache
           cache-from:
-            - type=registry,ref=${DOCKER_REGISTRY}/${IMAGE_REPO}:cache
+            - "app:type=registry,ref=${DOCKER_REGISTRY}/${IMAGE_REPO}:cache"
           cache-to:
-            - type=registry,mode=max,image-manifest=true,oci-mediatypes=true,ref=${DOCKER_REGISTRY}/${IMAGE_REPO}:cache
+            - "app:type=registry,mode=max,image-manifest=true,oci-mediatypes=true,ref=${DOCKER_REGISTRY}/${IMAGE_REPO}:cache"
           builder:
             name: container
             use: true
@@ -412,7 +412,7 @@ steps:
       - docker-compose#v5.4.1:
           build: app
           cache-from:
-            - type=registry,ref=${DOCKER_REGISTRY}/${IMAGE_REPO}:cache
+            - "app:type=registry,ref=${DOCKER_REGISTRY}/${IMAGE_REPO}:cache"
           builder:
             name: container
             use: true

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -401,19 +401,20 @@ steps:
             use: true
             create: true
             driver: docker-container
+  
   - wait
 
   - label: ":docker: Build an image using remote cache"
-  plugins:
-    - docker-compose#v5.4.1:
-        build: app
-        cache-from:
-          - type=registry,ref=${DOCKER_REGISTRY}/${IMAGE_REPO}:cache
-        driver:
-          name: container
-          use: true
-          create: true
-          driver: docker-container
+    plugins:
+      - docker-compose#v5.4.1:
+          build: app
+          cache-from:
+            - type=registry,ref=${DOCKER_REGISTRY}/${IMAGE_REPO}:cache
+          driver:
+            name: container
+            use: true
+            create: true
+            driver: docker-container
 ```
 
 The first Step will build the Image using a Builder Instance with the `docker-container` driver and push the image cache to the remote registry, as specified by `cache-to`, with additional cache export options being used to export all the layers of intermediate steps with the image manifests. More details cache export options [here](https://github.com/moby/buildkit?tab=readme-ov-file#registry-push-image-and-cache-separately).

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -384,9 +384,9 @@ steps:
 **To keep the daemon or state, use the `keep-daemon` or `keep-state` parameters.**
 **These parameter are only applicable with specific Drivers, for detail see [`docker buildx rm`](https://docs.docker.com/reference/cli/docker/buildx/rm/).**
 
-### Reusing caches from remote regestries
+### Reusing caches from remote registries
 
-A newly spawned agent won't contain any of the docker caches for the first run which will result in a long build step. To mitigate this you can reuse caches from a remote registry, but requires pushing cache and manifests to a registry using a Builder Driver that supports cache exports e.g., `docker-container` - the `docker` driver does not support this by default. This requires use of the `cache-from`, `cache-to`, `name` and `use` parameters but will use the `create` and `driver` parameters to create the Builder Instance across multiple Agents:
+A newly spawned agent won't contain any of the docker caches for the first run which will result in a long build step. To mitigate this you can reuse caches from a remote registry, but requires pushing cache and manifests to a registry using a Builder Driver that supports cache exports e.g., `docker-container` - the `docker` driver does not support this by default. For any remote registry used that requires authenication, see [Authenticated registries](#authenticated-registries) for more details. This requires use of the `cache-from`, `cache-to`, `name` and `use` parameters but will use the `create` and `driver` parameters to create the Builder Instance across multiple Agents:
 
 ```yaml
 steps:

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -271,7 +271,7 @@ A newly spawned agent won't contain any of the docker caches for the first run w
 
 ```yaml
 steps:
-  - label: ":docker Build an image"
+  - label: ":docker: Build an image"
     plugins:
       - docker-compose#v5.4.1:
           build: app
@@ -295,7 +295,7 @@ The values you add in the `cache-from` will be mapped to the corresponding servi
 
 ```yaml
 steps:
-  - label: ":docker Build an image"
+  - label: ":docker: Build an image"
     plugins:
       - docker-compose#v5.4.1:
           build: app
@@ -312,3 +312,72 @@ steps:
           push:
             - app:myregistry:port/myrepo/myapp:latest
 ```
+
+### Create, Use and Remove Builder Instances
+
+#### Create
+
+Most Docker setups, unless configured, will use the `docker` Builder Driver by default. More details on it [here](https://docs.docker.com/build/builders/drivers/docker/).
+
+The `docker` driver can handle most situations but for advance features with the Docker, different Builder Drivers are required and this requires a Builder Instance being created first, which can be done manually or with the Plugin. To create a Builder Instance using a chosen Driver, requires the `name`, `driver` and `create` parameters:
+
+```yaml
+steps:
+  - label: ":docker: Build an image"
+    plugins:
+      - docker-compose#v5.4.1:
+          build: app
+          push: app:index.docker.io/myorg/myrepo:my-branch
+          cache-from:
+            - "app:myregistry:port/myrepo/myapp:my-branch"
+            - "app:myregistry:port/myrepo/myapp:latest"
+          driver:
+            name: container
+            driver: docker-container
+            create: true
+```
+
+**If a Builder Instance with the same `name` already exists, it will not be recreated.**
+
+#### Use
+
+By default, Builder Instances specified by `name` or that are created with `create` are not used, and the default Builder Instance on the Agent will be used. To use a Builder Instance, requires the `name` and `use` parameters and the Builder Instance to exist:
+
+```yaml
+steps:
+  - label: ":docker: Build an image"
+    plugins:
+      - docker-compose#v5.4.1:
+          build: app
+          push: app:index.docker.io/myorg/myrepo:my-branch
+          cache-from:
+            - "app:myregistry:port/myrepo/myapp:my-branch"
+            - "app:myregistry:port/myrepo/myapp:latest"
+          driver:
+            name: container
+            use: true
+```
+
+#### Remove
+
+By default, Builder Instances specified by `name` or that are created with `create` are not removed after the Job finishs. To remove a Builder Instance, requires the `name` and `remove` parameters and the Builder Instance to exist:
+
+```yaml
+steps:
+  - label: ":docker: Build an image"
+    plugins:
+      - docker-compose#v5.4.1:
+          build: app
+          push: app:index.docker.io/myorg/myrepo:my-branch
+          cache-from:
+            - "app:myregistry:port/myrepo/myapp:my-branch"
+            - "app:myregistry:port/myrepo/myapp:latest"
+          driver:
+            name: container
+            remove: true
+```
+
+**Removing a Builder Instance by default will remove the daemon running it and its state (which can be used for cache).**
+**To keep the daemon or state, use the `keep-daemon` or `keep-state` parameters.**
+**These parameter are only applicable with specific Drivers, for detail see [`docker buildx rm`](https://docs.docker.com/reference/cli/docker/buildx/rm/).**
+

--- a/hooks/pre-command
+++ b/hooks/pre-command
@@ -1,0 +1,22 @@
+#!/bin/bash
+set -ueo pipefail
+
+DIR="$(cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd)"
+
+# shellcheck source=lib/shared.bash
+. "$DIR/../lib/shared.bash"
+
+docker_driver="$(plugin_read_config DOCKER_DRIVER "")"
+docker_drivers=("docker" "docker-container" "kubernetes" "remote")
+if [[ ${docker_drivers[*]} =~ $docker_driver ]]; then
+    echo "~~~ :docker: Creating and Using Docker Builder Instance with Driver: ${docker_driver}"
+    # Use Buildkite Job ID to create unique builder instance instance per Job
+    docker buildx create "${docker_driver}" --name "${BUILDKITE_JOB_ID}" --use
+    export DOCKER_DRIVER_INSTANCE=true
+elif [[ -z "$docker_driver"  ]]; then
+    echo "~~~ :docker: Using Default Docker Driver"
+else
+    echo "+++ 🚨 Invalid driver: ${docker_driver}"
+    echo "Valid Drivers: ${docker_drivers[*]}"
+    exit 1
+fi

--- a/hooks/pre-command
+++ b/hooks/pre-command
@@ -53,7 +53,13 @@ if [[ "${builder_create}" == "true" ]]; then
 
         remote_address="$(plugin_read_config BUILDER_REMOTE_ADDRESS "")"
         if [[ -n "${remote_address}" ]]; then
-            builder_instance_args+=("${remote_address}")
+            if [[ "${build_driver}" == "remote" ]]; then
+                builder_instance_args+=("${remote_address}")
+            else
+                echo "+++ 🚨 Builder Driver '${build_driver}' used with 'remote-address' parameter"
+                echo "'remote-address' can only be used with 'remote' driver"
+                exit 1
+            fi
         fi
 
         echo "~~~ :docker: Creating Builder Instance '${builder_name}' with Driver '${build_driver}'"

--- a/hooks/pre-command
+++ b/hooks/pre-command
@@ -11,7 +11,9 @@ valid_drivers="docker-container|kubernetes|remote"
 if [[ "${build_driver}" =~ ^(${valid_drivers})$ ]]; then
     echo "~~~ :docker: Creating and Using Builder Instance with Driver: ${build_driver}"
     # Use Buildkite Job ID to create unique builder instance instance per Job
-    docker buildx create "${build_driver}" --name "${BUILDKITE_JOB_ID}" --use
+    # add prefix due constraint needing to start with a letter
+    export BUILDER_INSTANCE_NAME="${build_driver}-${BUILDKITE_JOB_ID}"
+    docker buildx create "${build_driver}" --name ${BUILDER_INSTANCE_NAME} --use
     export BUILD_DRIVER_INSTANCE=true
 elif [[ -z "$build_driver"  ]]; then
     echo "~~~ :docker: Using Default Build Driver 'docker'"

--- a/hooks/pre-command
+++ b/hooks/pre-command
@@ -7,7 +7,7 @@ DIR="$(cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd)"
 . "$DIR/../lib/shared.bash"
 
 docker_driver="$(plugin_read_config DOCKER_DRIVER "")"
-docker_drivers=("docker" "docker-container" "kubernetes" "remote")
+docker_drivers=("docker-container" "kubernetes" "remote")
 if [[ ${docker_drivers[*]} =~ $docker_driver ]]; then
     echo "~~~ :docker: Creating and Using Docker Builder Instance with Driver: ${docker_driver}"
     # Use Buildkite Job ID to create unique builder instance instance per Job

--- a/hooks/pre-command
+++ b/hooks/pre-command
@@ -21,12 +21,12 @@ if [[ "${builder_create}" == "true" ]]; then
     if ! builder_instance_exists "${builder_name}"; then
         builder_instance_args=()
 
-        builder_instance_args=(--name "${builder_name}")
+        builder_instance_args+=(--name "${builder_name}")
 
         build_driver="$(plugin_read_config BUILDER_DRIVER "")"
         valid_drivers="docker-container|kubernetes|remote"
         if [[ "${build_driver}" =~ ^(${valid_drivers})$ ]]; then
-            builder_instance_args=(--driver "${build_driver}")
+            builder_instance_args+=(--driver "${build_driver}")
         else
             echo "+++ 🚨 Invalid driver: '${build_driver}'"
             echo "Valid Drivers: ${valid_drivers//|/, }"

--- a/hooks/pre-command
+++ b/hooks/pre-command
@@ -7,8 +7,8 @@ DIR="$(cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd)"
 . "$DIR/../lib/shared.bash"
 
 build_driver="$(plugin_read_config BUILD_DRIVER "")"
-build_drivers=("docker-container" "kubernetes" "remote")
-if [[ ${build_drivers[*]} =~ $build_driver ]]; then
+valid_drivers="docker-container|kubernetes|remote"
+if [[ "${build_driver}" =~ ^(${valid_drivers})$ ]]; then
     echo "~~~ :docker: Creating and Using Builder Instance with Driver: ${build_driver}"
     # Use Buildkite Job ID to create unique builder instance instance per Job
     docker buildx create "${build_driver}" --name "${BUILDKITE_JOB_ID}" --use
@@ -17,6 +17,6 @@ elif [[ -z "$build_driver"  ]]; then
     echo "~~~ :docker: Using Default Build Driver 'docker'"
 else
     echo "+++ 🚨 Invalid driver: ${build_driver}"
-    echo "Valid Drivers: ${build_drivers[*]}"
+    echo "Valid Drivers: ${valid_drivers//|/, }"
     exit 1
 fi

--- a/hooks/pre-command
+++ b/hooks/pre-command
@@ -13,7 +13,7 @@ if [[ "${build_driver}" =~ ^(${valid_drivers})$ ]]; then
     # Use Buildkite Job ID to create unique builder instance instance per Job
     # add prefix due constraint needing to start with a letter
     export BUILDER_INSTANCE_NAME="${build_driver}-${BUILDKITE_JOB_ID}"
-    docker buildx create --driver "${build_driver}" --name ${BUILDER_INSTANCE_NAME} --use
+    docker buildx create --driver "${build_driver}" --name ${BUILDER_INSTANCE_NAME} --use --bootstrap
     export BUILD_DRIVER_INSTANCE=true
 elif [[ -z "$build_driver"  ]]; then
     echo "~~~ :docker: Using Default Build Driver 'docker'"

--- a/hooks/pre-command
+++ b/hooks/pre-command
@@ -80,5 +80,5 @@ if [[ "${builder_use}" == "true" ]]; then
 else
     current_builder=$(docker buildx inspect | grep -m 1 "Name" | awk '{print $2}') || true
     current_builder_driver=$(docker buildx inspect | grep -m 1 "Driver" | awk '{print $2}') || true
-    echo "~~~ :docker: Using Default Build Driver '${current_builder}' with Driver '${current_builder_driver}'"
+    echo "~~~ :docker: Using Default Builder '${current_builder}' with Driver '${current_builder_driver}'"
 fi

--- a/hooks/pre-command
+++ b/hooks/pre-command
@@ -62,6 +62,9 @@ if [[ "${builder_create}" == "true" ]]; then
 
         echo "~~~ :docker: Creating Builder Instance '${builder_name}' with Driver '${build_driver}'"
         docker buildx create "${builder_instance_args[@]}"
+        if [[ "${builder_use}" == "false" ]]; then
+            echo "~~~ :warning: Builder Instance '${builder_name}' created but will not be used as 'use: true' parameter not specified"
+        fi
     else
         echo "~~~ :docker: Not Creating Builder Instance '${builder_name}' as already exists"
     fi

--- a/hooks/pre-command
+++ b/hooks/pre-command
@@ -13,7 +13,7 @@ if [[ "${build_driver}" =~ ^(${valid_drivers})$ ]]; then
     # Use Buildkite Job ID to create unique builder instance instance per Job
     # add prefix due constraint needing to start with a letter
     export BUILDER_INSTANCE_NAME="${build_driver}-${BUILDKITE_JOB_ID}"
-    docker buildx create --driver "${build_driver}" --name ${BUILDER_INSTANCE_NAME} --use --bootstrap
+    docker buildx create --driver "${build_driver}" --name "${BUILDER_INSTANCE_NAME}" --use --bootstrap
     export BUILD_DRIVER_INSTANCE=true
 elif [[ -z "$build_driver"  ]]; then
     echo "~~~ :docker: Using Default Build Driver 'docker'"

--- a/hooks/pre-command
+++ b/hooks/pre-command
@@ -6,17 +6,17 @@ DIR="$(cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd)"
 # shellcheck source=lib/shared.bash
 . "$DIR/../lib/shared.bash"
 
-docker_driver="$(plugin_read_config DOCKER_DRIVER "")"
-docker_drivers=("docker-container" "kubernetes" "remote")
-if [[ ${docker_drivers[*]} =~ $docker_driver ]]; then
-    echo "~~~ :docker: Creating and Using Docker Builder Instance with Driver: ${docker_driver}"
+build_driver="$(plugin_read_config BUILD_DRIVER "")"
+build_drivers=("docker-container" "kubernetes" "remote")
+if [[ ${build_drivers[*]} =~ $build_driver ]]; then
+    echo "~~~ :docker: Creating and Using Builder Instance with Driver: ${build_driver}"
     # Use Buildkite Job ID to create unique builder instance instance per Job
-    docker buildx create "${docker_driver}" --name "${BUILDKITE_JOB_ID}" --use
-    export DOCKER_DRIVER_INSTANCE=true
-elif [[ -z "$docker_driver"  ]]; then
-    echo "~~~ :docker: Using Default Docker Driver"
+    docker buildx create "${build_driver}" --name "${BUILDKITE_JOB_ID}" --use
+    export BUILD_DRIVER_INSTANCE=true
+elif [[ -z "$build_driver"  ]]; then
+    echo "~~~ :docker: Using Default Build Driver 'docker'"
 else
-    echo "+++ 🚨 Invalid driver: ${docker_driver}"
-    echo "Valid Drivers: ${docker_drivers[*]}"
+    echo "+++ 🚨 Invalid driver: ${build_driver}"
+    echo "Valid Drivers: ${build_drivers[*]}"
     exit 1
 fi

--- a/hooks/pre-command
+++ b/hooks/pre-command
@@ -15,8 +15,6 @@ if [[ "${builder_create}" == "true" ]] || [[ "${builder_use}" == "true" ]]; then
         echo "+++ 🚨 Builder Name cannot be empty when using 'create' or 'use' parameters"
         exit 1
     fi
-    # exporting to use in pre-exit
-    export builder_name
 fi
 
 if [[ "${builder_create}" == "true" ]]; then

--- a/hooks/pre-command
+++ b/hooks/pre-command
@@ -13,7 +13,7 @@ if [[ "${build_driver}" =~ ^(${valid_drivers})$ ]]; then
     # Use Buildkite Job ID to create unique builder instance instance per Job
     # add prefix due constraint needing to start with a letter
     export BUILDER_INSTANCE_NAME="${build_driver}-${BUILDKITE_JOB_ID}"
-    docker buildx create "${build_driver}" --name ${BUILDER_INSTANCE_NAME} --use
+    docker buildx create --driver "${build_driver}" --name ${BUILDER_INSTANCE_NAME} --use
     export BUILD_DRIVER_INSTANCE=true
 elif [[ -z "$build_driver"  ]]; then
     echo "~~~ :docker: Using Default Build Driver 'docker'"

--- a/hooks/pre-command
+++ b/hooks/pre-command
@@ -6,19 +6,73 @@ DIR="$(cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd)"
 # shellcheck source=lib/shared.bash
 . "$DIR/../lib/shared.bash"
 
-build_driver="$(plugin_read_config BUILD_DRIVER "")"
-valid_drivers="docker-container|kubernetes|remote"
-if [[ "${build_driver}" =~ ^(${valid_drivers})$ ]]; then
-    echo "~~~ :docker: Creating and Using Builder Instance with Driver: ${build_driver}"
-    # Use Buildkite Job ID to create unique builder instance instance per Job
-    # add prefix due constraint needing to start with a letter
-    export BUILDER_INSTANCE_NAME="${build_driver}-${BUILDKITE_JOB_ID}"
-    docker buildx create --driver "${build_driver}" --name "${BUILDER_INSTANCE_NAME}" --use --bootstrap
-    export BUILD_DRIVER_INSTANCE=true
-elif [[ -z "$build_driver"  ]]; then
-    echo "~~~ :docker: Using Default Build Driver 'docker'"
+builder_create="$(plugin_read_config BUILDER_CREATE "false")"
+builder_use="$(plugin_read_config BUILDER_USE "false")"
+builder_name="$(plugin_read_config BUILDER_NAME "")"
+
+if [[ "${builder_create}" == "true" ]] || [[ "${builder_use}" == "true" ]]; then
+    if [[ -z "${builder_name}" ]]; then
+        echo "+++ 🚨 Builder Name cannot be empty when using 'create' or 'use' parameters"
+        exit 1
+    fi
+    # exporting to use in pre-exit
+    export builder_name
+fi
+
+if [[ "${builder_create}" == "true" ]]; then
+    if ! builder_instance_exists "${builder_name}"; then
+        builder_instance_args=()
+
+        build_driver="$(plugin_read_config BUILDER_DRIVER "")"
+        valid_drivers="docker-container|kubernetes|remote"
+        if [[ "${build_driver}" =~ ^(${valid_drivers})$ ]]; then
+            builder_instance_args=(--driver "${build_driver}")
+        else
+            echo "+++ 🚨 Invalid driver: '${build_driver}'"
+            echo "Valid Drivers: ${valid_drivers//|/, }"
+            exit 1
+        fi
+
+        if [[ "$(plugin_read_config BUILDER_BOOTSTRAP "true")" == "true" ]]; then
+            builder_instance_args+=("--bootstrap")
+        fi
+
+        if [[ "$(plugin_read_config BUILDER_DEBUG "false")" == "true" ]]; then
+            builder_instance_args+=("--debug")
+        fi
+
+        driver_opt="$(plugin_read_config BUILDER_DRIVER_OPT "")"
+        if [[ -n "${driver_opt}" ]]; then
+            builder_instance_args+=("--driver-opt ${driver_opt}")
+        fi
+
+        builder_platform="$(plugin_read_config BUILDER_PLATFORM "")"
+        if [[ -n "${builder_platform}" ]]; then
+            builder_instance_args+=("--platform ${builder_platform}")
+        fi
+
+        remote_address="$(plugin_read_config BUILDER_REMOTE_ADDRESS "")"
+        if [[ -n "${remote_address}" ]]; then
+            builder_instance_args+=("${remote_address}")
+        fi
+
+        echo "~~~ :docker: Creating Builder Instance '${builder_name}' with Driver '${build_driver}'"
+        docker buildx create --driver "${build_driver}" --name "${BUILDER_INSTANCE_NAME}" --bootstrap ${build_driver_options:+"--driver-opt=${build_driver_options}"}
+    else
+        echo "~~~ :docker: Not Creating Builder Instance '${builder_name}' as already exists"
+    fi
+fi
+
+if [[ "${builder_use}" == "true" ]]; then
+    if builder_instance_exists "${builder_name}"; then
+        echo "~~~ :docker: Using Builder Instance '${builder_name}'"
+        docker buildx use "${builder_name}"
+    else
+        echo "+++ 🚨 Builder Instance '${builder_name}' does not exist"
+        exit 1
+    fi
 else
-    echo "+++ 🚨 Invalid driver: ${build_driver}"
-    echo "Valid Drivers: ${valid_drivers//|/, }"
-    exit 1
+    current_builder=$(docker buildx inspect | grep -m 1 "Name" | awk '{print $2}') || true
+    current_builder_driver=$(docker buildx inspect | grep -m 1 "Driver" | awk '{print $2}') || true
+    echo "~~~ :docker: Using Default Build Driver '${current_builder}' with Driver '${current_builder_driver}'"
 fi

--- a/hooks/pre-command
+++ b/hooks/pre-command
@@ -21,6 +21,8 @@ if [[ "${builder_create}" == "true" ]]; then
     if ! builder_instance_exists "${builder_name}"; then
         builder_instance_args=()
 
+        builder_instance_args=(--name "${builder_name}")
+
         build_driver="$(plugin_read_config BUILDER_DRIVER "")"
         valid_drivers="docker-container|kubernetes|remote"
         if [[ "${build_driver}" =~ ^(${valid_drivers})$ ]]; then
@@ -61,7 +63,7 @@ if [[ "${builder_create}" == "true" ]]; then
         fi
 
         echo "~~~ :docker: Creating Builder Instance '${builder_name}' with Driver '${build_driver}'"
-        docker buildx create --driver "${build_driver}" --name "${BUILDER_INSTANCE_NAME}" --bootstrap ${build_driver_options:+"--driver-opt=${build_driver_options}"}
+        docker buildx create "${builder_instance_args[@]}"
     else
         echo "~~~ :docker: Not Creating Builder Instance '${builder_name}' as already exists"
     fi

--- a/hooks/pre-command
+++ b/hooks/pre-command
@@ -19,9 +19,7 @@ fi
 
 if [[ "${builder_create}" == "true" ]]; then
     if ! builder_instance_exists "${builder_name}"; then
-        builder_instance_args=()
-
-        builder_instance_args+=(--name "${builder_name}")
+        builder_instance_args=(--name "${builder_name}")
 
         build_driver="$(plugin_read_config BUILDER_DRIVER "")"
         valid_drivers="docker-container|kubernetes|remote"

--- a/hooks/pre-exit
+++ b/hooks/pre-exit
@@ -42,6 +42,6 @@ if [[ "${builder_remove}" == true ]]; then
     docker buildx stop "${builder_name}"
     docker buildx rm "${builder_name}" ${builder_remove_args:+${builder_remove_args[@]}}
   else
-    echo "~~~ :docker: Cannot remove Builder Instance '${builder_name}' as does not exist"
+    echo "~~~ :warning: Cannot remove Builder Instance '${builder_name}' as does not exist"
   fi
 fi

--- a/hooks/pre-exit
+++ b/hooks/pre-exit
@@ -21,8 +21,8 @@ if [[ -n "$(plugin_read_list RUN)" ]] && [[ "$(plugin_read_config CLEANUP "true"
   compose_cleanup
 fi
 
-if [[ "${DOCKER_DRIVER_INSTANCE}" == true ]]; then
-  echo "~~~ :docker: Cleaning up Docker Builder Instance"
+if [[ "${BUILD_DRIVER_INSTANCE}" == true ]]; then
+  echo "~~~ :docker: Cleaning up Builder Instance"
   docker buildx stop "${BUILDKITE_JOB_ID}"
   docker buildx rm "${BUILDKITE_JOB_ID}"
 fi

--- a/hooks/pre-exit
+++ b/hooks/pre-exit
@@ -38,7 +38,7 @@ if [[ "${builder_remove}" == true ]]; then
       builder_remove_args+=("--keep-state")
     fi
 
-    echo "~~~ :docker: Cleaning up Builder Instance '${builder_name}"
+    echo "~~~ :docker: Cleaning up Builder Instance '${builder_name}'"
     docker buildx stop "${builder_name}"
     docker buildx rm "${builder_name}" ${builder_remove_args:+${builder_remove_args[@]}}
   else

--- a/hooks/pre-exit
+++ b/hooks/pre-exit
@@ -28,7 +28,7 @@ builder_remove="$(plugin_read_config BUILDER_REMOVE "false")"
 if [[ "${builder_remove}" == true ]]; then
   if builder_instance_exists "${builder_name}"; then
 
-    builder_remove_args=()
+    builder_remove_args=("${builder_name}")
 
     if [[ "$(plugin_read_config BUILDER_KEEP_DAEMON "false")" == "true" ]]; then
       builder_remove_args+=("--keep-daemon")
@@ -40,7 +40,7 @@ if [[ "${builder_remove}" == true ]]; then
 
     echo "~~~ :docker: Cleaning up Builder Instance '${builder_name}'"
     docker buildx stop "${builder_name}"
-    docker buildx rm "${builder_name}" ${builder_remove_args:+${builder_remove_args[@]}}
+    docker buildx rm "${builder_remove_args[@]}"
   else
     echo "~~~ :warning: Cannot remove Builder Instance '${builder_name}' as does not exist"
   fi

--- a/hooks/pre-exit
+++ b/hooks/pre-exit
@@ -31,6 +31,6 @@ if [[ "${builder_remove}" == true ]]; then
     docker buildx stop "${builder_name}"
     docker buildx rm "${builder_name}"
   else
-    echo "~~~ :docker: Cannot to remove Builder Instance '${builder_name}' as does not exist"
+    echo "~~~ :docker: Cannot remove Builder Instance '${builder_name}' as does not exist"
   fi
 fi

--- a/hooks/pre-exit
+++ b/hooks/pre-exit
@@ -22,6 +22,7 @@ if [[ -n "$(plugin_read_list RUN)" ]] && [[ "$(plugin_read_config CLEANUP "true"
 fi
 
 # clean up builder instances if specified
+builder_name="$(plugin_read_config BUILDER_NAME "")"
 builder_remove="$(plugin_read_config BUILDER_REMOVE "false")"
 
 if [[ "${builder_remove}" == true ]]; then

--- a/hooks/pre-exit
+++ b/hooks/pre-exit
@@ -21,7 +21,7 @@ if [[ -n "$(plugin_read_list RUN)" ]] && [[ "$(plugin_read_config CLEANUP "true"
   compose_cleanup
 fi
 
-if [[ "${BUILD_DRIVER_INSTANCE}" == true ]]; then
+if [[ "${BUILD_DRIVER_INSTANCE:-}" == true ]]; then
   echo "~~~ :docker: Cleaning up Builder Instance"
   docker buildx stop "${BUILDKITE_JOB_ID}"
   docker buildx rm "${BUILDKITE_JOB_ID}"

--- a/hooks/pre-exit
+++ b/hooks/pre-exit
@@ -23,6 +23,6 @@ fi
 
 if [[ "${BUILD_DRIVER_INSTANCE:-}" == true ]]; then
   echo "~~~ :docker: Cleaning up Builder Instance"
-  docker buildx stop "${BUILDKITE_JOB_ID}"
-  docker buildx rm "${BUILDKITE_JOB_ID}"
+  docker buildx stop "${BUILDER_INSTANCE_NAME}"
+  docker buildx rm "${BUILDER_INSTANCE_NAME}"
 fi

--- a/hooks/pre-exit
+++ b/hooks/pre-exit
@@ -13,7 +13,7 @@ rm -f "docker-compose.buildkite-${BUILDKITE_BUILD_NUMBER}-override.yml"
 
 # clean up resources after a run command. we do this here so that it will
 # run after a job is cancelled
-if [[ -n "$(plugin_read_list RUN)" ]] && [[ "$(plugin_read_config CLEANUP "true")" == "true" ]] ; then
+if [[ -n "$(plugin_read_list RUN)" ]] && [[ "$(plugin_read_config CLEANUP "true")" == "true" ]]; then
   # shellcheck source=lib/run.bash
   . "$DIR/../lib/run.bash"
 
@@ -27,9 +27,20 @@ builder_remove="$(plugin_read_config BUILDER_REMOVE "false")"
 
 if [[ "${builder_remove}" == true ]]; then
   if builder_instance_exists "${builder_name}"; then
+
+    builder_remove_args=()
+
+    if [[ "$(plugin_read_config BUILDER_KEEP_DAEMON "false")" == "true" ]]; then
+      builder_remove_args+=("--keep-daemon")
+    fi
+
+    if [[ "$(plugin_read_config BUILDER_KEEP_STATE "false")" == "true" ]]; then
+      builder_remove_args+=("--keep-state")
+    fi
+
     echo "~~~ :docker: Cleaning up Builder Instance '${builder_name}"
     docker buildx stop "${builder_name}"
-    docker buildx rm "${builder_name}"
+    docker buildx rm "${builder_name}" ${builder_remove_args:+${builder_remove_args[@]}}
   else
     echo "~~~ :docker: Cannot remove Builder Instance '${builder_name}' as does not exist"
   fi

--- a/hooks/pre-exit
+++ b/hooks/pre-exit
@@ -20,3 +20,9 @@ if [[ -n "$(plugin_read_list RUN)" ]] && [[ "$(plugin_read_config CLEANUP "true"
   echo "~~~ :docker: Cleaning up after docker-compose" >&2
   compose_cleanup
 fi
+
+if [[ "${DOCKER_DRIVER_INSTANCE}" == true ]]; then
+  echo "~~~ :docker: Cleaning up Docker Builder Instance"
+  docker buildx stop "${BUILDKITE_JOB_ID}"
+  docker buildx rm "${BUILDKITE_JOB_ID}"
+fi

--- a/hooks/pre-exit
+++ b/hooks/pre-exit
@@ -21,8 +21,15 @@ if [[ -n "$(plugin_read_list RUN)" ]] && [[ "$(plugin_read_config CLEANUP "true"
   compose_cleanup
 fi
 
-if [[ "${BUILD_DRIVER_INSTANCE:-}" == true ]]; then
-  echo "~~~ :docker: Cleaning up Builder Instance"
-  docker buildx stop "${BUILDER_INSTANCE_NAME}"
-  docker buildx rm "${BUILDER_INSTANCE_NAME}"
+# clean up builder instances if specified
+builder_remove="$(plugin_read_config BUILDER_REMOVE "false")"
+
+if [[ "${builder_remove}" == true ]]; then
+  if builder_instance_exists "${builder_name}"; then
+    echo "~~~ :docker: Cleaning up Builder Instance '${builder_name}"
+    docker buildx stop "${builder_name}"
+    docker buildx rm "${builder_name}"
+  else
+    echo "~~~ :docker: Cannot to remove Builder Instance '${builder_name}' as does not exist"
+  fi
 fi

--- a/lib/shared.bash
+++ b/lib/shared.bash
@@ -320,3 +320,14 @@ function validate_tag {
     return 1
   fi
 }
+
+function builder_instance_exists() {
+    local builder_name="$1"
+
+    # Check if the specified builder exists by suppressing output and checking the exit status
+    if docker buildx inspect "${builder_name}" >/dev/null 2>&1; then
+        return 0 # Builder exists
+    else
+        return 1 # Builder does not exist
+    fi
+}

--- a/plugin.yml
+++ b/plugin.yml
@@ -37,6 +37,10 @@ configuration:
           enum: [ "docker-container", "kubernetes", "remote" ]
         driver-opt:
           type: string
+        keep-daemon:
+          type: boolean
+        keep-state:
+          type: boolean
         name:
           type: string
         platform:

--- a/plugin.yml
+++ b/plugin.yml
@@ -23,6 +23,9 @@ configuration:
     build-alias:
       type: [ string, array ]
       minimum: 1
+    build-driver:
+      type: string
+      enum: [ "docker-container", "kubernetes", "remote" ]
     build-labels:
       type: [ string, array ]
       minimum: 1
@@ -55,9 +58,6 @@ configuration:
       minimum: 1
     dependencies:
       type: boolean
-    docker-driver:
-      type: string
-      enum: [ "docker-container", "kubernetes", "remote" ]
     entrypoint:
       type: string
     env:

--- a/plugin.yml
+++ b/plugin.yml
@@ -55,6 +55,9 @@ configuration:
       minimum: 1
     dependencies:
       type: boolean
+    docker-driver:
+      type: string
+      enum: [ "docker", "docker-container", "kubernetes", "remote" ]
     entrypoint:
       type: string
     env:

--- a/plugin.yml
+++ b/plugin.yml
@@ -50,7 +50,7 @@ configuration:
         remove:
           type: boolean
         use:
-          type: string
+          type: boolean
       additionalProperties: false
     build-labels:
       type: [ string, array ]

--- a/plugin.yml
+++ b/plugin.yml
@@ -57,7 +57,7 @@ configuration:
       type: boolean
     docker-driver:
       type: string
-      enum: [ "docker", "docker-container", "kubernetes", "remote" ]
+      enum: [ "docker-container", "kubernetes", "remote" ]
     entrypoint:
       type: string
     env:

--- a/plugin.yml
+++ b/plugin.yml
@@ -47,6 +47,7 @@ configuration:
           type: boolean
         use:
           type: string
+      additionalProperties: false
     build-labels:
       type: [ string, array ]
       minimum: 1

--- a/plugin.yml
+++ b/plugin.yml
@@ -23,9 +23,30 @@ configuration:
     build-alias:
       type: [ string, array ]
       minimum: 1
-    build-driver:
-      type: string
-      enum: [ "docker-container", "kubernetes", "remote" ]
+    builder:
+      type: object
+      properties:
+        bootstrap:
+          type: boolean
+        create:
+          type: boolean
+        debug:
+          type: boolean
+        driver:
+          type: string
+          enum: [ "docker-container", "kubernetes", "remote" ]
+        driver-opt:
+          type: string
+        name:
+          type: string
+        platform:
+          type: string
+        remote-address:
+          type: string
+        remove:
+          type: boolean
+        use:
+          type: string
     build-labels:
       type: [ string, array ]
       minimum: 1

--- a/tests/builder-instances.bats
+++ b/tests/builder-instances.bats
@@ -5,12 +5,6 @@ load '../lib/shared'
 
 # export DOCKER_STUB_DEBUG=/dev/tty
 
-teardown() {
-    if [[ -f "${BATS_MOCK_BINDIR}/docker" ]]; then
-        unstub docker
-    fi
-}
-
 @test "No Builder Instance Parameters" {
 
     stub docker \
@@ -21,6 +15,8 @@ teardown() {
 
     assert_success
     assert_output "~~~ :docker: Using Default Builder 'test' with Driver 'driver'"
+
+    unstub docker
 }
 
 @test "Create Builder Instance with invalid Name" {
@@ -99,6 +95,8 @@ teardown() {
 
     assert_failure
     assert_output "+++ 🚨 Builder Instance 'builder-name' does not exist"
+
+    unstub docker
 }
 
 @test "Use Builder Instance that Exists" {
@@ -113,6 +111,8 @@ teardown() {
 
     assert_success
     assert_output "~~~ :docker: Using Builder Instance '$BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILDER_NAME'"
+
+    unstub docker
 }
 
 @test "Remove Builder Instance that Exists" {
@@ -130,6 +130,8 @@ teardown() {
 
     assert_success
     assert_output "~~~ :docker: Cleaning up Builder Instance 'builder-name'"
+
+    unstub docker
 }
 
 @test "Remove Builder Instance that Exists with keep-daemon" {
@@ -148,6 +150,8 @@ teardown() {
 
     assert_success
     assert_output "~~~ :docker: Cleaning up Builder Instance 'builder-name'"
+
+    unstub docker
 }
 
 @test "Remove Builder Instance that Exists with keep-daemon and keep-state" {
@@ -167,6 +171,8 @@ teardown() {
 
     assert_success
     assert_output "~~~ :docker: Cleaning up Builder Instance 'builder-name'"
+    
+    unstub docker
 }
 
 @test "Remove Builder Instance that does not Exists" {
@@ -182,4 +188,6 @@ teardown() {
 
     assert_success
     assert_output "~~~ :warning: Cannot remove Builder Instance 'builder-name' as does not exist"
+
+    unstub docker
 }

--- a/tests/builder-instances.bats
+++ b/tests/builder-instances.bats
@@ -67,9 +67,8 @@ teardown() {
     run "$PWD"/hooks/pre-command
 
     assert_success
-    assert_output \
-        "~~~ :docker: Creating Builder Instance 'builder-name' with Driver 'docker-container'
-~~~ :docker: Using Default Builder 'test' with Driver 'driver'"
+    assert_output --partial "~~~ :docker: Creating Builder Instance 'builder-name' with Driver 'docker-container'"
+    assert_output --partial "~~~ :docker: Using Default Builder 'test' with Driver 'driver'"
 }
 
 @test "Create Builder Instance with valid Driver but already Exists" {
@@ -85,9 +84,8 @@ teardown() {
     run "$PWD"/hooks/pre-command
 
     assert_success
-    assert_output \
-        "~~~ :docker: Not Creating Builder Instance 'builder-name' as already exists
-~~~ :docker: Using Default Builder 'test' with Driver 'driver'"
+    assert_output --partial "~~~ :docker: Not Creating Builder Instance 'builder-name' as already exists"
+    assert_output --partial "~~~ :docker: Using Default Builder 'test' with Driver 'driver'"
 }
 
 @test "Use Builder Instance that does not Exist" {

--- a/tests/builder-instances.bats
+++ b/tests/builder-instances.bats
@@ -3,6 +3,8 @@
 load "${BATS_PLUGIN_PATH}/load.bash"
 load '../lib/shared'
 
+# export DOCKER_STUB_DEBUG=/dev/tty
+
 @test "No Builder Instance Parameters" {
 
     stub docker \

--- a/tests/builder-instances.bats
+++ b/tests/builder-instances.bats
@@ -14,3 +14,21 @@ load '../lib/shared'
     assert_success
     assert_output "~~~ :docker: Using Default Builder 'test' with Driver 'driver'"
 }
+
+@test "Create Builder Instance with invalid Name" {
+    export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILDER_CREATE=true
+
+    run "$PWD"/hooks/pre-command
+
+    assert_failure
+    assert_output "+++ 🚨 Builder Name cannot be empty when using 'create' or 'use' parameters"
+}
+
+@test "Use Builder Instance with invalid Name" {
+    export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILDER_USE=true
+
+    run "$PWD"/hooks/pre-command
+
+    assert_failure
+    assert_output "+++ 🚨 Builder Name cannot be empty when using 'create' or 'use' parameters"
+}

--- a/tests/builder-instances.bats
+++ b/tests/builder-instances.bats
@@ -116,3 +116,72 @@ teardown() {
     assert_success
     assert_output "~~~ :docker: Using Builder Instance '$BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILDER_NAME'"
 }
+
+@test "Remove Builder Instance that Exists" {
+    export BUILDKITE_BUILD_NUMBER=111
+    export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILDER_USE=true
+    export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILDER_NAME=builder-name
+    export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILDER_REMOVE=true
+
+    stub docker \
+        "buildx inspect builder-name : exit 0" \
+        "buildx stop builder-name : exit 0" \
+        "buildx rm builder-name : exit 0"
+
+    run "$PWD"/hooks/pre-exit
+
+    assert_success
+    assert_output "~~~ :docker: Cleaning up Builder Instance 'builder-name'"
+}
+
+@test "Remove Builder Instance that Exists with keep-daemon" {
+    export BUILDKITE_BUILD_NUMBER=111
+    export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILDER_USE=true
+    export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILDER_NAME=builder-name
+    export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILDER_REMOVE=true
+    export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILDER_KEEP_DAEMON=true
+
+    stub docker \
+        "buildx inspect builder-name : exit 0" \
+        "buildx stop builder-name : exit 0" \
+        "buildx rm builder-name --keep-daemon : exit 0"
+
+    run "$PWD"/hooks/pre-exit
+
+    assert_success
+    assert_output "~~~ :docker: Cleaning up Builder Instance 'builder-name'"
+}
+
+@test "Remove Builder Instance that Exists with keep-daemon and keep-state" {
+    export BUILDKITE_BUILD_NUMBER=111
+    export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILDER_USE=true
+    export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILDER_NAME=builder-name
+    export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILDER_REMOVE=true
+    export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILDER_KEEP_DAEMON=true
+    export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILDER_KEEP_STATE=true
+
+    stub docker \
+        "buildx inspect builder-name : exit 0" \
+        "buildx stop builder-name : exit 0" \
+        "buildx rm builder-name --keep-daemon --keep-state : exit 0"
+
+    run "$PWD"/hooks/pre-exit
+
+    assert_success
+    assert_output "~~~ :docker: Cleaning up Builder Instance 'builder-name'"
+}
+
+@test "Remove Builder Instance that does not Exists" {
+    export BUILDKITE_BUILD_NUMBER=111
+    export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILDER_USE=true
+    export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILDER_NAME=builder-name
+    export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILDER_REMOVE=true
+
+    stub docker \
+        "buildx inspect builder-name : exit 1"
+
+    run "$PWD"/hooks/pre-exit
+
+    assert_success
+    assert_output "~~~ :docker: Cannot remove Builder Instance 'builder-name' as does not exist"
+}

--- a/tests/builder-instances.bats
+++ b/tests/builder-instances.bats
@@ -89,3 +89,30 @@ teardown() {
         "~~~ :docker: Not Creating Builder Instance 'builder-name' as already exists
 ~~~ :docker: Using Default Builder 'test' with Driver 'driver'"
 }
+
+@test "Use Builder Instance that does not Exist" {
+    export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILDER_USE=true
+    export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILDER_NAME=builder-name
+
+    stub docker \
+        "buildx inspect builder-name : exit 1"
+
+    run "$PWD"/hooks/pre-command
+
+    assert_failure
+    assert_output "+++ 🚨 Builder Instance 'builder-name' does not exist"
+}
+
+@test "Use Builder Instance that Exists" {
+    export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILDER_USE=true
+    export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILDER_NAME=builder-name
+
+    stub docker \
+        "buildx inspect builder-name : exit 0" \
+        "buildx use builder-name : exit 0"
+
+    run "$PWD"/hooks/pre-command
+
+    assert_success
+    assert_output "~~~ :docker: Using Builder Instance '$BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILDER_NAME'"
+}

--- a/tests/builder-instances.bats
+++ b/tests/builder-instances.bats
@@ -183,5 +183,5 @@ teardown() {
     run "$PWD"/hooks/pre-exit
 
     assert_success
-    assert_output "~~~ :docker: Cannot remove Builder Instance 'builder-name' as does not exist"
+    assert_output "~~~ :warning: Cannot remove Builder Instance 'builder-name' as does not exist"
 }

--- a/tests/builder-instances.bats
+++ b/tests/builder-instances.bats
@@ -32,3 +32,15 @@ load '../lib/shared'
     assert_failure
     assert_output "+++ 🚨 Builder Name cannot be empty when using 'create' or 'use' parameters"
 }
+
+@test "Create Builder Instance with invalid Driver" {
+    export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILDER_CREATE=true
+    export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILDER_NAME=builder-name
+    export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILDER_DRIVER=""
+
+    run "$PWD"/hooks/pre-command
+
+    assert_failure
+    assert_output --partial "+++ 🚨 Invalid driver: ''"
+    assert_output --partial "Valid Drivers: docker-container, kubernetes, remote"
+}

--- a/tests/builder-instances.bats
+++ b/tests/builder-instances.bats
@@ -1,0 +1,16 @@
+#!/usr/bin/env bats
+
+load "${BATS_PLUGIN_PATH}/load.bash"
+load '../lib/shared'
+
+@test "No Builder Instance Parameters" {
+
+    stub docker \
+        "buildx inspect : echo 'Name: test'" \
+        "buildx inspect : echo 'Driver: driver'"
+
+    run "$PWD"/hooks/pre-command
+
+    assert_success
+    assert_output "~~~ :docker: Using Default Builder 'test' with Driver 'driver'"
+}

--- a/tests/builder-instances.bats
+++ b/tests/builder-instances.bats
@@ -5,6 +5,12 @@ load '../lib/shared'
 
 # export DOCKER_STUB_DEBUG=/dev/tty
 
+teardown() {
+    if [[ -f "${BATS_MOCK_BINDIR}/docker" ]]; then
+        unstub docker
+    fi
+}
+
 @test "No Builder Instance Parameters" {
 
     stub docker \


### PR DESCRIPTION
Per Issue: https://github.com/buildkite-plugins/docker-compose-buildkite-plugin/issues/457

To be able to fully support using the `cache-to` parameter, the Build Driver needs to be changed to use a different driver other than the default `docker` driver.
This PR will add the basic ability to change the driver used in a per Job basis and clean up the Build Instance afterwards to avoid issues of lingering Build Instances.

- [x] README.md updated
- [x] tests added
- [x] examples added to examples/examples.md
