### PR TITLE
accept key value list and map format for env field

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,9 +75,27 @@ Important: this only works when building a single service, an error will be gene
 
 A list of KEY=VALUE that are passed through as build arguments when image is being built.
 
-#### `env` or `environment` (run only, string or array)
+#### `env` or `environment` (run only, string, array, or map)
 
-A list of either KEY or KEY=VALUE that are passed through as environment variables to the container.
+Environment variables to pass through to the container. Accepts a list of `KEY` or `KEY=VALUE` strings, or a map of `KEY: VALUE` pairs — matching the format used at the pipeline and step level in Buildkite.
+
+List format:
+```yaml
+env:
+  - MY_VAR=value
+  - ANOTHER_VAR
+```
+
+Map format:
+```yaml
+env:
+  MY_VAR: value
+  ANOTHER_VAR: other
+```
+
+Only the list format supports bare keys (e.g. `- ANOTHER_VAR`) that inherit their value from the agent environment; map format requires an explicit value for each key.
+
+When using map format, keys containing consecutive underscores may also set a collapsed-underscore alias on the agent, and both forms can be passed to the container. Prefer list format for keys with consecutive underscores.
 
 #### `env-propagation-list` (run only)
 

--- a/commands/run.sh
+++ b/commands/run.sh
@@ -114,6 +114,7 @@ fi
 
 # append env vars provided in ENV or ENVIRONMENT, these are newline delimited
 # supports both list format (- KEY=value) and map format (KEY: value)
+# PROPAGATION_LIST excludes env-propagation-list, which shares the ENV_ prefix when flattened
 while IFS=$'\n' read -r env ; do
   [[ -n "${env:-}" ]] && run_params+=("-e" "${env}")
 done <<< "$(printf '%s\n%s' \

--- a/commands/run.sh
+++ b/commands/run.sh
@@ -113,11 +113,12 @@ if [[ "$(plugin_read_config RUN_LABELS "true")" =~ ^(true|on|1)$ ]]; then
 fi
 
 # append env vars provided in ENV or ENVIRONMENT, these are newline delimited
+# supports both list format (- KEY=value) and map format (KEY: value)
 while IFS=$'\n' read -r env ; do
   [[ -n "${env:-}" ]] && run_params+=("-e" "${env}")
 done <<< "$(printf '%s\n%s' \
-  "$(plugin_read_list ENV)" \
-  "$(plugin_read_list ENVIRONMENT)")"
+  "$(plugin_read_list_or_map ENV)" \
+  "$(plugin_read_list_or_map ENVIRONMENT)")"
 
 # Propagate all environment variables into the container if requested
 if [[ "$(plugin_read_config PROPAGATE_ENVIRONMENT "false")" =~ ^(true|on|1)$ ]] ; then

--- a/commands/run.sh
+++ b/commands/run.sh
@@ -117,7 +117,7 @@ fi
 while IFS=$'\n' read -r env ; do
   [[ -n "${env:-}" ]] && run_params+=("-e" "${env}")
 done <<< "$(printf '%s\n%s' \
-  "$(plugin_read_list_or_map ENV)" \
+  "$(plugin_read_list_or_map ENV PROPAGATION_LIST)" \
   "$(plugin_read_list_or_map ENVIRONMENT)")"
 
 # Propagate all environment variables into the container if requested

--- a/lib/shared.bash
+++ b/lib/shared.bash
@@ -65,6 +65,24 @@ function prefix_read_list() {
   fi
 }
 
