### PR TITLE
Add option to allow env var usage in `push` strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,14 @@ A list of volumes to mount into the container. If a matching volume exists in th
 
 Additionally, volumes may be specified via the agent environment variable `BUILDKITE_DOCKER_DEFAULT_VOLUMES`, a `;` (semicolon) delimited list of mounts in the `-v` syntax. (Ex. `buildkite:/buildkite;./app:/app`).
 
+#### `expand-push-vars` (push only, boolean, unsafe)
+
+When set to true, it will activate interpolation of variables in the elements within the `push` configuration array. When turned off (the default), attempting to use variables will fail as the literal `$VARIABLE_NAME` string will be used as the target..
+
+:warning: **Important:** this is considered an unsafe option as the most compatible way to achieve this is to run the strings through `eval` which could lead to arbitrary code execution or information leaking if you don't have complete control of the pipeline
+
+Note that rules regarding [environment variable interpolation](https://buildkite.com/docs/pipelines/environment-variables#runtime-variable-interpolation) apply here. That means that `$VARIABLE_NAME` is resolved at pipeline upload time, whereas `$$VARIABLE_NAME` will be at run time. All things being equal, you likely want to use `$$VARIABLE_NAME` on the variables mentioned in this option.
+
 #### `expand-volume-vars` (run only, boolean, unsafe)
 
 When set to true, it will activate interpolation of variables in the elements of the `volumes` configuration array. When turned off (the default), attempting to use variables will fail as the literal `$VARIABLE_NAME` string will be passed to the `-v` option.

--- a/commands/push.sh
+++ b/commands/push.sh
@@ -40,7 +40,12 @@ prebuilt_image_namespace="$(plugin_read_config PREBUILT_IMAGE_NAMESPACE 'docker-
 
 # Then we figure out what to push, and where
 for line in $(plugin_read_list PUSH) ; do
-  IFS=':' read -r -a tokens <<< "$line"
+  if [[ "$(plugin_read_config EXPAND_PUSH_VARS 'false')" == "true" ]]; then
+    push_target=$(eval echo "$line")
+  else
+    push_target="$line"
+  fi
+  IFS=':' read -r -a tokens <<< "$push_target"
   service_name=${tokens[0]}
   service_image="$(compose_image_for_service "$service_name")"
 

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -26,7 +26,6 @@ steps:
 
 The plugin will honor the value of the `COMPOSE_FILE` environment variable if one exists (for example, at the pipeline or step level). But you can also specify custom Docker Compose config files with the `config` option:
 
-
 ```yml
 steps:
   - command: test.sh
@@ -266,6 +265,8 @@ steps:
             - app:index.docker.io/myorg/myrepo/myapp
             - app:index.docker.io/myorg/myrepo/myapp:latest
 ```
+
+If you want to use environment variables in the `push` element, you will need to activate the (unsafe) option `expand-push-vars` (and most likely escape it using `$$VARIABLE_NAME` to ensure they are not interpolated when the pipeline is uploaded).
 
 ### Reusing caches from images
 

--- a/plugin.yml
+++ b/plugin.yml
@@ -94,6 +94,8 @@ configuration:
       minimum: 1
     env-propagation-list:
       type: string
+    expand-push-vars:
+      type: boolean
     expand-volume-vars:
       type: boolean
     graceful-shutdown:
@@ -200,6 +202,7 @@ configuration:
     env: [ run ]
     env-propagation-list: [ run ]
     environment: [ run ]
+    expand-push-vars: [ push ]
     expand-volume-vars: [ volumes ]
     graceful-shutdown: [ run ]
     leave-volumes: [ run ]

--- a/tests/push.bats
+++ b/tests/push.bats
@@ -92,7 +92,7 @@ setup_file() {
     "compose -f docker-compose.yml -p buildkite1111 config : echo blah" \
     "pull myimage : echo pulled prebuilt image" \
     "image inspect \* : echo found \$3" \
-    "tag myimage my.repository/myservice:-llamas : exit 1" \
+    "tag myimage my.repository/myservice:-llamas : exit 1"
 
   stub buildkite-agent \
     "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 0" \

--- a/tests/push.bats
+++ b/tests/push.bats
@@ -108,6 +108,59 @@ setup_file() {
   unstub buildkite-agent
 }
 
+@test "Push a prebuilt image with a repository and a tag containing a variable and the expand option on" {
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_PUSH="myservice:my.repository/myservice:\$MY_VAR"
+  export MY_VAR="llamas"
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_EXPAND_PUSH_VARS=true
+
+  stub docker \
+    "compose -f docker-compose.yml -p buildkite1111 config : echo ''" \
+    "pull myimage : echo pulled prebuilt image" \
+    "image inspect myimage : exit 0" \
+    "tag myimage my.repository/myservice:llamas : echo tagged image" \
+    "push my.repository/myservice:llamas : echo pushed myservice"
+
+  stub buildkite-agent \
+    "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 0" \
+    "meta-data get docker-compose-plugin-built-image-tag-myservice : echo myimage" \
+    "meta-data set docker-compose-plugin-built-image-tag-myservice \* : echo tagged \$4"
+
+  run "$PWD"/hooks/command
+
+  assert_success
+  assert_output --partial "pulled prebuilt image"
+  assert_output --partial "tagged image"
+  assert_output --partial "pushed myservice"
+
+  unstub docker
+  unstub buildkite-agent
+}
+
+@test "Push a prebuilt image with a repository and a tag containing a variable and the expand option off" {
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_PUSH="myservice:my.repository/myservice:\$MY_VAR"
+  export MY_VAR="llamas"
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_EXPAND_PUSH_VARS=false
+
+  stub docker \
+    "compose -f docker-compose.yml -p buildkite1111 config : echo blah" \
+    "pull myimage : echo pulled prebuilt image" \
+    "image inspect \* : echo found \$3" \
+    'tag myimage my.repository/myservice:\$MY_VAR : exit 1'
+
+  stub buildkite-agent \
+    "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 0" \
+    "meta-data get docker-compose-plugin-built-image-tag-myservice : echo myimage"
+
+  run "$PWD"/hooks/command
+
+  assert_failure
+  assert_output --partial "Pulling pre-built service"
+  refute_output --partial "tagged image"
+
+  unstub docker
+  unstub buildkite-agent
+}
+
 @test "Push a prebuilt image to multiple tags" {
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_PUSH_0=myservice:my.repository/myservice:llamas
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_PUSH_1=myservice:my.repository/myservice:latest
@@ -161,7 +214,7 @@ setup_file() {
     "meta-data exists docker-compose-plugin-built-image-tag-helper : exit 1"
 
   stub docker \
-    "compose -f docker-compose.yml -p buildkite1111 config : cat $PWD/tests/composefiles/docker-compose.config.v3.2.yml" 
+    "compose -f docker-compose.yml -p buildkite1111 config : cat $PWD/tests/composefiles/docker-compose.config.v3.2.yml"
 
   run "$PWD"/hooks/command
 


### PR DESCRIPTION
Mirroring how it is done for `volume`, this PR adds a boolean config option, `expand-push-vars`, which enables runtime interpolation of variables within `push` configuration strings (and all the same risks of eval'ing strings).
