### PR TITLE
Add `bake` option to build and push with `docker buildx bake`

### DIFF
--- a/README.md
+++ b/README.md
@@ -396,6 +396,22 @@ Assuming you have a compatible Docker installation and configuration in the agen
 
 You may want to also add `BUILDKIT_INLINE_CACHE=1` to your build arguments (`args` option in this plugin), but know that [there are known issues with it](https://github.com/moby/buildkit/issues/2274).
 
+#### `bake` (build only, boolean)
+
+Build the services with [`docker buildx bake`](https://docs.docker.com/build/bake/) instead of `docker compose build`, pushing the resulting image(s) straight to the registry (`bake --push`) rather than loading them into the local Docker daemon.
+
+This is useful with the `docker-container` and `remote` build [drivers](https://docs.docker.com/build/builders/drivers/): with those drivers the built image lives in BuildKit's own store, so `docker compose build` must export it as a tarball and import it into the daemon before it can be pushed. For large images — Windows containers are the extreme case, with multi-gigabyte base layers — that load dominates the step even on a full cache hit. Pushing directly from BuildKit skips it entirely.
+
+The image tags, `cache-from`, `cache-to`, `target` and `build-labels` options are honoured (bake reads them from the Compose config and the generated override file), as are `builder`, `no-cache`, `skip-pull`, `ssh`, `buildkit-inline-cache` and `args`. Because the image is pushed rather than loaded, the pushed image is recorded in the build metadata (unless `push-metadata` is `false`) so later `run` and `push` steps use it, just like a regular `push`.
+
+Notes:
+
+- The service must define an `image` with a registry reference to push to, and the agent must be authenticated for that registry.
+- As bake pushes during the build, you do not need a separate `push` entry for the same service in this step.
+- Requires BuildKit; it has no effect with `cli-version: 1` unless `buildkit` is also enabled.
+
+Default: `false`
+
 #### `ssh` (build only, boolean or string)
 
 It will add the `--ssh` option to the build command with the passed value (if `true` it will use `default`). Note that it assumes you have a compatible Docker installation and configuration in the agent (meaning you are using BuildKit and it is correctly setup).

--- a/commands/build.sh
+++ b/commands/build.sh
@@ -105,6 +105,13 @@ while read -r line ; do
   [[ -n "$line" ]] && services+=("$line")
 done <<< "$(plugin_read_list BUILD)"
 
+# When `bake` is enabled, build (and push) with `docker buildx bake` instead of
+# `docker compose build`, which avoids loading the image into the local daemon.
+if [[ "$(plugin_read_config BAKE "false")" == "true" ]] ; then
+  build_with_bake "${services[@]}"
+  return 0
+fi
+
 if [[ -f "${override_file}" ]]; then
   build_params+=(-f "${override_file}")
 fi

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -441,3 +441,27 @@ steps:
 The first Step will build the Image using a Builder Instance with the `docker-container` driver and push the image cache to the remote registry, as specified by `cache-to`, with additional cache export options being used to export all the layers of intermediate steps with the image manifests. More details cache export options [here](https://github.com/moby/buildkit?tab=readme-ov-file#registry-push-image-and-cache-separately).
 
 The second Step will build the Image using a Builder Instance with the `docker-container` driver and use remote registry for the image cache, as specified by `cache-from`, speeding up Image building process.
+
+### Building and pushing directly with bake
+
+With the `docker-container` and `remote` build drivers, `docker compose build` has to export the built image as a tarball and load it into the Docker daemon before it can be pushed. For large images this load can dominate the step even when every layer is cached — Windows containers are the worst case, with multi-gigabyte base layers. The `bake` option builds with `docker buildx bake` and pushes straight to the registry, so the image never round-trips through the daemon:
+
+```yaml
+steps:
+  - label: ":docker: Build and push the image with bake"
+    plugins:
+      - docker-compose#v5.13.0:
+          build: app
+          bake: true
+          cache-from:
+            - "app:type=registry,ref=${DOCKER_REGISTRY}/${IMAGE_REPO}:cache"
+          cache-to:
+            - "app:type=inline"
+          builder:
+            name: container
+            use: true
+            create: true
+            driver: docker-container
+```
+
+The `app` service must define an `image` with a registry reference to push to, and the agent must be authenticated for that registry. Because the image is pushed during the build, there is no need for a separate `push` entry, and the pushed image is recorded in the build metadata so later `run` and `push` steps use it just like a regular `push`.

--- a/hooks/command
+++ b/hooks/command
@@ -27,6 +27,8 @@ fi
 
 # Dispatch to the command file
 if in_array "BUILD" "${commands[@]}" ; then
+  # shellcheck source=lib/bake.bash
+  . "$DIR/../lib/bake.bash"
   # shellcheck source=commands/build.sh
   . "$DIR/../commands/build.sh"
 fi

--- a/lib/bake.bash
+++ b/lib/bake.bash
@@ -1,0 +1,97 @@
+#!/bin/bash
+
+BAKE_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# compose_image_for_service lives in push.bash; source it so the pushed image can
+# be recorded in metadata for later run/push steps, exactly like the push command.
+# shellcheck source=lib/push.bash
+. "$BAKE_LIB_DIR/push.bash"
+
+# Builds the given services with `docker buildx bake` and pushes them straight to
+# the registry, instead of the regular `docker compose build` (which loads the
+# built image into the local Docker daemon first).
+#
+# With the `docker-container` or `remote` build drivers the built image lives in
+# BuildKit's own store, so `docker compose build` has to export it as a tarball
+# and import it into the daemon before it can be pushed. For large images (for
+# example Windows containers, whose base layers are several GB) that load
+# dominates the step even on a full cache hit. `bake --push` uses BuildKit's
+# registry exporter, so the image goes from BuildKit to the registry directly and
+# the daemon is never involved.
+#
+# The generated override file and the Compose config files carry the image tags,
+# cache_from/cache_to, target and labels, and bake reads them through `--file`,
+# so those options apply unchanged.
+function build_with_bake() {
+  local services=("$@")
+
+  local override_file="docker-compose.buildkite-${BUILDKITE_BUILD_NUMBER}-override.yml"
+
+  local group_type="+++"
+  if [[ "${BUILDKITE_PLUGIN_DOCKER_COMPOSE_COLLAPSE_LOGS:-false}" == "true" ]]; then
+    group_type="---"
+  fi
+
+  local bake_params=(buildx bake)
+
+  local file
+  for file in $(docker_compose_config_files) ; do
+    bake_params+=(--file "$file")
+  done
+
+  if [[ -f "${override_file}" ]]; then
+    bake_params+=(--file "${override_file}")
+  fi
+
+  if [[ -n "$(plugin_read_config BUILDER_NAME "")" ]] && [[ "$(plugin_read_config BUILDER_USE "false")" == "true" ]]; then
+    bake_params+=(--builder "$(plugin_read_config BUILDER_NAME "")")
+  fi
+
+  if [[ ! "$(plugin_read_config SKIP_PULL "false")" == "true" ]] ; then
+    bake_params+=(--pull)
+  fi
+
+  if [[ "$(plugin_read_config NO_CACHE "false")" == "true" ]] ; then
+    bake_params+=(--no-cache)
+  fi
+
+  # bake writes to the daemon by default; push straight to the registry so the
+  # image is never round-tripped through a local daemon load.
+  bake_params+=(--push)
+
+  if [[ "$(plugin_read_config BUILDKIT_INLINE_CACHE "false")" == "true" ]] ; then
+    bake_params+=(--set "*.args.BUILDKIT_INLINE_CACHE=1")
+  fi
+
+  if [[ "$(plugin_read_config SSH "false")" != "false" ]] ; then
+    local ssh_context
+    ssh_context="$(plugin_read_config SSH)"
+    if [[ "${ssh_context}" == "true" ]]; then
+      ssh_context='default'
+    fi
+    bake_params+=(--set "*.ssh=${ssh_context}")
+  fi
+
+  local arg
+  while read -r arg ; do
+    [[ -n "${arg:-}" ]] && bake_params+=(--set "*.args.${arg}")
+  done <<< "$(plugin_read_list ARGS)"
+
+  bake_params+=("${services[@]}")
+
+  echo "${group_type} :docker: Building and pushing services with bake: ${services[*]}"
+  plugin_prompt_and_must_run docker "${bake_params[@]}"
+
+  # Record the pushed image for each service so later run/push steps pull it
+  # instead of falling back to a rebuild (mirrors the push command's behaviour).
+  if [[ "$(plugin_read_config PUSH_METADATA "true")" == "true" ]] ; then
+    local prebuilt_image_namespace service image
+    prebuilt_image_namespace="$(plugin_read_config PREBUILT_IMAGE_NAMESPACE 'docker-compose-plugin-')"
+    for service in "${services[@]}" ; do
+      image="$(compose_image_for_service "$service")"
+      if [[ -n "$image" ]] ; then
+        set_prebuilt_image "${prebuilt_image_namespace}" "${service}" "${image}"
+      fi
+    done
+  fi
+}

--- a/plugin.yml
+++ b/plugin.yml
@@ -20,6 +20,8 @@ configuration:
     args:
       type: [ string, array ]
       minimum: 1
+    bake:
+      type: boolean
     build-alias:
       type: [ string, array ]
       minimum: 1
@@ -193,6 +195,7 @@ configuration:
   dependencies:
     ansi: [ run ]
     args: [ build ]
+    bake: [ build ]
     build-alias: [ push ]
     build-labels: [ build ]
     build-parallel: [ build ]

--- a/tests/build.bats
+++ b/tests/build.bats
@@ -357,3 +357,65 @@ setup_file() {
 
   unstub docker
 }
+
+@test "Build with bake builds, pushes and records metadata" {
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD=myservice
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BAKE=true
+
+  stub docker \
+    "buildx bake --file docker-compose.yml --pull --push myservice : echo baked myservice" \
+    "compose -f docker-compose.yml -p buildkite1111 config : printf '%s\n' '  myservice:' '    image: myimage'"
+
+  stub buildkite-agent \
+    "meta-data set docker-compose-plugin-built-image-tag-myservice myimage : echo recorded metadata"
+
+  run "$PWD"/hooks/command
+
+  assert_success
+  assert_output --partial "baked myservice"
+  assert_output --partial "recorded metadata"
+
+  unstub docker
+  unstub buildkite-agent
+}
+
+@test "Build with bake honours builder, no-cache, inline cache and args" {
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD=myservice
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BAKE=true
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_PUSH_METADATA=false
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILDER_NAME=mybuilder
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILDER_USE=true
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_SKIP_PULL=true
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_NO_CACHE=true
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILDKIT_INLINE_CACHE=true
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_ARGS_0=MYARG=myvalue
+
+  stub docker \
+    "buildx bake --file docker-compose.yml --builder mybuilder --no-cache --push --set *.args.BUILDKIT_INLINE_CACHE=1 --set *.args.MYARG=myvalue myservice : echo baked myservice"
+
+  run "$PWD"/hooks/command
+
+  assert_success
+  assert_output --partial "baked myservice"
+
+  unstub docker
+}
+
+@test "Build with bake passes the cache-from override file" {
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CONFIG="tests/composefiles/docker-compose.v3.2.yml"
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD_0=helloworld
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BAKE=true
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_PUSH_METADATA=false
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CACHE_FROM_0=helloworld:my.repository/myservice_cache:latest
+
+  stub docker \
+    "buildx bake --file tests/composefiles/docker-compose.v3.2.yml --file docker-compose.buildkite-1-override.yml --pull --push helloworld : echo baked helloworld"
+
+  run "$PWD"/hooks/command
+
+  assert_success
+  assert_output --partial "- my.repository/myservice_cache:latest"
+  assert_output --partial "baked helloworld"
+
+  unstub docker
+}


### PR DESCRIPTION
## Summary

Adds an opt-in, build-only `bake` boolean that builds services with `docker buildx bake --push` instead of `docker compose build`.

With the `docker-container` and `remote` build drivers, the built image lives in BuildKit's own store, so `docker compose build` exports it as a tarball and imports it into the Docker daemon before it can be pushed. For large images that load dominates the step **even on a full cache hit** — Windows containers are the extreme case, with multi-gigabyte base layers.

`bake --push` uses BuildKit's registry exporter, so the image goes straight from BuildKit to the registry and the daemon is never involved. In our CI (Windows native builds on a `remote` builder) this took the image build+push step from ~12 min — almost entirely tarball export/import, everything else cached — down to ~1–2 min.

## Behaviour

- Opt-in; default `false`, so existing behaviour is unchanged.
- Reuses the generated override file and Compose config files, so `image`, `cache-from`, `cache-to`, `target` and `build-labels` all apply (bake reads them via `--file`).
- Honours `builder`, `no-cache`, `skip-pull`, `ssh`, `buildkit-inline-cache` and `args`.
- Because it pushes, the pushed image is recorded in the build metadata (unless `push-metadata: false`), so later `run`/`push` steps use it — exactly like a regular `push`.

```yml
steps:
  - plugins:
      - docker-compose#v5.13.0:
          build: app
          bake: true
          builder:
            name: container
            use: true
            create: true
            driver: docker-container
```

## Notes / limitations

- The service must define an `image` with a registry reference, and the agent must be authenticated for that registry.
- bake pushes during the build, so a separate `push` entry for the same service isn't needed.
- Requires BuildKit (no effect under `cli-version: 1` unless `buildkit` is also enabled).

## Testing

- `shellcheck` clean.
- Added unit tests in `tests/build.bats` (build + push + metadata; builder/no-cache/inline-cache/args; cache-from override file). The full `bats tests` suite passes.
- `plugin-linter` passes (plugin.yml valid; all README/examples config examples valid).
