### PR TITLE
fix: add timeouts to ensure_stopped and compose_cleanup to prevent orphaned containers on cancellation

### DIFF
--- a/commands/run.sh
+++ b/commands/run.sh
@@ -478,9 +478,9 @@ fi
 
 ensure_stopped() {
   echo '+++ :warning: Signal received, stopping container'
-  timeout 30 docker stop "${container_name}" || true
+  run_with_deadline 30 docker stop "${container_name}" || true
   echo '~~~ Last log lines that may be missing above (if container was not already removed)'
-  timeout 10 docker logs "${container_name}" || true
+  run_with_deadline 10 docker logs "${container_name}" || true
   exitcode='TRAP'
 }
 

--- a/commands/run.sh
+++ b/commands/run.sh
@@ -478,9 +478,7 @@ fi
 
 ensure_stopped() {
   echo '+++ :warning: Signal received, stopping container'
-  run_with_deadline 8 docker stop "${container_name}" || true
-  echo '~~~ Last log lines that may be missing above (if container was not already removed)'
-  run_with_deadline 2 docker logs "${container_name}" || true
+  run_with_deadline 2 docker stop "${container_name}" || true
   exitcode='TRAP'
 }
 

--- a/commands/run.sh
+++ b/commands/run.sh
@@ -478,9 +478,9 @@ fi
 
 ensure_stopped() {
   echo '+++ :warning: Signal received, stopping container'
-  docker stop "${container_name}" || true
+  timeout 30 docker stop "${container_name}" || true
   echo '~~~ Last log lines that may be missing above (if container was not already removed)'
-  docker logs "${container_name}" || true
+  timeout 10 docker logs "${container_name}" || true
   exitcode='TRAP'
 }
 

--- a/commands/run.sh
+++ b/commands/run.sh
@@ -478,9 +478,9 @@ fi
 
 ensure_stopped() {
   echo '+++ :warning: Signal received, stopping container'
-  run_with_deadline 30 docker stop "${container_name}" || true
+  run_with_deadline 8 docker stop "${container_name}" || true
   echo '~~~ Last log lines that may be missing above (if container was not already removed)'
-  run_with_deadline 10 docker logs "${container_name}" || true
+  run_with_deadline 2 docker logs "${container_name}" || true
   exitcode='TRAP'
 }
 

