### PR TITLE
Store Docker digest in metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,28 @@ Whether to set the metadata aboout the image for a service being pushed.
 
 Default: `true`.
 
+#### Image Digest Storage
+
+When images are pushed, the plugin automatically extracts and stores the image digest (SHA256 hash) in Buildkite metadata. This allows you to reference the exact image that was pushed in later pipeline steps.
+
+The digest is stored with the key `docker-compose-plugin-built-image-digest-<service>` (or using your custom `prebuilt-image-namespace` if configured).
+
+**Example of retrieving the digest in a later step:**
+
+```bash
+# Get the digest for a service called "app"
+DIGEST=$(buildkite-agent meta-data get "docker-compose-plugin-built-image-digest-app")
+echo "App image digest: $DIGEST"
+
+# Use the digest to reference the exact image
+docker pull myregistry/app@$DIGEST
+```
+
+The digest storage follows the same rules as other metadata:
+- It's disabled when `push-metadata` is set to `false`
+- It uses the same namespace as other plugin metadata
+- It provides a warning if the digest cannot be retrieved
+
 #### `push-retries` (push only, integer)
 
 A number of times to retry failed docker push. Defaults to 0.

--- a/commands/push.sh
+++ b/commands/push.sh
@@ -80,6 +80,7 @@ for line in $(plugin_read_list PUSH) ; do
   if [[ ${#tokens[@]} -eq 1 ]] ; then
     echo "${group_type} :docker: Pushing images for ${service_name}" >&2;
     retry "$push_retries" run_docker_compose "${push_command[@]}" "${service_name}"
+    store_image_digest "${prebuilt_image_namespace}" "${service_name}" "${service_image}"
     set_prebuilt_image "${prebuilt_image_namespace}" "${service_name}" "${service_image}"
     target_image="${service_image}" # necessary for build-alias
   # push: "service-name:repo:tag"
@@ -88,6 +89,7 @@ for line in $(plugin_read_list PUSH) ; do
     echo "${group_type} :docker: Pushing image $target_image" >&2;
     plugin_prompt_and_run docker tag "$service_image" "$target_image"
     retry "$push_retries" plugin_prompt_and_run docker "${push_command[@]}" "$target_image"
+    store_image_digest "${prebuilt_image_namespace}" "${service_name}" "${target_image}"
     set_prebuilt_image "${prebuilt_image_namespace}" "${service_name}" "${target_image}"
   fi
 done

--- a/lib/push.bash
+++ b/lib/push.bash
@@ -28,3 +28,37 @@ docker_image_exists() {
   local image="$1"
   plugin_prompt_and_run docker image inspect "${image}" &> /dev/null
 }
+
+# Extracts the image digest from a pushed image and stores it in Buildkite metadata
+store_image_digest() {
+  local namespace="$1"
+  local service="$2"
+  local image="$3"
+  
+  # Skip if push-metadata is disabled
+  if [ "$(plugin_read_config PUSH_METADATA "true")" != "true" ]; then
+    return 0
+  fi
+  
+  # Get the image digest
+  local digest
+  digest=$(docker inspect --format='{{range .RepoDigests}}{{.}}{{"\n"}}{{end}}' "$image" 2>/dev/null | head -1 | cut -d'@' -f2)
+  
+  if [ -n "$digest" ]; then
+    # Store digest in Buildkite metadata using the same namespace as other metadata
+    local digest_key="built-image-digest-${service}"
+    plugin_set_metadata "$namespace" "$digest_key" "$digest"
+    echo "~~~ :information_source: Stored image digest for $service: $digest"
+  else
+    echo "--- :warning: Could not retrieve digest for image: $image"
+  fi
+}
+
+# Retrieves a stored image digest for a service name
+get_image_digest() {
+  local namespace="$1"
+  local service="$2"
+  local digest_key="built-image-digest-${service}"
+  
+  plugin_get_metadata "$namespace" "$digest_key"
+}

--- a/tests/metadata.bats
+++ b/tests/metadata.bats
@@ -78,3 +78,26 @@ load '../lib/metadata'
   assert_output --partial "Not setting metadata for prebuilt image, push-metadata option is set to false"
 }
 
+@test "Get image digest from metadata" {
+  stub buildkite-agent \
+    "meta-data exists docker-compose-plugin-built-image-digest-test : exit 0" \
+    "meta-data get docker-compose-plugin-built-image-digest-test : echo sha256:abcd1234"
+
+  run get_image_digest "docker-compose-plugin-" "test"
+
+  assert_success
+  assert_output --partial "sha256:abcd1234"
+
+  unstub buildkite-agent
+}
+
+@test "Get image digest from metadata when not present" {
+  stub buildkite-agent \
+    "meta-data exists docker-compose-plugin-built-image-digest-test : exit 1"
+
+  run get_image_digest "docker-compose-plugin-" "test"
+
+  assert_failure
+
+  unstub buildkite-agent
+}


### PR DESCRIPTION
This is something that we're currently using in order to leverage docker containers across pipelines. Possibly there's a better way of doing this? Aliases perhaps?