### PR TITLE
Quiet push

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,9 +273,15 @@ Sets `docker-compose` to run with `--verbose`
 
 The default is `false`.
 
-#### `quiet-pull` (run only, boolean)
+#### `quiet-pull` (run/push only, boolean)
 
-Start up dependencies with `--quiet-pull` to prevent even more logs during that portion of the execution.
+During `run`, start up dependencies with `--quiet-pull` to prevent even more logs during that portion of the execution. Will also add `--quiet` if a `docker pull` is executed before a `push` step.
+
+The default is `false`.
+
+#### `quiet-push` (push only, boolean)
+
+Will add `--quiet` to the `docker push` command to prevent such verbose logs.
 
 The default is `false`.
 

--- a/commands/run.sh
+++ b/commands/run.sh
@@ -71,17 +71,21 @@ if [[ ${#prebuilt_services[@]} -gt 0 ]] ; then
   up_params+=(-f "$override_file")
 fi
 
+pull_params+=("pull")
+
 # If there are multiple services to pull, run it in parallel (although this is now the default)
 if [[ ${#pull_services[@]} -gt 1 ]] ; then
-  pull_params+=("pull" "--parallel" "${pull_services[@]}")
-elif [[ ${#pull_services[@]} -eq 1 ]] ; then
-  pull_params+=("pull" "${pull_services[0]}")
+  pull_params+=("--parallel")
+fi
+
+if [ "$(plugin_read_config QUIET_PULL "false")" == "true" ] ; then
+  pull_params+=("--quiet")
 fi
 
 # Pull down specified services
 if [[ ${#pull_services[@]} -gt 0 ]] && [[ "$(plugin_read_config SKIP_PULL "false")" != "true" ]]; then
   echo "~~~ :docker: Pulling services ${pull_services[0]}"
-  retry "$pull_retries" run_docker_compose "${pull_params[@]}"
+  retry "$pull_retries" run_docker_compose "${pull_params[@]}" "${pull_services[@]}"
 fi
 
 # We set a predictable container name so we can find it and inspect it later on

--- a/plugin.yml
+++ b/plugin.yml
@@ -132,6 +132,8 @@ configuration:
       type: integer
     quiet-pull:
       type: boolean
+    quiet-push:
+      type: boolean
     require-prebuild:
       type: boolean
     rm:
@@ -210,7 +212,8 @@ configuration:
     pull: [ run ]
     pull-retries: [ run ]
     push-retries: [ push ]
-    quiet-pull: [ run ]
+    quiet-pull: [ push, run]
+    quiet-push: [ push ]
     require-prebuild: [ run ]
     rm: [ run ]
     run-image: [ run ]


### PR DESCRIPTION
Adds a new option to pass `--quiet` to push comands. While I was at it, I had the `quiet-pull` option be respected when the `pull` happens during a `push` stage.

Closes #475 