### PR TITLE
Bubble up cleanup failures

### DIFF
--- a/hooks/pre-exit
+++ b/hooks/pre-exit
@@ -11,6 +11,8 @@ DIR="$(cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd)"
 # remove build override files
 rm -f "docker-compose.buildkite-${BUILDKITE_BUILD_NUMBER}-override.yml"
 
+FAILURES=0
+
 # clean up resources after a run command. we do this here so that it will
 # run after a job is cancelled
 if [[ -n "$(plugin_read_list RUN)" ]] && [[ "$(plugin_read_config CLEANUP "true")" == "true" ]]; then
@@ -18,7 +20,9 @@ if [[ -n "$(plugin_read_list RUN)" ]] && [[ "$(plugin_read_config CLEANUP "true"
   . "$DIR/../lib/run.bash"
 
   echo "~~~ :docker: Cleaning up after docker-compose" >&2
-  compose_cleanup
+  if ! compose_cleanup; then
+    FAILURES="$?"
+  fi
 fi
 
 # clean up builder instances if specified

--- a/tests/docker-compose-cleanup.bats
+++ b/tests/docker-compose-cleanup.bats
@@ -7,35 +7,120 @@ load '../lib/run'
 setup () {
   run_docker_compose() {
     # shellcheck disable=2317 # funtion used by loaded scripts
-    echo "$@"
+    stubbed_run_docker_compose "$@"
   }
 }
 
 @test "Default cleanup of docker-compose" {
+  stub stubbed_run_docker_compose \
+    "kill : echo \$@" \
+    "rm --force -v : echo \$@" \
+    "down --remove-orphans --volumes : echo \$@"
+
   run compose_cleanup
 
   assert_success
   assert_equal "${lines[0]}" "kill"
   assert_equal "${lines[1]}" "rm --force -v"
   assert_equal "${lines[2]}" "down --remove-orphans --volumes"
+
+  unstub stubbed_run_docker_compose
 }
 
 @test "Possible to gracefully shutdown containers in docker-compose cleanup" {
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_GRACEFUL_SHUTDOWN=1
+  stub stubbed_run_docker_compose \
+    "stop : echo \$@" \
+    "rm --force -v : echo \$@" \
+    "down --remove-orphans --volumes : echo \$@"
+
   run compose_cleanup
 
   assert_success
   assert_equal "${lines[0]}" "stop"
   assert_equal "${lines[1]}" "rm --force -v"
   assert_equal "${lines[2]}" "down --remove-orphans --volumes"
+
+  unstub stubbed_run_docker_compose
 }
 
 @test "Possible to skip volume destruction in docker-compose cleanup" {
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_LEAVE_VOLUMES=1
+
+  stub stubbed_run_docker_compose \
+    "kill : echo \$@" \
+    "rm --force : echo \$@" \
+    "down --remove-orphans : echo \$@"
+
   run compose_cleanup
 
   assert_success
   assert_equal "${lines[0]}" "kill"
   assert_equal "${lines[1]}" "rm --force"
   assert_equal "${lines[2]}" "down --remove-orphans"
+
+  unstub stubbed_run_docker_compose
+}
+
+@test "cleanup returns failure on kill failure" {
+  stub stubbed_run_docker_compose \
+    "kill : exit 1" \
+    "rm --force -v : echo \$@" \
+    "down --remove-orphans --volumes : echo \$@"
+
+  run compose_cleanup
+
+  assert_failure 1
+
+  assert_equal "${lines[0]}" "rm --force -v"
+  assert_equal "${lines[1]}" "down --remove-orphans --volumes"
+
+  unstub stubbed_run_docker_compose
+}
+
+@test "cleanup returns failure on rm failure" {
+  stub stubbed_run_docker_compose \
+    "kill : echo \$@" \
+    "rm --force -v : exit 1" \
+    "down --remove-orphans --volumes : echo \$@"
+
+  run compose_cleanup
+
+  assert_failure 1
+
+  assert_equal "${lines[0]}" "kill"
+  assert_equal "${lines[1]}" "down --remove-orphans --volumes"
+
+  unstub stubbed_run_docker_compose
+}
+
+@test "cleanup returns failure on down failure" {
+  stub stubbed_run_docker_compose \
+    "kill : echo \$@" \
+    "rm --force -v : echo \$@" \
+    "down --remove-orphans --volumes : exit 1"
+
+  run compose_cleanup
+
+  assert_failure 1
+
+  assert_equal "${lines[0]}" "kill"
+  assert_equal "${lines[1]}" "rm --force -v"
+
+  unstub stubbed_run_docker_compose
+}
+
+@test "cleanup returns 2 failures on kill and down failure" {
+  stub stubbed_run_docker_compose \
+    "kill : exit 1" \
+    "rm --force -v : echo \$@" \
+    "down --remove-orphans --volumes : exit 1"
+
+  run compose_cleanup
+
+  assert_failure 2
+
+  assert_output "rm --force -v"
+
+  unstub stubbed_run_docker_compose
 }


### PR DESCRIPTION
The cleanup function run in the `pre-exit` hook swallowed up any kind of failures. This changes that behaviour and makes sure that if there are any, it is bubbled up and causes a failure in the step.

Closes #445

IMPORTANT: this is a very big change in behaviour that I'm interested in making sure that doesn't break other scenarios (our tests cover happy paths so that is covered). Anyone willing to test it out is more than welcome!