### PR TITLE
`require-prebuild` affects all images

### DIFF
--- a/README.md
+++ b/README.md
@@ -324,7 +324,7 @@ Sets the `--entrypoint` argument when running `docker compose`.
 
 #### `require-prebuild` (run only, boolean)
 
-If no prebuilt image is found for the run step, it will cause the plugin to fail the step.
+Make sure that images for the service being run and all specified in `pull` are found for the run step, fail the step otherwise. Note that specifying a `run-image` will skip this check for the service being run.
 
 The default is `false`.
 

--- a/commands/run.sh
+++ b/commands/run.sh
@@ -49,6 +49,13 @@ for service_name in "${prebuilt_candidates[@]}" ; do
     prebuilt_image="$prebuilt_image_override"
   elif prebuilt_image=$(get_prebuilt_image "$prebuilt_image_namespace" "$service_name") ; then
      echo "~~~ :docker: Found a pre-built image for $service_name"
+  else
+    echo "+++ 🚨 No pre-built image found from a previous 'build' step for service ${service_name} and config file."
+
+    if [[ "${BUILDKITE_PLUGIN_DOCKER_COMPOSE_REQUIRE_PREBUILD:-}" =~ ^(true|on|1)$ ]]; then
+      echo "The step specified that it was required"
+      exit 1
+    fi
   fi
 
   if [[ -n "$prebuilt_image" ]] ; then
@@ -349,15 +356,6 @@ if [[ "$(plugin_read_config SERVICE_PORTS "false")" == "true" ]]; then
 fi
 
 run_params+=("$run_service")
-
-if [[ ! -f "$override_file" ]] ; then
-  echo "+++ 🚨 No pre-built image found from a previous 'build' step for this service and config file."
-
-  if [[ "${BUILDKITE_PLUGIN_DOCKER_COMPOSE_REQUIRE_PREBUILD:-}" =~ ^(true|on|1)$ ]]; then
-    echo "The step specified that it was required"
-    exit 1
-  fi
-fi
 
 up_params+=("up")  # this ensures that the array has elements to avoid issues with bash 4.3
 


### PR DESCRIPTION
Ensures that `require-prebuild` checks all the images instead of just _some_.

Closes #483 