### PR TITLE
doc: clarify upgrade path to v5 — image-repository and image-name attrs

### DIFF
--- a/docs/upgrading-to-v5.md
+++ b/docs/upgrading-to-v5.md
@@ -44,7 +44,7 @@ The plugin should print out the override file used in the step's logs for you to
 
 As per the documentation, the images you want to use as cache must have been built with the `BUILDKIT_INLINE_CACHE=1` build argument. Otherwise, the manifest used by docker to determine if the image contains layers that could be useful to pull will not be present and will not be used.
 
-Note that docker silently ignores any `cache-from` configuration that is not valid or can not be used. 
+Note that docker silently ignores any `cache-from` configuration that is not valid or can not be used.
 
 ## `image-repository` and/or `image-name`
 
@@ -53,6 +53,8 @@ These options were used to push images in `build` steps.
 You need to:
 * delete these options
 * add a `push` or `run` on the very same step
+* combine them into a single entry in the format `repository:tag`
+
 
 Example change:
 ```diff

--- a/docs/upgrading-to-v5.md
+++ b/docs/upgrading-to-v5.md
@@ -54,6 +54,17 @@ You need to:
 * delete these options
 * add a `push` or `run` on the very same step
 
+Example change:
+```diff
+-    - docker-compose#v4.16.0:
++    - docker-compose#v5.0.0:
+         build: base
+-        image-name: image-name-build_id
+-        image-repository: image-repo-host/builds
+         push:
++        - image-repo-host/builds:image-name-build_id
+```
+
 ## `cli-version`
 
 If you were using this option to ensure that `docker compose` was used, you should be able to remove it safely. On the other hand, if your build environment only has the old v1 CLI interface (`docker-compose`), you will need to make some changes.


### PR DESCRIPTION
Add example of a change in the `push` step while upgrading to v5.

Closes https://github.com/buildkite-plugins/docker-compose-buildkite-plugin/issues/471