### PR TITLE
Implement retry mechanise for builder creation failure

### DIFF
--- a/README.md
+++ b/README.md
@@ -400,6 +400,12 @@ If set to true, will use `docker buildx create` to create a new Builder Instance
 
 The default is `false`.
 
+##### `create-retries` (integer)
+
+Number of times to retry creating the builder instance if it fails. This is useful to handle transient errors during builder creation.
+
+The default is `3`.
+
 ##### `debug` (boolean)
 
 If set to true, enables debug logging during creation of builder instance. Optional when using `create`.

--- a/hooks/pre-command
+++ b/hooks/pre-command
@@ -9,6 +9,7 @@ DIR="$(cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd)"
 builder_create="$(plugin_read_config BUILDER_CREATE "false")"
 builder_use="$(plugin_read_config BUILDER_USE "false")"
 builder_name="$(plugin_read_config BUILDER_NAME "")"
+builder_create_retries="$(plugin_read_config BUILDER_CREATE_RETRIES "3")"
 
 if [[ "${builder_create}" == "true" ]] || [[ "${builder_use}" == "true" ]]; then
     if [[ -z "${builder_name}" ]]; then
@@ -61,7 +62,7 @@ if [[ "${builder_create}" == "true" ]]; then
         fi
 
         echo "~~~ :docker: Creating Builder Instance '${builder_name}' with Driver '${build_driver}'"
-        docker buildx create "${builder_instance_args[@]}"
+        retry "${builder_create_retries}" docker buildx create "${builder_instance_args[@]}"
         if [[ "${builder_use}" == "false" ]]; then
             echo "~~~ :warning: Builder Instance '${builder_name}' created but will not be used as 'use: true' parameter not specified"
         fi

--- a/plugin.yml
+++ b/plugin.yml
@@ -30,6 +30,8 @@ configuration:
           type: boolean
         create:
           type: boolean
+        create-retries:
+          type: integer
         debug:
           type: boolean
         driver:


### PR DESCRIPTION
## Problem

We experience a small percentage of builds on agents with a failure in the create and bootstrapping of the builder instance.

```
:docker: Creating Builder Instance 'my-docker-container' with Driver 'docker-container'
#1 [internal] booting buildkit
#1 pulling image moby/buildkit:buildx-stable-1
#1 pulling image moby/buildkit:buildx-stable-1 2.4s done
#1 creating container buildx_buildkit_my-docker-container0
#1 creating container buildx_buildkit_my-docker-container0 14.4s done
#1 ERROR: Error response from daemon: No such container: buildx_buildkit_my-docker-container0
------
 > [internal] booting buildkit:
------
ERROR: Error response from daemon: No such container: buildx_buildkit_my-docker-container0
```

## Solution

This PR implements a retry mechanism for builder creation following the same pattern as other retries in this codebase

Tests included.

## Feedback

Let me know if you need anything changed.