### PR TITLE
Skip metadata push

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ The name of the service the command should be run within. If the docker-compose 
 
 A list of services to push. You can specify just the service name to push or the format `service:registry:tag` to override where the service's image is pushed to. Needless to say, the image for the service must have been built in the very same step or built and pushed previously to ensure it is available for pushing.
 
+**Important**: when the image for a service is pushed it sets metadata on the build so that future steps will know to use that image to run that service. This can lead to race conditions when pushing multiple images for a service. Can be turned off with the `push-metadata` option.
+
 :warning: If a service does not have an `image` configuration and no registry/tag are specified in the `push` option, pushing of the service will be skipped by docker.
 
 :warning: The `push` command will fail when the image refers to a remote registry that requires a login and the agent has not been authenticated for it (for example, using the [ecr](https://github.com/buildkite-plugins/ecr-buildkite-plugin) or [docker-login](https://github.com/buildkite-plugins/docker-login-buildkite-plugin) plugins).
@@ -168,6 +170,12 @@ Default: `false`
 #### `pull-retries` (run only, integer)
 
 A number of times to retry failed docker pull. Defaults to 0.
+
+#### `push-metadata` (push only, boolean)
+
+Whether to set the metadata aboout the image for a service being pushed.
+
+Default: `true`.
 
 #### `push-retries` (push only, integer)
 

--- a/lib/metadata.bash
+++ b/lib/metadata.bash
@@ -56,6 +56,12 @@ function set_prebuilt_image() {
   local service="$2"
   local image="$3"
 
+  # assumes that the lib/shared.bash has already been sourced
+  if [ "$(plugin_read_config PUSH_METADATA "true")" != "true" ]; then
+    plugin_prompt "Not setting metadata for prebuilt image, push-metadata option is set to false"
+    return 0
+  fi
+
   plugin_set_metadata "$namespace" "$(prebuilt_image_meta_data_key "$service")" "$image"
 }
 

--- a/plugin.yml
+++ b/plugin.yml
@@ -128,6 +128,8 @@ configuration:
       minimum: 1
     pull-retries:
       type: integer
+    push-metadata:
+      type: boolean
     push-retries:
       type: integer
     quiet-pull:
@@ -211,6 +213,7 @@ configuration:
     propagate-uid-gid: [ run ]
     pull: [ run ]
     pull-retries: [ run ]
+    push-metadata: [ push ]
     push-retries: [ push ]
     quiet-pull: [ push, run]
     quiet-push: [ push ]

--- a/tests/metadata.bats
+++ b/tests/metadata.bats
@@ -53,3 +53,28 @@ load '../lib/metadata'
   assert_output --partial "buildkite-agent meta-data get docker-compose-plugin-built-image-tag-test"
   unstub buildkite-agent
 }
+
+@test "Set prebuilt image in metadata" {
+  stub buildkite-agent \
+    "meta-data set docker-compose-plugin-built-image-tag-test \* : echo setting metadata to \$4"
+
+  run set_prebuilt_image "docker-compose-plugin-" "test" "new-image"
+
+  assert_success
+
+  assert_output --partial "buildkite-agent meta-data set docker-compose-plugin-built-image-tag-test new-image"
+
+  unstub buildkite-agent
+}
+
+@test "Can skip setting prebuilt image in metadata" {
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_PUSH_METADATA=false
+
+  run set_prebuilt_image "docker-compose-plugin-" "test" "new-image"
+
+  assert_success
+
+  refute_output --partial "buildkite-agent meta-data set docker-compose-plugin-built-image-tag-test new-image"
+  assert_output --partial "Not setting metadata for prebuilt image, push-metadata option is set to false"
+}
+


### PR DESCRIPTION
Adds a new option `push-metadata` that defaults to `true` to avoid setting the metadata

Closes #469 