+# Reads either a value, a list, or a map from plugin config
+# For map format (YAML object), outputs KEY=value pairs
+function plugin_read_list_or_map() {
+  local prefix="BUILDKITE_PLUGIN_DOCKER_COMPOSE_$1"
+  local list_param="${prefix}_0"
+
+  if [[ -n "${!list_param:-}" ]] || [[ -n "${!prefix:-}" ]]; then
+    prefix_read_list "$prefix"
+  else
+    local env_prefix="${prefix}_"
+    local key
+    while IFS= read -r varname ; do
+      key="${varname#${env_prefix}}"
+      echo "${key}=${!varname}"
+    done < <(compgen -v "${env_prefix}" | sort)
+  fi
+}
+
 # Reads either a value or a list from plugin config into a global result array
 # Returns success if values were read
 function plugin_read_list_into_result() {

--- a/lib/shared.bash
+++ b/lib/shared.bash
@@ -67,8 +67,11 @@ function prefix_read_list() {
 
 # Reads either a value, a list, or a map from plugin config
 # For map format (YAML object), outputs KEY=value pairs
+# Additional arguments are sibling config key suffixes to exclude from map scanning
 function plugin_read_list_or_map() {
-  local prefix="BUILDKITE_PLUGIN_DOCKER_COMPOSE_$1"
+  local config_key="$1"
+  shift
+  local prefix="BUILDKITE_PLUGIN_DOCKER_COMPOSE_${config_key}"
   local list_param="${prefix}_0"
 
   if [[ -n "${!list_param:-}" ]] || [[ -n "${!prefix:-}" ]]; then
@@ -78,7 +81,9 @@ function plugin_read_list_or_map() {
     local key
     while IFS= read -r varname ; do
       key="${varname#${env_prefix}}"
-      echo "${key}=${!varname}"
+      if ! in_array "${key}" "$@"; then
+        echo "${key}=${!varname}"
+      fi
     done < <(compgen -v "${env_prefix}" | sort)
   fi
 }

--- a/lib/shared.bash
+++ b/lib/shared.bash
@@ -80,7 +80,7 @@ function plugin_read_list_or_map() {
     local env_prefix="${prefix}_"
     local key
     while IFS= read -r varname ; do
-      key="${varname#${env_prefix}}"
+      key="${varname#"${env_prefix}"}"
       if ! in_array "${key}" "$@"; then
         echo "${key}=${!varname}"
       fi

--- a/lib/shared.bash
+++ b/lib/shared.bash
@@ -77,14 +77,14 @@ function plugin_read_list_or_map() {
   if [[ -n "${!list_param:-}" ]] || [[ -n "${!prefix:-}" ]]; then
     prefix_read_list "$prefix"
   else
-    local env_prefix="${prefix}_"
+    local scan_prefix="${prefix}_"
     local key
     while IFS= read -r varname ; do
-      key="${varname#"${env_prefix}"}"
+      key="${varname#"${scan_prefix}"}"
       if ! in_array "${key}" "$@"; then
         echo "${key}=${!varname}"
       fi
-    done < <(compgen -v "${env_prefix}" | sort)
+    done < <(compgen -v "${scan_prefix}" | sort)
   fi
 }
 

--- a/plugin.yml
+++ b/plugin.yml
@@ -91,10 +91,10 @@ configuration:
     entrypoint:
       type: string
     env:
-      type: [ string, array ]
+      type: [ string, array, object ]
       minimum: 1
     environment:
-      type: [ string, array ]
+      type: [ string, array, object ]
       minimum: 1
     env-propagation-list:
       type: string

--- a/tests/run.bats
+++ b/tests/run.bats
@@ -222,6 +222,54 @@ cmd3"
   unstub buildkite-agent
 }
 
+@test "Run without a prebuilt image with env as a map" {
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RUN=myservice
+  export BUILDKITE_COMMAND=pwd
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CHECK_LINKED_CONTAINERS=false
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLEANUP=false
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_ENV_ANOTHER_VAR=value2
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_ENV_MY_VAR=value1
+
+  stub docker \
+    "compose -f docker-compose.yml -p buildkite1111 up -d --scale myservice=0 myservice : echo ran myservice dependencies" \
+    "compose -f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 -e ANOTHER_VAR=value2 -e MY_VAR=value1 -T --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice with env map"
+
+  stub buildkite-agent \
+    "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 1"
+
+  run "$PWD"/hooks/command
+
+  assert_success
+  assert_output --partial "ran myservice with env map"
+
+  unstub docker
+  unstub buildkite-agent
+}
+
+@test "Run without a prebuilt image with environment as a map" {
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RUN=myservice
+  export BUILDKITE_COMMAND=pwd
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CHECK_LINKED_CONTAINERS=false
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLEANUP=false
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_ENVIRONMENT_ANOTHER_VAR=value2
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_ENVIRONMENT_MY_VAR=value1
+
+  stub docker \
+    "compose -f docker-compose.yml -p buildkite1111 up -d --scale myservice=0 myservice : echo ran myservice dependencies" \
+    "compose -f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 -e ANOTHER_VAR=value2 -e MY_VAR=value1 -T --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice with environment map"
+
+  stub buildkite-agent \
+    "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 1"
+
+  run "$PWD"/hooks/command
+
+  assert_success
+  assert_output --partial "ran myservice with environment map"
+
+  unstub docker
+  unstub buildkite-agent
+}
+
 @test "Run without a prebuilt image with no-cache" {
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RUN=myservice
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_NO_CACHE=true

--- a/tests/run.bats
+++ b/tests/run.bats
@@ -270,6 +270,31 @@ cmd3"
   unstub buildkite-agent
 }
 
+@test "Run with env as a map and env-propagation-list together" {
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RUN=myservice
+  export BUILDKITE_COMMAND=pwd
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CHECK_LINKED_CONTAINERS=false
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CLEANUP=false
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_ENV_MY_VAR=value1
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_ENV_PROPAGATION_LIST=LIST_OF_VARS
+  export LIST_OF_VARS="VAR_A VAR_B"
+
+  stub docker \
+    "compose -f docker-compose.yml -p buildkite1111 up -d --scale myservice=0 myservice : echo ran myservice dependencies" \
+    "compose -f docker-compose.yml -p buildkite1111 run --name buildkite1111_myservice_build_1 -e MY_VAR=value1 -e VAR_A -e VAR_B -T --rm myservice /bin/sh -e -c 'pwd' : echo ran myservice with env map and propagation list"
+
+  stub buildkite-agent \
+    "meta-data exists docker-compose-plugin-built-image-tag-myservice : exit 1"
+
+  run "$PWD"/hooks/command
+
+  assert_success
+  assert_output --partial "ran myservice with env map and propagation list"
+
+  unstub docker
+  unstub buildkite-agent
+}
+
 @test "Run without a prebuilt image with no-cache" {
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_RUN=myservice
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_NO_CACHE=true


### PR DESCRIPTION
The env and environment fields previously only accepted a list format (`KEY=value)`, which differs from how env vars are defined at the pipeline and step level in Buildkite.This change makes the plugin accept both the list format and the map format (KEY: value), so users can write env vars in whichever way they prefer