--- a/lib/run.bash
+++ b/lib/run.bash
@@ -2,15 +2,16 @@
 
 compose_cleanup() {
   local FAILURES=0
+  local deadline="${_CLEANUP_DEADLINE:-30}"
 
   if [[ "$(plugin_read_config GRACEFUL_SHUTDOWN 'false')" == "false" ]]; then
-    SIGNAL_PARAMS=(kill)
+    SIGNAL="kill"
   else
-    SIGNAL_PARAMS=(stop --timeout 30)
+    SIGNAL="stop"
   fi
 
   # Send all containers the corresponding signal
-  if ! run_docker_compose "${SIGNAL_PARAMS[@]}"; then
+  if ! run_with_deadline "$deadline" run_docker_compose "${SIGNAL}"; then
     FAILURES=$((FAILURES + 1))
   fi
 
@@ -20,17 +21,17 @@ compose_cleanup() {
     RM_PARAMS+=(-v)
   fi
 
-  if ! run_docker_compose "${RM_PARAMS[@]}"; then
+  if ! run_with_deadline "$deadline" run_docker_compose "${RM_PARAMS[@]}"; then
     FAILURES=$((FAILURES + 1))
   fi
 
   # Stop and remove all the linked services and network
-  DOWN_PARAMS=(down --remove-orphans --timeout 30)
+  DOWN_PARAMS=(down --remove-orphans)
   if [[ "$(plugin_read_config LEAVE_VOLUMES 'false')" == "false" ]]; then
     DOWN_PARAMS+=(--volumes)
   fi
 
-  if ! run_docker_compose "${DOWN_PARAMS[@]}"; then
+  if ! run_with_deadline "$deadline" run_docker_compose "${DOWN_PARAMS[@]}"; then
     FAILURES=$((FAILURES + 1))
   fi
 

--- a/lib/run.bash
+++ b/lib/run.bash
@@ -4,13 +4,13 @@ compose_cleanup() {
   local FAILURES=0
 
   if [[ "$(plugin_read_config GRACEFUL_SHUTDOWN 'false')" == "false" ]]; then
-    SIGNAL="kill"
+    SIGNAL_PARAMS=(kill)
   else
-    SIGNAL="stop"
+    SIGNAL_PARAMS=(stop --timeout 30)
   fi
 
   # Send all containers the corresponding signal
-  if ! run_docker_compose "${SIGNAL}"; then
+  if ! run_docker_compose "${SIGNAL_PARAMS[@]}"; then
     FAILURES=$((FAILURES + 1))
   fi
 
@@ -25,7 +25,7 @@ compose_cleanup() {
   fi
 
   # Stop and remove all the linked services and network
-  DOWN_PARAMS=(down --remove-orphans)
+  DOWN_PARAMS=(down --remove-orphans --timeout 30)
   if [[ "$(plugin_read_config LEAVE_VOLUMES 'false')" == "false" ]]; then
     DOWN_PARAMS+=(--volumes)
   fi

--- a/lib/shared.bash
+++ b/lib/shared.bash
@@ -35,6 +35,21 @@ function plugin_prompt_and_must_run() {
   plugin_prompt_and_run "$@" || exit $?
 }
 
+# Runs a command with a wall-clock deadline, killing it if it does not finish in time.
+# Portable alternative to the `timeout` command which is not available on all platforms.
+function run_with_deadline() {
+  local seconds="$1"; shift
+  "$@" &
+  local cmd_pid=$!
+  ( sleep "$seconds" && kill "$cmd_pid" 2>/dev/null ) &
+  local watcher_pid=$!
+  wait "$cmd_pid" 2>/dev/null
+  local status=$?
+  kill "$watcher_pid" 2>/dev/null
+  wait "$watcher_pid" 2>/dev/null || true
+  return "$status"
+}
+
 # Shorthand for reading env config
 function plugin_read_config() {
   local var="BUILDKITE_PLUGIN_DOCKER_COMPOSE_${1}"

--- a/lib/shared.bash
+++ b/lib/shared.bash
@@ -39,32 +39,33 @@ function plugin_prompt_and_must_run() {
 # does not finish in time. Uses a subshell with job control so each background job
 # gets its own process group, ensuring descendants cannot outlive the deadline.
 function run_with_deadline() (
-  local seconds="$1"; shift
+     local seconds="$1"; shift
+     local term_after=$((seconds > 1 ? seconds - 1 : 0))
 
-  set -m
-  "$@" &
-  local cmd_pid=$!
+     set -m
+     "$@" &
+     local cmd_pid=$!
 
-  (
-    sleep "$seconds"
-    kill -TERM -- "-$cmd_pid" 2>/dev/null || exit 0
-    sleep 1
-    kill -KILL -- "-$cmd_pid" 2>/dev/null || true
-  ) &
-  local watcher_pid=$!
+     (
+       sleep "$term_after"
+       kill -TERM -- "-$cmd_pid" 2>/dev/null || exit 0
+       sleep "$((seconds - term_after))"
+       kill -KILL -- "-$cmd_pid" 2>/dev/null || true
+     ) &
+     local watcher_pid=$!
 
-  wait "$cmd_pid" 2>/dev/null
-  local status=$?
+     wait "$cmd_pid" 2>/dev/null
+     local status=$?
 
-  if kill -0 -- "-$cmd_pid" 2>/dev/null; then
-    wait "$watcher_pid" 2>/dev/null || true
-  else
-    kill -TERM -- "-$watcher_pid" 2>/dev/null || true
-    wait "$watcher_pid" 2>/dev/null || true
-  fi
+     if kill -0 -- "-$cmd_pid" 2>/dev/null; then
+       wait "$watcher_pid" 2>/dev/null || true
+     else
+       kill -TERM -- "-$watcher_pid" 2>/dev/null || true
+       wait "$watcher_pid" 2>/dev/null || true
+     fi
 
-  return "$status"
-)
+     return "$status"
+   )
 
 # Shorthand for reading env config
 function plugin_read_config() {

--- a/lib/shared.bash
+++ b/lib/shared.bash
@@ -35,20 +35,36 @@ function plugin_prompt_and_must_run() {
   plugin_prompt_and_run "$@" || exit $?
 }
 
-# Runs a command with a wall-clock deadline, killing it if it does not finish in time.
-# Portable alternative to the `timeout` command which is not available on all platforms.
-function run_with_deadline() {
+# Runs a command with a wall-clock deadline, killing its entire process group if it
+# does not finish in time. Uses a subshell with job control so each background job
+# gets its own process group, ensuring descendants cannot outlive the deadline.
+function run_with_deadline() (
   local seconds="$1"; shift
+
+  set -m
   "$@" &
   local cmd_pid=$!
-  ( sleep "$seconds" && kill "$cmd_pid" 2>/dev/null ) &
+
+  (
+    sleep "$seconds"
+    kill -TERM -- "-$cmd_pid" 2>/dev/null || exit 0
+    sleep 1
+    kill -KILL -- "-$cmd_pid" 2>/dev/null || true
+  ) &
   local watcher_pid=$!
+
   wait "$cmd_pid" 2>/dev/null
   local status=$?
-  kill "$watcher_pid" 2>/dev/null
-  wait "$watcher_pid" 2>/dev/null || true
+
+  if kill -0 -- "-$cmd_pid" 2>/dev/null; then
+    wait "$watcher_pid" 2>/dev/null || true
+  else
+    kill -TERM -- "-$watcher_pid" 2>/dev/null || true
+    wait "$watcher_pid" 2>/dev/null || true
+  fi
+
   return "$status"
-}
+)
 
 # Shorthand for reading env config
 function plugin_read_config() {

--- a/tests/cleanup.bats
+++ b/tests/cleanup.bats
@@ -19,7 +19,7 @@ load '../lib/run'
   stub docker \
     "compose -f docker-compose.yml -p buildkite1111 kill : echo killing containers" \
     "compose -f docker-compose.yml -p buildkite1111 rm --force -v : echo removing stopped containers" \
-    "compose -f docker-compose.yml -p buildkite1111 down --remove-orphans --volumes : echo removing everything"
+    "compose -f docker-compose.yml -p buildkite1111 down --remove-orphans --timeout 30 --volumes : echo removing everything"
 
   run "$PWD"/hooks/pre-exit
 

--- a/tests/cleanup.bats
+++ b/tests/cleanup.bats
@@ -19,7 +19,7 @@ load '../lib/run'
   stub docker \
     "compose -f docker-compose.yml -p buildkite1111 kill : echo killing containers" \
     "compose -f docker-compose.yml -p buildkite1111 rm --force -v : echo removing stopped containers" \
-    "compose -f docker-compose.yml -p buildkite1111 down --remove-orphans --timeout 30 --volumes : echo removing everything"
+    "compose -f docker-compose.yml -p buildkite1111 down --remove-orphans --volumes : echo removing everything"
 
   run "$PWD"/hooks/pre-exit
 

--- a/tests/docker-compose-cleanup.bats
+++ b/tests/docker-compose-cleanup.bats
@@ -38,7 +38,20 @@ setup () {
   [[ $((SECONDS - start)) -lt 6 ]]
   ! pgrep -f "sleep 9998" >/dev/null 2>&1
 }
+@test "run_with_deadline includes escalation in the deadline" {
+     local sleep_calls="${BATS_TEST_TMPDIR}/sleep-calls"
 
+     sleep() {
+       printf '%s\n' "$1" >> "$sleep_calls"
+     }
+
+     run run_with_deadline 5 bash -c 'trap "" TERM; while :; do :; done'
+     assert_failure
+
+     run cat "$sleep_calls"
+     assert_success
+     assert_output $'4\n1'
+   }
 @test "Default cleanup of docker-compose" {
   stub stubbed_run_docker_compose \
     "kill : echo \$@" \

--- a/tests/docker-compose-cleanup.bats
+++ b/tests/docker-compose-cleanup.bats
@@ -11,18 +11,29 @@ setup () {
   }
 }
 
+@test "run_with_deadline allows a fast command to complete" {
+  run run_with_deadline 5 echo "done"
+  assert_success
+  assert_output "done"
+}
+
+@test "run_with_deadline terminates a command that exceeds the deadline" {
+  run run_with_deadline 1 sleep 100
+  assert_failure
+}
+
 @test "Default cleanup of docker-compose" {
   stub stubbed_run_docker_compose \
     "kill : echo \$@" \
     "rm --force -v : echo \$@" \
-    "down --remove-orphans --timeout 30 --volumes : echo \$@"
+    "down --remove-orphans --volumes : echo \$@"
 
   run compose_cleanup
 
   assert_success
   assert_equal "${lines[0]}" "kill"
   assert_equal "${lines[1]}" "rm --force -v"
-  assert_equal "${lines[2]}" "down --remove-orphans --timeout 30 --volumes"
+  assert_equal "${lines[2]}" "down --remove-orphans --volumes"
 
   unstub stubbed_run_docker_compose
 }
@@ -30,16 +41,16 @@ setup () {
 @test "Possible to gracefully shutdown containers in docker-compose cleanup" {
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_GRACEFUL_SHUTDOWN=1
   stub stubbed_run_docker_compose \
-    "stop --timeout 30 : echo \$@" \
+    "stop : echo \$@" \
     "rm --force -v : echo \$@" \
-    "down --remove-orphans --timeout 30 --volumes : echo \$@"
+    "down --remove-orphans --volumes : echo \$@"
 
   run compose_cleanup
 
   assert_success
-  assert_equal "${lines[0]}" "stop --timeout 30"
+  assert_equal "${lines[0]}" "stop"
   assert_equal "${lines[1]}" "rm --force -v"
-  assert_equal "${lines[2]}" "down --remove-orphans --timeout 30 --volumes"
+  assert_equal "${lines[2]}" "down --remove-orphans --volumes"
 
   unstub stubbed_run_docker_compose
 }
@@ -50,14 +61,14 @@ setup () {
   stub stubbed_run_docker_compose \
     "kill : echo \$@" \
     "rm --force : echo \$@" \
-    "down --remove-orphans --timeout 30 : echo \$@"
+    "down --remove-orphans : echo \$@"
 
   run compose_cleanup
 
   assert_success
   assert_equal "${lines[0]}" "kill"
   assert_equal "${lines[1]}" "rm --force"
-  assert_equal "${lines[2]}" "down --remove-orphans --timeout 30"
+  assert_equal "${lines[2]}" "down --remove-orphans"
 
   unstub stubbed_run_docker_compose
 }
@@ -66,14 +77,14 @@ setup () {
   stub stubbed_run_docker_compose \
     "kill : exit 1" \
     "rm --force -v : echo \$@" \
-    "down --remove-orphans --timeout 30 --volumes : echo \$@"
+    "down --remove-orphans --volumes : echo \$@"
 
   run compose_cleanup
 
   assert_failure 1
 
   assert_equal "${lines[0]}" "rm --force -v"
-  assert_equal "${lines[1]}" "down --remove-orphans --timeout 30 --volumes"
+  assert_equal "${lines[1]}" "down --remove-orphans --volumes"
 
   unstub stubbed_run_docker_compose
 }
@@ -82,14 +93,14 @@ setup () {
   stub stubbed_run_docker_compose \
     "kill : echo \$@" \
     "rm --force -v : exit 1" \
-    "down --remove-orphans --timeout 30 --volumes : echo \$@"
+    "down --remove-orphans --volumes : echo \$@"
 
   run compose_cleanup
 
   assert_failure 1
 
   assert_equal "${lines[0]}" "kill"
-  assert_equal "${lines[1]}" "down --remove-orphans --timeout 30 --volumes"
+  assert_equal "${lines[1]}" "down --remove-orphans --volumes"
 
   unstub stubbed_run_docker_compose
 }
@@ -98,7 +109,7 @@ setup () {
   stub stubbed_run_docker_compose \
     "kill : echo \$@" \
     "rm --force -v : echo \$@" \
-    "down --remove-orphans --timeout 30 --volumes : exit 1"
+    "down --remove-orphans --volumes : exit 1"
 
   run compose_cleanup
 
@@ -114,7 +125,7 @@ setup () {
   stub stubbed_run_docker_compose \
     "kill : exit 1" \
     "rm --force -v : echo \$@" \
-    "down --remove-orphans --timeout 30 --volumes : exit 1"
+    "down --remove-orphans --volumes : exit 1"
 
   run compose_cleanup
 

--- a/tests/docker-compose-cleanup.bats
+++ b/tests/docker-compose-cleanup.bats
@@ -15,14 +15,14 @@ setup () {
   stub stubbed_run_docker_compose \
     "kill : echo \$@" \
     "rm --force -v : echo \$@" \
-    "down --remove-orphans --volumes : echo \$@"
+    "down --remove-orphans --timeout 30 --volumes : echo \$@"
 
   run compose_cleanup
 
   assert_success
   assert_equal "${lines[0]}" "kill"
   assert_equal "${lines[1]}" "rm --force -v"
-  assert_equal "${lines[2]}" "down --remove-orphans --volumes"
+  assert_equal "${lines[2]}" "down --remove-orphans --timeout 30 --volumes"
 
   unstub stubbed_run_docker_compose
 }
@@ -30,16 +30,16 @@ setup () {
 @test "Possible to gracefully shutdown containers in docker-compose cleanup" {
   export BUILDKITE_PLUGIN_DOCKER_COMPOSE_GRACEFUL_SHUTDOWN=1
   stub stubbed_run_docker_compose \
-    "stop : echo \$@" \
+    "stop --timeout 30 : echo \$@" \
     "rm --force -v : echo \$@" \
-    "down --remove-orphans --volumes : echo \$@"
+    "down --remove-orphans --timeout 30 --volumes : echo \$@"
 
   run compose_cleanup
 
   assert_success
-  assert_equal "${lines[0]}" "stop"
+  assert_equal "${lines[0]}" "stop --timeout 30"
   assert_equal "${lines[1]}" "rm --force -v"
-  assert_equal "${lines[2]}" "down --remove-orphans --volumes"
+  assert_equal "${lines[2]}" "down --remove-orphans --timeout 30 --volumes"
 
   unstub stubbed_run_docker_compose
 }
@@ -50,14 +50,14 @@ setup () {
   stub stubbed_run_docker_compose \
     "kill : echo \$@" \
     "rm --force : echo \$@" \
-    "down --remove-orphans : echo \$@"
+    "down --remove-orphans --timeout 30 : echo \$@"
 
   run compose_cleanup
 
   assert_success
   assert_equal "${lines[0]}" "kill"
   assert_equal "${lines[1]}" "rm --force"
-  assert_equal "${lines[2]}" "down --remove-orphans"
+  assert_equal "${lines[2]}" "down --remove-orphans --timeout 30"
 
   unstub stubbed_run_docker_compose
 }
@@ -66,14 +66,14 @@ setup () {
   stub stubbed_run_docker_compose \
     "kill : exit 1" \
     "rm --force -v : echo \$@" \
-    "down --remove-orphans --volumes : echo \$@"
+    "down --remove-orphans --timeout 30 --volumes : echo \$@"
 
   run compose_cleanup
 
   assert_failure 1
 
   assert_equal "${lines[0]}" "rm --force -v"
-  assert_equal "${lines[1]}" "down --remove-orphans --volumes"
+  assert_equal "${lines[1]}" "down --remove-orphans --timeout 30 --volumes"
 
   unstub stubbed_run_docker_compose
 }
@@ -82,14 +82,14 @@ setup () {
   stub stubbed_run_docker_compose \
     "kill : echo \$@" \
     "rm --force -v : exit 1" \
-    "down --remove-orphans --volumes : echo \$@"
+    "down --remove-orphans --timeout 30 --volumes : echo \$@"
 
   run compose_cleanup
 
   assert_failure 1
 
   assert_equal "${lines[0]}" "kill"
-  assert_equal "${lines[1]}" "down --remove-orphans --volumes"
+  assert_equal "${lines[1]}" "down --remove-orphans --timeout 30 --volumes"
 
   unstub stubbed_run_docker_compose
 }
@@ -98,7 +98,7 @@ setup () {
   stub stubbed_run_docker_compose \
     "kill : echo \$@" \
     "rm --force -v : echo \$@" \
-    "down --remove-orphans --volumes : exit 1"
+    "down --remove-orphans --timeout 30 --volumes : exit 1"
 
   run compose_cleanup
 
@@ -114,7 +114,7 @@ setup () {
   stub stubbed_run_docker_compose \
     "kill : exit 1" \
     "rm --force -v : echo \$@" \
-    "down --remove-orphans --volumes : exit 1"
+    "down --remove-orphans --timeout 30 --volumes : exit 1"
 
   run compose_cleanup
 

--- a/tests/docker-compose-cleanup.bats
+++ b/tests/docker-compose-cleanup.bats
@@ -17,9 +17,17 @@ setup () {
   assert_output "done"
 }
 
-@test "run_with_deadline terminates a command that exceeds the deadline" {
-  run run_with_deadline 1 sleep 100
+@test "run_with_deadline terminates a hanging command within the deadline" {
+  local start=$SECONDS
+  run run_with_deadline 2 sleep 100
   assert_failure
+  [[ $((SECONDS - start)) -lt 5 ]]
+}
+
+@test "run_with_deadline kills descendant processes after the deadline" {
+  run run_with_deadline 1 bash -c 'sleep 9999 & wait'
+  assert_failure
+  ! pgrep -f "sleep 9999" >/dev/null 2>&1
 }
 
 @test "Default cleanup of docker-compose" {

--- a/tests/docker-compose-cleanup.bats
+++ b/tests/docker-compose-cleanup.bats
@@ -30,6 +30,15 @@ setup () {
   ! pgrep -f "sleep 9999" >/dev/null 2>&1
 }
 
+@test "run_with_deadline kills TERM-resistant processes via SIGKILL escalation" {
+  local start=$SECONDS
+  # bash ignores SIGTERM; only SIGKILL from the escalation path can stop it
+  run run_with_deadline 2 bash -c 'trap "" TERM; while true; do sleep 9998; done'
+  assert_failure
+  [[ $((SECONDS - start)) -lt 6 ]]
+  ! pgrep -f "sleep 9998" >/dev/null 2>&1
+}
+
 @test "Default cleanup of docker-compose" {
   stub stubbed_run_docker_compose \
     "kill : echo \$@" \


### PR DESCRIPTION
Added timeout 30 to docker stop and timeout 10 to docker logs in ensure_stopped() so the trap handler always returns within a bounded time, leaving room for compose_cleanup() to run.
Also added --timeout 30 to docker compose stop (graceful shutdown path) and docker compose down in compose_cleanup() to guard against the same unbounded hang pattern there.
