### PR TITLE
Use safer env-var expansion where available

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,10 @@ When set to true, it will activate interpolation of variables in the elements wi
 
 Note that rules regarding [environment variable interpolation](https://buildkite.com/docs/pipelines/environment-variables#runtime-variable-interpolation) apply here. That means that `$VARIABLE_NAME` is resolved at pipeline upload time, whereas `$$VARIABLE_NAME` will be at run time. All things being equal, you likely want to use `$$VARIABLE_NAME` on the variables mentioned in this option.
 
+#### `expand-push-vars-allowlist` (push only, string, when using expand-push-vars on a system with envsubst)
+
+On a system with `envsubst`, that tool will be used instead of `eval`, and this variable can be used to define the commands `SHELL-FORMAT` argument, which defines the environment variable allowlist so that unexpected interpolations are not permitted.
+
 #### `expand-volume-vars` (run only, boolean, unsafe)
 
 When set to true, it will activate interpolation of variables in the elements of the `volumes` configuration array. When turned off (the default), attempting to use variables will fail as the literal `$VARIABLE_NAME` string will be passed to the `-v` option.

--- a/commands/push.sh
+++ b/commands/push.sh
@@ -41,10 +41,17 @@ prebuilt_image_namespace="$(plugin_read_config PREBUILT_IMAGE_NAMESPACE 'docker-
 # Then we figure out what to push, and where
 for line in $(plugin_read_list PUSH) ; do
   if [[ "$(plugin_read_config EXPAND_PUSH_VARS 'false')" == "true" ]]; then
-    push_target=$(eval echo "$line")
+    allowlist="$(plugin_read_config EXPAND_PUSH_VARS_ALLOWLIST '__UNSET__')"
+    echo "allowlist=${allowlist}"
+    if [[ "$allowlist" == "__UNSET__" ]]; then
+      push_target="$(expand_var "$line")"
+    else
+      push_target="$(expand_var "$line" "$allowlist")"
+    fi
   else
     push_target="$line"
   fi
+  echo "pushtarget=${push_target}"
   IFS=':' read -r -a tokens <<< "$push_target"
   service_name=${tokens[0]}
   service_image="$(compose_image_for_service "$service_name")"

--- a/lib/shared.bash
+++ b/lib/shared.bash
@@ -322,6 +322,37 @@ function retry {
   done
 }
 
+# Expands the env vars in a string, using envsubst if present, falling back to
+# eval when it's missing.
+function expand_var() {
+  # Try to use the safest approach possible
+  if command -v envsubst > /dev/null; then
+    if [[ $# -eq 1 ]]; then
+      # safer
+      expand_var_with_envsubst "$1"
+    else
+      # safest
+      expand_var_with_envsubst "$1" "$2"
+    fi
+  else
+    # unsafe
+    expand_var_with_eval "$1"
+  fi
+}
+
+function expand_var_with_envsubst() {
+  if [[ $# -eq 1 ]]; then
+    echo "$1" | envsubst
+  else
+    echo "$1" | envsubst "$2"
+  fi
+}
+
+function expand_var_with_eval() {
+  echo "$(eval echo "$1")"
+}
+
+
 function is_windows() {
   [[ "$OSTYPE" =~ ^(win|msys|cygwin) ]]
 }

--- a/plugin.yml
+++ b/plugin.yml
@@ -96,6 +96,8 @@ configuration:
       type: string
     expand-push-vars:
       type: boolean
+    expand-push-vars-allowlist:
+      type: string
     expand-volume-vars:
       type: boolean
     graceful-shutdown:
@@ -203,6 +205,7 @@ configuration:
     env-propagation-list: [ run ]
     environment: [ run ]
     expand-push-vars: [ push ]
+    expand-push-vars-allowlist: [ push ]
     expand-volume-vars: [ volumes ]
     graceful-shutdown: [ run ]
     leave-volumes: [ run ]

--- a/tests/shared_lib.bats
+++ b/tests/shared_lib.bats
@@ -1,0 +1,87 @@
+#!/usr/bin/env bats
+
+load "${BATS_PLUGIN_PATH}/load.bash"
+load '../lib/shared.bash'
+
+
+@test "expand_var works" {
+  export MY_VAR="llamas"
+  export MY_STRING="foo:bar:\$MY_VAR"
+
+  run expand_var "$MY_STRING"
+
+  assert_success
+  assert_output "foo:bar:llamas"
+}
+
+@test "expand_var works via envsubst" {
+  export MY_VAR="llamas"
+  export MY_STRING="foo:bar:\$MY_VAR"
+
+  ENVSUB_STUB_STDIN="$BATS_TEST_TMPDIR/envsubst_input"
+  stub envsubst  "cat > '$ENVSUB_STUB_STDIN'; echo 'foo:bar:llamas'"
+
+  run expand_var_with_envsubst "$MY_STRING"
+
+  assert_success
+  assert_output "foo:bar:llamas"
+
+  run cat "$ENVSUB_STUB_STDIN"
+
+  assert_success
+  assert_output "$MY_STRING"
+
+  unstub envsubst
+}
+
+@test "expand_var works via envsubst with an allowlist" {
+  export MY_VAR="llamas"
+  export MY_STRING="foo:bar:\$MY_VAR"
+  export ALLOWLIST="\$MY_VAR"
+
+  ENVSUB_STUB_STDIN="$BATS_TEST_TMPDIR/envsubst_input"
+  stub envsubst  "'$ALLOWLIST' : cat > '$ENVSUB_STUB_STDIN'; echo 'foo:bar:llamas'"
+
+  run expand_var_with_envsubst "$MY_STRING" "$ALLOWLIST"
+
+  assert_success
+  assert_output "foo:bar:llamas"
+
+  run cat "$ENVSUB_STUB_STDIN"
+
+  assert_success
+  assert_output "$MY_STRING"
+
+  unstub envsubst
+}
+
+@test "expand_var works via envsubst with an allowlist not including the var" {
+  export MY_VAR="llamas"
+  export MY_STRING="foo:bar:\$MY_VAR:\$MY_OTHER_VAR"
+  export ALLOWLIST="\$MY_OTHER_VAR"
+
+  ENVSUB_STUB_STDIN="$BATS_TEST_TMPDIR/envsubst_input"
+  stub envsubst  "'$ALLOWLIST' : cat > '$ENVSUB_STUB_STDIN'; echo 'foo:bar:\$MY_VAR:llamas'"
+
+  run expand_var_with_envsubst "$MY_STRING" "$ALLOWLIST"
+
+  assert_success
+  assert_output "foo:bar:\$MY_VAR:llamas"
+
+  run cat "$ENVSUB_STUB_STDIN"
+
+  assert_success
+  assert_output "$MY_STRING"
+
+  unstub envsubst
+}
+
+@test "expand_var works via eval" {
+  export MY_VAR="llamas"
+  export MY_STRING="foo:bar:\$MY_VAR"
+
+  run expand_var_with_eval "$MY_STRING"
+
+  assert_success
+  assert_output "foo:bar:llamas"
+}


### PR DESCRIPTION
Hey there,

This is a small follow-up pr to https://github.com/buildkite-plugins/docker-compose-buildkite-plugin/pull/493, that looks for `envsubst` on the host system, and when found opts to use that instead of eval for the string interpolation.

It also adds a `expand-push-vars-allowlist` configuration option which enables the stricter use of `envsubst` when only expected/permitted env vars are substituted and anything else is left alone, which I believe allows users to reduce the unsafe-ness of `expand-push-vars` if that's something they care about.

I've tested the scenarios for this in some real pipelines (✅), and have added some bats tests for the two new types of expansion, but I couldn't find a reliable way to stub the `command` built-in in order to test `expand_var`, or add another properly different example to `push.bats`. Happy to add them too if someone knows the secret sauce 🙏 